### PR TITLE
feat(agent): publish in-loop render contract

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -26,6 +26,9 @@ export type { RunKilnAgentOptions, RunKilnAgentResult, KilnKnowhow, KilnInputIma
 export { resolveToolSurface, buildAgentTools } from './surface';
 export type { KilnToolSurface, RefineMode } from './surface';
 
+export { DEFAULT_INLOOP_VIEW_RENDER_TIMEOUT_MS } from '../tools/registry';
+export type { InLoopViewRender } from '../tools/registry';
+
 export {
   generateKilnAsset,
   generateKilnCodeAgent,

--- a/src/tools/__tests__/registry-render-views.test.ts
+++ b/src/tools/__tests__/registry-render-views.test.ts
@@ -31,6 +31,12 @@ describe('kilnRenderViewsDef (unified kiln_render)', () => {
     expect(kilnToolRegistry.filter((d) => d === kilnRenderViewsDef)).toEqual([]);
   });
 
+  test('describes the conditional GPU PBR path and the flat-shaded CPU fallback honestly', () => {
+    expect(kilnRenderViewsDef.description).toContain('GPU PBR shading');
+    expect(kilnRenderViewsDef.description).toContain('textured or metallic materials');
+    expect(kilnRenderViewsDef.description).toContain('flat-shaded CPU render');
+  });
+
   test('valid code returns metrics AND the six-view grid PNG from one execution', async () => {
     const out = (await kilnRenderViewsDef.run({ code: BOX_CODE })) as KilnRenderViewsResult;
     expect(out.ok).toBe(true);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -643,7 +643,7 @@ const KILN_RENDER_VIEWS_DESCRIPTION =
   'elevation 0 = eye level, positive looks down. Use it to aim every cell at what actually needs ' +
   'checking — a seam, an underside, a joint the standard six leave occluded — instead of spending ' +
   'cells on angles that show nothing. Max 9 cells. The reply echoes the grid shape it rendered. ' +
-  'If the build fails you get an error and NO image — fix the code and render again. Flat-shaded CPU render; writes no files.';
+  'If the build fails you get an error and NO image — fix the code and render again. Uses GPU PBR shading when the scene has textured or metallic materials and the renderer is reachable; otherwise uses a flat-shaded CPU render. Writes no files.';
 
 /** Create the unified render/view definition with host-owned QA context. */
 export function createKilnRenderViewsDef(context: KilnToolContext = {}): KilnToolDef {


### PR DESCRIPTION
## Summary
- export the engine-owned in-loop deadline and render-event type from @kiln/engine/agent for Studio hosts
- correct kiln_render's cached description to explain conditional GPU PBR shading and the flat-shaded CPU fallback
- pin the honest description in a focused test

## Validation
- focused description test failed before the change and now passes
- bun run typecheck
- bun run lint (existing warnings/infos only)
- bun run test: 1204 pass, 2 skip, 0 fail
- bun run test:coverage: 95.98% functions, 92.57% lines