### PR TITLE
feat(agent): export captureViewsViaPort as the public degrade shell

### DIFF
--- a/src/agent/generate.test.ts
+++ b/src/agent/generate.test.ts
@@ -391,6 +391,30 @@ describe('generateKilnAsset viewRenderPort (B3b/B4)', () => {
     expect(r.views).toBeInstanceOf(Buffer);
   });
 
+  test('captureViewsViaPort is a public single-owner shell (success + degrade)', async () => {
+    const { captureViewsViaPort } = await import('./generate');
+    const viewsPng = await stubViewPngs();
+    const okOutcome = await captureViewsViaPort(
+      async () => ({ ok: true, rendererId: 'dawn-vulkan:test-gpu:1.0', viewsPng }),
+      new Uint8Array([1, 2, 3]), // hosts hold Uint8Array GLBs; accepted directly
+    );
+    expect(okOutcome.ok).toBe(true);
+    if (okOutcome.ok) {
+      expect(okOutcome.rendererId).toBe('dawn-vulkan:test-gpu:1.0');
+      const { compositeViewPngGrid } = await import('../views');
+      expect(Buffer.compare(okOutcome.png, compositeViewPngGrid(viewsPng).png)).toBe(0);
+    }
+
+    const degraded = await captureViewsViaPort(
+      async () => {
+        throw new Error('GPU service unreachable');
+      },
+      Buffer.from([1, 2, 3]),
+    );
+    expect(degraded.ok).toBe(false);
+    if (!degraded.ok) expect(degraded.reason).toContain('GPU service unreachable');
+  });
+
   test('B4: the port receives a copy of the GLB bytes, not a live alias', async () => {
     runImpl = okRun;
     const viewsPng = await stubViewPngs();

--- a/src/agent/generate.ts
+++ b/src/agent/generate.ts
@@ -194,9 +194,9 @@ export async function generateKilnCodeAgent(opts: {
   };
 }
 
-const DEFAULT_VIEW_RENDER_TIMEOUT_MS = 8000;
+export const DEFAULT_VIEW_RENDER_TIMEOUT_MS = 8000;
 
-type PortViewsOutcome =
+export type PortViewsOutcome =
   | { ok: true; png: Buffer; rendererId: string }
   | { ok: false; reason: string };
 
@@ -209,11 +209,15 @@ type PortViewsOutcome =
  * port, ok:false, timeout, missing rendererId, undecodable or mismatched PNGs —
  * returns `{ ok: false, reason }` so the caller degrades to the CPU rasterizer
  * instead of failing the generation.
+ *
+ * Exported as the single owner of the degrade policy: hosts that assemble their
+ * own generation pipeline (rather than calling generateKilnAsset) route their
+ * produced GLB through this same shell instead of re-implementing it.
  */
-async function captureViewsViaPort(
+export async function captureViewsViaPort(
   port: PbrRenderPort,
-  glb: Buffer,
-  timeoutMs: number,
+  glb: Buffer | Uint8Array,
+  timeoutMs: number = DEFAULT_VIEW_RENDER_TIMEOUT_MS,
 ): Promise<PortViewsOutcome> {
   // Same views + cell size as the CPU grid default, so the composited layout
   // matches renderCodeViewGrid (H-33 env variant included).

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -26,8 +26,18 @@ export type { RunKilnAgentOptions, RunKilnAgentResult, KilnKnowhow, KilnInputIma
 export { resolveToolSurface, buildAgentTools } from './surface';
 export type { KilnToolSurface, RefineMode } from './surface';
 
-export { generateKilnAsset, generateKilnCodeAgent, DEFAULT_KILN_AGENT_MODEL } from './generate';
-export type { GenerateKilnAssetOptions, GenerateKilnAssetResult } from './generate';
+export {
+  generateKilnAsset,
+  generateKilnCodeAgent,
+  captureViewsViaPort,
+  DEFAULT_KILN_AGENT_MODEL,
+  DEFAULT_VIEW_RENDER_TIMEOUT_MS,
+} from './generate';
+export type {
+  GenerateKilnAssetOptions,
+  GenerateKilnAssetResult,
+  PortViewsOutcome,
+} from './generate';
 
 export {
   makeKilnTools,


### PR DESCRIPTION
Studio's agent runtime composes its own pipeline (runKilnAgent + renderGLB) rather than calling generateKilnAsset, so it needs the port-routing + degrade shell directly. This exports the existing `captureViewsViaPort` (single owner of the degrade policy), `PortViewsOutcome`, and `DEFAULT_VIEW_RENDER_TIMEOUT_MS`, widens the GLB parameter to `Buffer | Uint8Array`, and adds a direct public-surface test (success + degrade). No behavior change on existing paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)