### PR TITLE
fix(agent): thread in-loop render context into tools

### DIFF
--- a/src/agent/run-surface.test.ts
+++ b/src/agent/run-surface.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, test } from 'bun:test';
 
 import { buildAgentTools, resolveToolSurface, type ToolBuildOptions } from './surface';
 import type { SubmitSink, EditSink, UnifiedSink } from './tools';
+import type { InLoopViewRender, KilnToolContext } from '../tools/registry';
 
 function freshSinks() {
   return {
@@ -22,6 +23,23 @@ function freshSinks() {
 
 const base: ToolBuildOptions = {};
 const names = (tools: ReturnType<typeof buildAgentTools>) => tools.map((t) => t.name);
+
+function findTool(tools: ReturnType<typeof buildAgentTools>, name: string) {
+  const tool = tools.find((candidate) => candidate.name === name) as
+    | { invoke(input: unknown): Promise<unknown> }
+    | undefined;
+  if (!tool) throw new Error(`tool ${name} not found`);
+  return tool;
+}
+
+const METAL_CODE = `
+const meta = { name: 'metal-box', category: 'prop' };
+function build() {
+  const root = createRoot('Root');
+  createPart('Body', boxGeo(1, 1, 1), gameMaterial('#c0c0c0', { metalness: 0.6 }), { parent: root });
+  return root;
+}
+`;
 
 // A1: no standalone kiln_validate on the unified surface — kiln_draft and
 // kiln_edit validate the buffer inline in their results.
@@ -82,6 +100,30 @@ describe('buildAgentTools', () => {
   test('current surface, refine in rewrite mode -> the five generate tools (no edit tools)', () => {
     const opts = { ...base, existingCode: 'const meta = {};', refineMode: 'rewrite' as const };
     expect(names(buildAgentTools('current', opts, freshSinks()))).toEqual(CURRENT_GEN);
+  });
+
+  test('threads the host render port, its short deadline, and tally callback into unified kiln_render', async () => {
+    const events: InLoopViewRender[] = [];
+    let portCalls = 0;
+    const context: KilnToolContext = {
+      viewRenderPort: () => {
+        portCalls += 1;
+        return new Promise(() => {});
+      },
+      viewRenderTimeoutMs: 5,
+      onViewsRendered: (event) => events.push(event),
+    };
+    const tools = buildAgentTools('unified', context, freshSinks());
+
+    await findTool(tools, 'kiln_draft').invoke({ code: METAL_CODE });
+    const rendered = await findTool(tools, 'kiln_render').invoke({});
+
+    expect(Array.isArray(rendered)).toBe(true);
+    expect(portCalls).toBe(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.neededPbr).toBe(true);
+    expect(events[0]?.degraded).toBe(true);
+    expect(events[0]?.degradedReason).toContain('timed out after 5ms');
   });
 });
 

--- a/src/agent/run.ts
+++ b/src/agent/run.ts
@@ -35,6 +35,7 @@ import {
 } from '../prompt';
 import type { AssetCategory, AssetStyle } from '../prompt';
 import type { AssetIntentV1 } from '../contracts';
+import type { KilnToolContext } from '../tools/registry';
 import type { SubmitSink, EditSink, UnifiedSink, EditRecord, KilnRenderCandidate } from './tools';
 import {
   resolveToolSurface,
@@ -85,7 +86,8 @@ function imageFormatFromMime(mime: string): 'png' | 'jpeg' | 'gif' | 'webp' {
   return 'png';
 }
 
-export interface RunKilnAgentOptions {
+export interface RunKilnAgentOptions
+  extends Pick<KilnToolContext, 'viewRenderPort' | 'viewRenderTimeoutMs' | 'onViewsRendered'> {
   /** A constructed Strands `Model` instance (provider-agnostic). */
   model: unknown;
   /** Natural-language description of the asset to build. */

--- a/src/agent/surface.ts
+++ b/src/agent/surface.ts
@@ -7,6 +7,7 @@
  */
 import type { Tool } from '@strands-agents/sdk';
 import type { AssetCategory, AssetIntentV1 } from '../contracts';
+import type { KilnToolContext } from '../tools/registry';
 
 import {
   makeKilnTools,
@@ -28,7 +29,7 @@ export type KilnToolSurface = 'current' | 'unified';
 export type RefineMode = 'rewrite' | 'edit';
 
 /** The subset of run options the tool assembly reads. */
-export interface ToolBuildOptions {
+export interface ToolBuildOptions extends KilnToolContext {
   existingCode?: string;
   refineMode?: RefineMode;
   /** Trusted request category captured outside generated source. */
@@ -70,6 +71,11 @@ export function buildAgentTools(
   const trustedContext = {
     ...(opts.intent ? { intent: opts.intent } : {}),
     ...(opts.category ? { category: opts.category } : {}),
+    ...(opts.viewRenderPort ? { viewRenderPort: opts.viewRenderPort } : {}),
+    ...(opts.viewRenderTimeoutMs !== undefined
+      ? { viewRenderTimeoutMs: opts.viewRenderTimeoutMs }
+      : {}),
+    ...(opts.onViewsRendered ? { onViewsRendered: opts.onViewsRendered } : {}),
   };
   if (surface === 'unified') {
     return makeKilnUnifiedTools({


### PR DESCRIPTION
## Summary
- expose the host-injected in-loop render port, short deadline, and tally callback on RunKilnAgentOptions
- preserve those fields through buildAgentTools into every tool factory
- add a regression test proving a metallic unified-surface render calls the port, honors the short timeout, degrades to CPU, and reports the tally

## Validation
- focused test failed before the fix with zero port calls
- bun run typecheck
- bun run lint (existing warnings/infos only)
- bun run test: 1203 pass, 2 skip, 0 fail
- bun run test:coverage: 95.98% functions, 92.57% lines