### PR TITLE
fix(render): keep CPU renderer identity lazy

### DIFF
--- a/src/agent/generate.ts
+++ b/src/agent/generate.ts
@@ -24,7 +24,6 @@ import {
   type ResolvedCapture,
 } from '../views/capture';
 import { compositeViewPngGrid } from '../views/grid';
-import { CPU_RASTER_RENDERER_ID } from '../views/renderer-id';
 import type { AssetStyle } from '../prompt';
 import { createAssetIntentV1, type AssetCategory, type AssetIntentV1 } from '../contracts';
 import { runKilnAgent, type RefineMode, type KilnKnowhow, type KilnInputImage } from './run';
@@ -419,7 +418,10 @@ export async function generateKilnAsset(
     }
     if (!views) {
       try {
-        const { renderCodeViewGrid } = await import('../views');
+        // Keep the renderer id on this same lazy entrypoint. renderer-id.ts reads
+        // package metadata at module initialization; an eager import changes the
+        // production agent boot graph even when no CPU fallback is needed.
+        const { renderCodeViewGrid, CPU_RASTER_RENDERER_ID } = await import('../views');
         // The degrade path must reproduce the SAME layout the port was asked
         // for, or a GPU outage silently reshapes the artifact.
         const grid = await renderCodeViewGrid(agent.code, capture ? { capture } : {});


### PR DESCRIPTION
## Summary
- remove the eager iews/renderer-id import from the agent generation module
- load CPU_RASTER_RENDERER_ID from the same lazy wait import('../views') used by the CPU fallback
- preserve the lazy captureViewsViaPort registry import and the production dependency-cycle seam

enderer-id.ts reads package metadata at module initialization, so this import boundary is a production boot-order contract not covered by ordinary behavior tests.

## Validation
- 37 focused generation and in-loop render-port tests pass
- un run typecheck passes
- un run lint exits 0 with the existing Biome warnings only
- git diff --check passes

No deployment or external mutation beyond this branch/PR.