### PR TITLE
fix(scripts): resolve coverage-checker path portably in its test

### DIFF
--- a/scripts/check-coverage.test.mjs
+++ b/scripts/check-coverage.test.mjs
@@ -3,8 +3,11 @@ import { spawnSync } from 'node:child_process';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const checker = new URL('./check-coverage.mjs', import.meta.url).pathname;
+// URL#pathname keeps a leading slash before Windows drive letters ("/C:/...");
+// fileURLToPath is the portable conversion.
+const checker = fileURLToPath(new URL('./check-coverage.mjs', import.meta.url));
 
 async function fixture(thresholds) {
   const directory = await mkdtemp(join(tmpdir(), 'kiln-coverage-'));


### PR DESCRIPTION
`new URL(...).pathname` keeps a leading slash before Windows drive letters ("/C:/..."), so the two check-coverage tests failed with module-not-found on Windows workstations. `fileURLToPath` is the portable conversion; behavior on POSIX is unchanged.

Unblocks the workspace root `validate` gate (engine-coverage leg) on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)