### PR TITLE
docs: refresh the agent context surface after chunk F

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,19 @@ Read [README.md](./README.md) before changing exports or package contents. Runti
 `scripts/`. The package intentionally ships TypeScript source through the explicit `files` and
 `exports` lists in `package.json`.
 
+## Host-injected render and cache boundaries
+
+The engine defines the host-injected `PbrRenderPort`; Studio owns the HTTP adapter, authentication,
+environment configuration, production service, and EMF telemetry. Exported `captureViewsViaPort` is
+the single owner of the deadline, renderer/PNG validation, grid composition, and never-throw CPU
+fallback. Do not duplicate that degrade policy in a host or introduce network/service knowledge into
+the deterministic engine paths.
+
+Prompt-cache transports are deliberately different. Native Anthropic and Bedrock adapters consume a
+system `[TextBlock, CachePointBlock]`; OpenRouter-hosted Anthropic keeps plain system text and receives
+top-level `cache_control: { type: 'ephemeral' }` because its Vercel bridge drops cache-point blocks.
+Preserve that distinction and the provider usage fields when changing model routing.
+
 ## Toolchain and validation
 
 Supported CI toolchain: Bun `1.3.14`; Node `22.23.1`; npm `12.0.1`. Do not use a Bun canary or implicit latest for a


### PR DESCRIPTION
Authored by Codex on the hub; branch relayed through SSH because the hub has no GitHub write credentials.

Aligns the auto-loaded agent context with reality after the GPU render program landed: the render service is live in production, enablement rides the shared secret rather than the CDK template, `KILN_PBR_RENDER_TIMEOUT_MS` is 120s against measured cold 39.9s / warm 3.0s, and `put-secret-value` replaces the whole secret string so any future write must read-merge-write.

Codex reports validation passing (root documentation contracts, 4 engine reliability tests, 19 Studio operational-document tests) and the largest auto-loaded file at 14,187 bytes, under the 18 KB limit.

**Review note:** the clones were taken at `bac06e7`, which predates #171. Settlement wording therefore describes the floor without the provider-rejection refinement that has since merged and deployed. Worth a follow-up line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)