### PR TITLE
ci: GitHub Actions CI for @kiln/engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: typecheck · lint · test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint (Biome)
+        run: bun run lint
+
+      # KILN_SPIKE_LIVE=0 (the `test` script default) keeps tests offline — no model
+      # calls, no provider key. `test:live` is the opt-in live path, not run in CI.
+      - name: Unit tests
+        run: bun test


### PR DESCRIPTION
Adds `.github/workflows/ci.yml`: typecheck · biome · `bun test` (offline, `KILN_SPIKE_LIVE=0`). Runs on PR + push to main. Pinned bun 1.3.9, frozen lockfile.