### PR TITLE
docs: record why @ai-sdk/provider cannot move to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ Runtime: `three`, `@gltf-transform/*`, `manifold-3d` (CSG, WASM), `three-subdivi
 `@strands-agents/sdk` + `@ai-sdk/provider` — is an **optional peer**: install it only
 when you use `@kiln/engine/agent`.
 
+### `@ai-sdk/provider` is pinned to v3 by Strands, not by us
+
+Do not bump `@ai-sdk/provider` to v4 or `@openrouter/ai-sdk-provider` to v3. The blocker is
+`@strands-agents/sdk`: every version through **1.11.1** peers `@ai-sdk/provider@^3.0.0`, and its
+`VercelModel` — which every OpenRouter model here is wrapped in — is typed against
+`LanguageModelV3`. A type cast does not help, because Strands emits V3 shapes at *runtime*:
+`vercel.js` sends `{type: 'file', data: <bare bytes>}` where V4 expects `{type: 'data', data}`, and
+`{type: 'file-data', ...}`, which does not exist in V4 at all.
+
+`@ai-sdk/provider` v4 itself is purely additive, and our only real code change would be one string
+(`'file-data'` → `'file'`) in three files — which is exactly why this looks deceptively easy. Stay on
+`@openrouter/ai-sdk-provider@2.10.0` until Strands ships v4 support.
+
+Note also that the `ai` package is an unused devDependency here; the engine imports it nowhere, so
+"migrate `ai` v6 → v7" is not the task it appears to be.
+
 ## Determinism
 
 Render/rasterizer compute paths are deterministic — no `Date.now()` / `Math.random()` —


### PR DESCRIPTION
The `@ai-sdk/provider` v3 → v4 upgrade looks like a one-string change and is not. This records the actual blocker in the place someone will look before attempting it.

Verified rather than recalled:

- `@strands-agents/sdk@1.11.1` is the current latest and still peers `@ai-sdk/provider ^3.0.0`, as does 1.11.0
- the installed 1.10.0 dist emits V3 shapes **at runtime** — `vercel.js:409` sends `{type: 'file', data: <bare bytes>}` where V4 expects `{type: 'data', data}`, and `:476` sends `{type: 'file-data'}`, which V4 has no such member for

So a cast cannot absorb it; `VercelModel` wraps every OpenRouter model the engine uses.

Also notes that `ai` is an unused devDependency — the engine imports it nowhere — since the task has twice been framed as "migrate `ai` v6 → v7", which is not what it is.

This previously lived only in a workspace session document that is now being deleted, so without this it would be re-investigated from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)