### PR TITLE
Enforce generation-global model call budget

### DIFF
--- a/src/agent/call-budget.test.ts
+++ b/src/agent/call-budget.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_GENERATION_MODEL_CALL_LIMIT,
+  createGenerationCallBudget,
+  generationModelCallLimitFromEnv,
+} from './call-budget';
+
+describe('generation-global model-call budget', () => {
+  test('defaults to the existing aggregate 40-call ceiling', () => {
+    expect(createGenerationCallBudget().receipt()).toMatchObject({
+      limit: DEFAULT_GENERATION_MODEL_CALL_LIMIT,
+      consumed: 0,
+      remaining: 40,
+      exhausted: false,
+    });
+  });
+
+  test('attributes one shared allowance across author, observer, repair, retry, and fallback', () => {
+    const budget = createGenerationCallBudget(5);
+    for (const role of ['author', 'observer', 'repair', 'retry', 'fallback'] as const) {
+      expect(budget.tryConsume(role)).toBe(true);
+    }
+    expect(budget.tryConsume('repair')).toBe(false);
+    expect(budget.receipt()).toEqual({
+      limit: 5,
+      consumed: 5,
+      remaining: 0,
+      exhausted: true,
+      denied: 1,
+      byRole: { author: 1, observer: 1, repair: 1, retry: 1, fallback: 1 },
+    });
+  });
+
+  test('zero preserves the existing explicit unlimited configuration while retaining attribution', () => {
+    const budget = createGenerationCallBudget(0);
+    for (let i = 0; i < 50; i++) expect(budget.tryConsume('author')).toBe(true);
+    expect(budget.receipt()).toMatchObject({
+      limit: 0,
+      consumed: 50,
+      remaining: null,
+      exhausted: false,
+      denied: 0,
+      byRole: { author: 50 },
+    });
+  });
+
+  test('the generation-global env wins while the legacy step env remains a fallback', () => {
+    expect(
+      generationModelCallLimitFromEnv({
+        KILN_GENERATION_MAX_CALLS: '12',
+        KILN_AGENT_MAX_STEPS: '7',
+      }),
+    ).toBe(12);
+    expect(generationModelCallLimitFromEnv({ KILN_AGENT_MAX_STEPS: '7' })).toBe(7);
+    expect(generationModelCallLimitFromEnv({ KILN_GENERATION_MAX_CALLS: 'invalid' })).toBe(40);
+  });
+});

--- a/src/agent/call-budget.ts
+++ b/src/agent/call-budget.ts
@@ -1,0 +1,78 @@
+/** One deterministic model-call allowance shared by every paid role in a generation. */
+
+export const DEFAULT_GENERATION_MODEL_CALL_LIMIT = 40;
+
+export type GenerationModelCallRole = 'author' | 'observer' | 'repair' | 'retry' | 'fallback';
+
+export interface GenerationCallBudgetReceipt {
+  /** Aggregate ceiling. Zero preserves the legacy explicit unlimited setting. */
+  limit: number;
+  consumed: number;
+  /** Null only for an unlimited budget. */
+  remaining: number | null;
+  exhausted: boolean;
+  /** Dispatches refused before reaching a provider. */
+  denied: number;
+  byRole: Partial<Record<GenerationModelCallRole, number>>;
+}
+
+export interface GenerationCallBudget {
+  /** Atomically reserve one call for a role. False means do not dispatch. */
+  tryConsume(role: GenerationModelCallRole): boolean;
+  /** Immutable JSON-safe snapshot for metrics, persistence, and tests. */
+  receipt(): GenerationCallBudgetReceipt;
+}
+
+/** Invalid configuration must not turn the cost guard off. */
+export function resolveGenerationModelCallLimit(raw: unknown): number {
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_GENERATION_MODEL_CALL_LIMIT;
+  const parsed = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
+    return DEFAULT_GENERATION_MODEL_CALL_LIMIT;
+  }
+  return parsed;
+}
+
+export function generationModelCallLimitFromEnv(
+  env: Readonly<{
+    KILN_GENERATION_MAX_CALLS?: string;
+    KILN_AGENT_MAX_STEPS?: string;
+  }> = process.env as {
+    KILN_GENERATION_MAX_CALLS?: string;
+    KILN_AGENT_MAX_STEPS?: string;
+  },
+): number {
+  return resolveGenerationModelCallLimit(env.KILN_GENERATION_MAX_CALLS ?? env.KILN_AGENT_MAX_STEPS);
+}
+
+export function createGenerationCallBudget(
+  limit = DEFAULT_GENERATION_MODEL_CALL_LIMIT,
+): GenerationCallBudget {
+  const resolvedLimit = resolveGenerationModelCallLimit(limit);
+  let consumed = 0;
+  let denied = 0;
+  const byRole: Partial<Record<GenerationModelCallRole, number>> = {};
+
+  return {
+    tryConsume(role) {
+      if (resolvedLimit > 0 && consumed >= resolvedLimit) {
+        denied += 1;
+        return false;
+      }
+      consumed += 1;
+      byRole[role] = (byRole[role] ?? 0) + 1;
+      return true;
+    },
+    receipt() {
+      const remaining = resolvedLimit === 0 ? null : Math.max(0, resolvedLimit - consumed);
+      return {
+        limit: resolvedLimit,
+        consumed,
+        remaining,
+        exhausted: resolvedLimit > 0 && remaining === 0,
+        denied,
+        byRole: { ...byRole },
+      };
+    },
+  };
+}

--- a/src/agent/hooks.test.ts
+++ b/src/agent/hooks.test.ts
@@ -11,6 +11,7 @@ import {
   AfterModelCallEvent,
 } from '@strands-agents/sdk';
 import { MetricsCollector } from './hooks';
+import { createGenerationCallBudget } from './call-budget';
 
 type Cb = (event: unknown) => void;
 
@@ -84,6 +85,31 @@ describe('MetricsCollector', () => {
     expect(m.wasCapped()).toBe(true);
     // steps stays at 3 — the cancelled call never fired AfterModelCallEvent.
     expect(m.readMetrics().steps).toBe(3);
+  });
+
+  test('two collectors debit one aggregate budget before author and repair dispatch', () => {
+    const budget = createGenerationCallBudget(3);
+    const author = new MetricsCollector(undefined, 40, budget, 'author');
+    const repair = new MetricsCollector(undefined, 40, budget, 'repair');
+    const authorAgent = fakeAgent();
+    const repairAgent = fakeAgent();
+    author.attach(authorAgent.agent as never);
+    repair.attach(repairAgent.agent as never);
+
+    expect(authorAgent.modelCall().cancelled).toBe(false);
+    expect(authorAgent.modelCall().cancelled).toBe(false);
+    expect(repairAgent.modelCall().cancelled).toBe(false);
+    const exhausted = repairAgent.modelCall();
+
+    expect(exhausted.cancelled).toBe(true);
+    expect(exhausted.cancelText).toContain('generation model-call budget');
+    expect(repair.wasCapped()).toBe(true);
+    expect(budget.receipt()).toMatchObject({
+      consumed: 3,
+      remaining: 0,
+      denied: 1,
+      byRole: { author: 2, repair: 1 },
+    });
   });
 
   test('records token usage from the agent result', () => {

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -17,6 +17,7 @@ import {
   BeforeModelCallEvent,
   AfterModelCallEvent,
 } from '@strands-agents/sdk';
+import type { GenerationCallBudget, GenerationModelCallRole } from './call-budget';
 
 /** Token-usage subset we surface. The cache fields mirror the Strands `Usage`
  *  type (dist/src/models/streaming.d.ts): the Anthropic adapter fills them from
@@ -81,15 +82,16 @@ export class MetricsCollector {
    * @param onEvent - Optional live sink, fired as the loop runs (tool calls,
    * model calls). Errors thrown by the sink are swallowed — a broken progress
    * listener must never fail a generation.
-   * @param maxSteps - Optional hard cap on model calls (agent-loop iterations).
-   * When the loop reaches this many calls, the NEXT model call is cancelled
-   * (SDK `BeforeModelCallEvent.cancel`), ending the loop with a clean stop
-   * instead of an unbounded tool/edit/render loop. A pure cost backstop — set
-   * well above normal runs (~10 calls); only catches runaways. 0/undefined = off.
+   * @param maxSteps - Legacy per-collector cap, retained for direct callers that
+   * do not inject a generation-global budget.
+   * @param generationCallBudget - Shared allowance across author, observer, and
+   * repair work. It supersedes maxSteps and is consumed before dispatch.
    */
   constructor(
     private readonly onEvent?: (event: KilnAgentEvent) => void,
     private readonly maxSteps?: number,
+    private readonly generationCallBudget?: GenerationCallBudget,
+    private readonly modelCallRole: GenerationModelCallRole = 'author',
   ) {}
 
   private emit(event: KilnAgentEvent): void {
@@ -111,12 +113,22 @@ export class MetricsCollector {
       this.steps += 1;
       this.emit({ type: 'model_call', step: this.steps });
     });
-    // Hard step cap: before a model call that would exceed maxSteps, cancel it.
+    // Hard cost cap: reserve from the shared budget before dispatch. Direct
+    // legacy collectors without one retain their local maxSteps behavior.
     // The SDK ends the loop with stopReason 'endTurn' (no exception) — `capped`
     // lets the caller turn that bounded stop into a clear failed generation.
     const offCap =
-      this.maxSteps && this.maxSteps > 0
+      this.generationCallBudget || (this.maxSteps && this.maxSteps > 0)
         ? agent.addHook(BeforeModelCallEvent, (event) => {
+            if (this.generationCallBudget) {
+              if (this.generationCallBudget.tryConsume(this.modelCallRole)) return;
+              this.capped = true;
+              const receipt = this.generationCallBudget.receipt();
+              event.cancel =
+                `kiln: generation model-call budget reached (${receipt.limit} aggregate calls) — ` +
+                'aborted before provider dispatch to bound cost';
+              return;
+            }
             if (this.steps >= this.maxSteps!) {
               this.capped = true;
               event.cancel = `kiln: agent step cap reached (${this.maxSteps} model calls) — aborted to bound cost`;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -120,3 +120,15 @@ export type {
 
 export { MetricsCollector } from './hooks';
 export type { CollectedMetrics, AgentUsage, KilnAgentEvent } from './hooks';
+
+export {
+  createGenerationCallBudget,
+  generationModelCallLimitFromEnv,
+  resolveGenerationModelCallLimit,
+  DEFAULT_GENERATION_MODEL_CALL_LIMIT,
+} from './call-budget';
+export type {
+  GenerationCallBudget,
+  GenerationCallBudgetReceipt,
+  GenerationModelCallRole,
+} from './call-budget';

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -27,7 +27,12 @@ export { resolveToolSurface, buildAgentTools } from './surface';
 export type { KilnToolSurface, RefineMode } from './surface';
 
 export { DEFAULT_INLOOP_VIEW_RENDER_TIMEOUT_MS } from '../tools/registry';
-export type { InLoopViewRender } from '../tools/registry';
+export type {
+  InLoopViewRender,
+  RenderObservationInput,
+  RenderObservationPort,
+  RenderObservationValue,
+} from '../tools/registry';
 
 export {
   generateKilnAsset,

--- a/src/agent/run-surface.test.ts
+++ b/src/agent/run-surface.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, test } from 'bun:test';
 
 import { buildAgentTools, resolveToolSurface, type ToolBuildOptions } from './surface';
 import type { SubmitSink, EditSink, UnifiedSink } from './tools';
-import type { InLoopViewRender, KilnToolContext } from '../tools/registry';
+import type { InLoopViewRender, KilnToolContext, RenderObservationInput } from '../tools/registry';
 
 function freshSinks() {
   return {
@@ -124,6 +124,24 @@ describe('buildAgentTools', () => {
     expect(events[0]?.neededPbr).toBe(true);
     expect(events[0]?.degraded).toBe(true);
     expect(events[0]?.degradedReason).toContain('timed out after 5ms');
+  });
+
+  test('threads a host visual observer into unified kiln_render without returning pixels', async () => {
+    const observed: RenderObservationInput[] = [];
+    const context: KilnToolContext = {
+      renderObservationPort: async (input) => {
+        observed.push(input);
+        return { schemaVersion: 1, verdict: 'ready', findings: [] };
+      },
+    };
+    const tools = buildAgentTools('unified', context, freshSinks());
+
+    await findTool(tools, 'kiln_draft').invoke({ code: METAL_CODE });
+    const rendered = (await findTool(tools, 'kiln_render').invoke({})) as unknown[];
+
+    expect(rendered).toHaveLength(1);
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.toolName).toBe('kiln_render');
   });
 });
 

--- a/src/agent/run.ts
+++ b/src/agent/run.ts
@@ -89,7 +89,10 @@ function imageFormatFromMime(mime: string): 'png' | 'jpeg' | 'gif' | 'webp' {
 }
 
 export interface RunKilnAgentOptions
-  extends Pick<KilnToolContext, 'viewRenderPort' | 'viewRenderTimeoutMs' | 'onViewsRendered'> {
+  extends Pick<
+    KilnToolContext,
+    'viewRenderPort' | 'viewRenderTimeoutMs' | 'onViewsRendered' | 'renderObservationPort'
+  > {
   /** A constructed Strands `Model` instance (provider-agnostic). */
   model: unknown;
   /** Natural-language description of the asset to build. */

--- a/src/agent/run.ts
+++ b/src/agent/run.ts
@@ -48,6 +48,12 @@ import {
 import { unifiedDiff } from './diff';
 import { MetricsCollector, type AgentUsage, type KilnAgentEvent } from './hooks';
 import {
+  createGenerationCallBudget,
+  generationModelCallLimitFromEnv,
+  type GenerationCallBudget,
+  type GenerationModelCallRole,
+} from './call-budget';
+import {
   installRenderImageCompaction,
   installGenerationCounters,
   type GenerationCounters,
@@ -91,7 +97,11 @@ function imageFormatFromMime(mime: string): 'png' | 'jpeg' | 'gif' | 'webp' {
 export interface RunKilnAgentOptions
   extends Pick<
     KilnToolContext,
-    'viewRenderPort' | 'viewRenderTimeoutMs' | 'onViewsRendered' | 'renderObservationPort'
+    | 'viewRenderPort'
+    | 'viewRenderTimeoutMs'
+    | 'onViewsRendered'
+    | 'renderObservationPort'
+    | 'generationCallBudget'
   > {
   /** A constructed Strands `Model` instance (provider-agnostic). */
   model: unknown;
@@ -165,6 +175,8 @@ export interface RunKilnAgentOptions
    *  consolidate, and the refined program is kept only if its grade improves.
    *  'off' skips the check (no extra model turn, no assessment bake). */
   gradeRefine?: 'auto' | 'off';
+  /** Attribution role for this invocation within the shared generation budget. */
+  modelCallRole?: GenerationModelCallRole;
 }
 
 export interface RunKilnAgentResult {
@@ -218,14 +230,22 @@ function lastMessageText(message: Message | undefined): string | undefined {
  * on `result.error` with whatever metrics were collected beforehand.
  */
 export async function runKilnAgent(opts: RunKilnAgentOptions): Promise<RunKilnAgentResult> {
-  // Hard agent-loop cap (runaway backstop, NOT a throttle): a stuck model could
+  // Hard generation-global cap (runaway backstop, NOT a throttle): a stuck model could
   // otherwise loop draft/edit/render forever, re-feeding a growing transcript
   // (input tokens scale ~linearly with step count). Default 40 — ~4x the normal
   // run (~10 model calls) and clear of the slowest legit runs observed (~23); only
-  // catches genuine infinite loops. Env-overridable (set 0 to disable, raise for
-  // an unusually deep build).
-  const maxSteps = Number(process.env['KILN_AGENT_MAX_STEPS'] ?? 40) || 0;
-  const metrics = new MetricsCollector(opts.onEvent, maxSteps);
+  // catches genuine infinite loops. The same object can span author, observer,
+  // retry/fallback, and bounded repair calls. Env-overridable (set 0 to disable).
+  const configuredLimit = generationModelCallLimitFromEnv();
+  const generationCallBudget: GenerationCallBudget =
+    opts.generationCallBudget ?? createGenerationCallBudget(configuredLimit);
+  const maxSteps = generationCallBudget.receipt().limit;
+  const metrics = new MetricsCollector(
+    opts.onEvent,
+    maxSteps,
+    generationCallBudget,
+    opts.modelCallRole ?? 'author',
+  );
   const surface = resolveToolSurface(opts.toolSurface);
   const trustedCategory = opts.intent?.category ?? opts.category ?? 'prop';
   const gradeAssessmentOptions = {
@@ -245,7 +265,7 @@ export async function runKilnAgent(opts: RunKilnAgentOptions): Promise<RunKilnAg
   try {
     const tools: Tool[] = buildAgentTools(
       surface,
-      { ...opts, category: trustedCategory },
+      { ...opts, category: trustedCategory, generationCallBudget },
       { sink, editSink, unifiedSink },
     );
     const allTools: unknown[] = opts.extraTools ? [...tools, ...opts.extraTools] : tools;
@@ -428,8 +448,8 @@ export async function runKilnAgent(opts: RunKilnAgentOptions): Promise<RunKilnAg
         const trigger = {
           mode: 'auto' as const,
           report: assess.report,
-          steps: metrics.readMetrics().steps,
-          maxSteps,
+          steps: generationCallBudget.receipt().consumed,
+          maxSteps: generationCallBudget.receipt().limit,
         };
         if (assess.ok && assess.report && shouldGradeRefine(trigger)) {
           const report = assess.report;

--- a/src/agent/surface.ts
+++ b/src/agent/surface.ts
@@ -77,6 +77,7 @@ export function buildAgentTools(
       : {}),
     ...(opts.onViewsRendered ? { onViewsRendered: opts.onViewsRendered } : {}),
     ...(opts.renderObservationPort ? { renderObservationPort: opts.renderObservationPort } : {}),
+    ...(opts.generationCallBudget ? { generationCallBudget: opts.generationCallBudget } : {}),
   };
   if (surface === 'unified') {
     return makeKilnUnifiedTools({

--- a/src/agent/surface.ts
+++ b/src/agent/surface.ts
@@ -76,6 +76,7 @@ export function buildAgentTools(
       ? { viewRenderTimeoutMs: opts.viewRenderTimeoutMs }
       : {}),
     ...(opts.onViewsRendered ? { onViewsRendered: opts.onViewsRendered } : {}),
+    ...(opts.renderObservationPort ? { renderObservationPort: opts.renderObservationPort } : {}),
   };
   if (surface === 'unified') {
     return makeKilnUnifiedTools({

--- a/src/agent/tools-media.test.ts
+++ b/src/agent/tools-media.test.ts
@@ -51,6 +51,58 @@ describe('makeKilnTools media handling', () => {
     expect('pngBase64' in json).toBe(false);
   });
 
+  test('a host observer replaces screenshot pixels with a structured visual observation', async () => {
+    const calls: Array<{ toolName: string; pngs: readonly Uint8Array[] }> = [];
+    const tools = makeKilnTools(
+      {},
+      {
+        renderObservationPort: async (input) => {
+          calls.push({ toolName: input.toolName, pngs: input.pngs });
+          return {
+            schemaVersion: 1,
+            verdict: 'continue',
+            findings: [{ criterionId: 'silhouette', summary: 'The box is visible.' }],
+          };
+        },
+      },
+    );
+    const out = (await findTool(tools, 'kiln_screenshot').invoke({ code: BOX_CODE })) as unknown[];
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBeInstanceOf(JsonBlock);
+    const json = (out[0] as JsonBlock).json as Record<string, unknown>;
+    expect(json['ok']).toBe(true);
+    expect(json['visualObservation']).toEqual({
+      ok: true,
+      value: {
+        schemaVersion: 1,
+        verdict: 'continue',
+        findings: [{ criterionId: 'silhouette', summary: 'The box is visible.' }],
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.toolName).toBe('kiln_screenshot');
+    expect(calls[0]?.pngs).toHaveLength(1);
+  });
+
+  test('an observer failure degrades to explicit unavailable JSON and never leaks pixels', async () => {
+    const tools = makeKilnTools(
+      {},
+      {
+        renderObservationPort: async () => {
+          throw new Error('provider detail must stay host-only');
+        },
+      },
+    );
+    const out = (await findTool(tools, 'kiln_screenshot').invoke({ code: BOX_CODE })) as unknown[];
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBeInstanceOf(JsonBlock);
+    const json = (out[0] as JsonBlock).json as Record<string, unknown>;
+    expect(json['visualObservation']).toEqual({ ok: false, reason: 'observer-unavailable' });
+    expect(JSON.stringify(json)).not.toContain('provider detail');
+  });
+
   test('kiln_screenshot on broken code falls back to the plain JSON error output', async () => {
     const tools = makeKilnTools({});
     const out = (await findTool(tools, 'kiln_screenshot').invoke({ code: 'nope(' })) as {

--- a/src/agent/tools-media.test.ts
+++ b/src/agent/tools-media.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from 'bun:test';
 import { ImageBlock, JsonBlock } from '@strands-agents/sdk';
 
 import { makeKilnTools, makeKilnEditTools, type SubmitSink, type EditSink } from './tools';
+import { createGenerationCallBudget } from './call-budget';
 
 const BOX_CODE = `
 const meta = { name: 'test-box', category: 'prop' };
@@ -25,6 +26,28 @@ function findTool(tools: ReturnType<typeof makeKilnTools>, name: string) {
 }
 
 describe('makeKilnTools media handling', () => {
+  test('forwards the global budget so the observer port can debit actual dispatches', async () => {
+    const budget = createGenerationCallBudget(1);
+    expect(budget.tryConsume('author')).toBe(true);
+    let observerCalls = 0;
+    const tools = makeKilnTools(
+      {},
+      {
+        generationCallBudget: budget,
+        renderObservationPort: async (input) => {
+          observerCalls++;
+          expect(input.generationCallBudget).toBe(budget);
+          return { verdict: 'ready' };
+        },
+      },
+    );
+
+    const result = await findTool(tools, 'kiln_screenshot').invoke({ code: BOX_CODE });
+    expect(observerCalls).toBe(1);
+    expect(JSON.stringify(result)).toContain('ready');
+    expect(budget.receipt()).toMatchObject({ consumed: 1, denied: 0 });
+  });
+
   test('exposes the four registry tools plus the animation view and kiln_submit', () => {
     const sink: SubmitSink = {};
     const tools = makeKilnTools(sink);

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -62,9 +62,53 @@ const submitInput = z.object({
  * tool-result coercion passes block arrays through as-is — so it is cast past
  * JSONValue.
  */
-function toCallbackResult(def: KilnToolDef, output: unknown): JSONValue {
+function withVisualObservation(json: unknown, visualObservation: JSONValue): JSONValue {
+  if (json && typeof json === 'object' && !Array.isArray(json)) {
+    return { ...(json as Record<string, JSONValue>), visualObservation } as JSONValue;
+  }
+  return { result: json as JSONValue, visualObservation } as JSONValue;
+}
+
+async function observedMediaResult(
+  def: KilnToolDef,
+  pngs: readonly Uint8Array[],
+  json: unknown,
+  context: KilnToolContext,
+): Promise<JSONValue> {
+  try {
+    const value = await context.renderObservationPort!({
+      toolName: def.name,
+      pngs,
+      json,
+      ...(context.intent ? { intent: context.intent } : {}),
+    });
+    return [
+      new JsonBlock({
+        json: withVisualObservation(json, { ok: true, value } as JSONValue),
+      }),
+    ] as unknown as JSONValue;
+  } catch {
+    return [
+      new JsonBlock({
+        json: withVisualObservation(json, {
+          ok: false,
+          reason: 'observer-unavailable',
+        } as JSONValue),
+      }),
+    ] as unknown as JSONValue;
+  }
+}
+
+async function toCallbackResult(
+  def: KilnToolDef,
+  output: unknown,
+  context: KilnToolContext = {},
+): Promise<JSONValue> {
   const multi = def.mediaMulti?.(output);
   if (multi) {
+    if (context.renderObservationPort) {
+      return observedMediaResult(def, multi.pngs, multi.json, context);
+    }
     return [
       ...multi.pngs.map((png) => new ImageBlock({ format: 'png', source: { bytes: png } })),
       new JsonBlock({ json: multi.json as JSONValue }),
@@ -72,6 +116,9 @@ function toCallbackResult(def: KilnToolDef, output: unknown): JSONValue {
   }
   const media = def.media?.(output);
   if (media) {
+    if (context.renderObservationPort) {
+      return observedMediaResult(def, [media.png], media.json, context);
+    }
     return [
       new ImageBlock({ format: 'png', source: { bytes: media.png } }),
       new JsonBlock({ json: media.json as JSONValue }),
@@ -97,7 +144,11 @@ const animationBufferInput = z.object({
 /** Build a buffer-aware kiln_screenshot_animation tool that runs against `getCode()`
  *  (the working buffer) instead of a `code` argument. Same behavior as the registry
  *  def otherwise; image transports attach the frame(s) via toCallbackResult. */
-function makeBufferAnimationTool(getCode: () => string, def: KilnToolDef): Tool {
+function makeBufferAnimationTool(
+  getCode: () => string,
+  def: KilnToolDef,
+  context: KilnToolContext = {},
+): Tool {
   return tool({
     name: def.name,
     description: `${def.description} Operates on your current working buffer (omit code).`,
@@ -112,17 +163,18 @@ function makeBufferAnimationTool(getCode: () => string, def: KilnToolDef): Tool 
           ...(i.camera ? { camera: i.camera } : {}),
           ...(i.perFrame ? { perFrame: true } : {}),
         }),
+        context,
       );
     },
   });
 }
 
-function toStrandsTool(def: KilnToolDef): Tool {
+function toStrandsTool(def: KilnToolDef, context: KilnToolContext = {}): Tool {
   return tool({
     name: def.name,
     description: def.description,
     inputSchema: def.inputSchema as z.ZodType,
-    callback: async (input) => toCallbackResult(def, await def.run(input)),
+    callback: async (input) => toCallbackResult(def, await def.run(input), context),
   });
 }
 
@@ -134,10 +186,10 @@ function toStrandsTool(def: KilnToolDef): Tool {
  * @param sink - Receives the submitted final code. Read `sink.code` after invoke.
  */
 export function makeKilnTools(sink: SubmitSink, context: KilnToolContext = {}): Tool[] {
-  const kilnTools = createKilnToolRegistry(context).map(toStrandsTool);
+  const kilnTools = createKilnToolRegistry(context).map((def) => toStrandsTool(def, context));
   // kiln_screenshot_animation rides alongside the four registry tools (it takes a
   // `code` arg like them) so a from-scratch animated build can SEE its motion.
-  const animationTool = toStrandsTool(createKilnScreenshotAnimationDef(context));
+  const animationTool = toStrandsTool(createKilnScreenshotAnimationDef(context), context);
   const submitTool: Tool = tool({
     name: KILN_SUBMIT_TOOL_NAME,
     description:
@@ -345,7 +397,7 @@ export function makeKilnEditTools(
   const renderDef = find('kiln_render');
   const screenshotDef = find('kiln_screenshot');
 
-  const listTool = toStrandsTool(find('kiln_list_primitives'));
+  const listTool = toStrandsTool(find('kiln_list_primitives'), opts);
 
   const viewTool: Tool = tool({
     name: 'kiln_view',
@@ -399,12 +451,13 @@ export function makeKilnEditTools(
       toCallbackResult(
         screenshotDef,
         await screenshotDef.run({ code: (input as { code?: string }).code ?? buffer.code }),
+        opts,
       ),
   });
 
   // Buffer-aware motion view: a refine that touches an animated character can SEE
   // the clip move and confirm the edit didn't break it.
-  const animationTool = makeBufferAnimationTool(() => buffer.code, animationDef);
+  const animationTool = makeBufferAnimationTool(() => buffer.code, animationDef, opts);
 
   const submitTool: Tool = tool({
     name: KILN_SUBMIT_TOOL_NAME,
@@ -615,7 +668,7 @@ export function makeKilnUnifiedTools(
           }
         }
       }
-      return toCallbackResult(renderViewsDef, out);
+      return toCallbackResult(renderViewsDef, out, opts);
     },
   });
 
@@ -644,13 +697,13 @@ export function makeKilnUnifiedTools(
         ...(i.zoom !== undefined ? { zoom: i.zoom } : {}),
         ...(i.isolate !== undefined ? { isolate: i.isolate } : {}),
       });
-      return toCallbackResult(inspectDef, out);
+      return toCallbackResult(inspectDef, out, opts);
     },
   });
 
   // Buffer-aware motion view: after drafting/editing an animated character, SEE a
   // clip move (sideways walk, reverse knee, backward swing, item not tracking).
-  const animationTool = makeBufferAnimationTool(() => buffer.code, animationDef);
+  const animationTool = makeBufferAnimationTool(() => buffer.code, animationDef, opts);
 
   // Buffer-aware interior view: after drafting/editing a BUILDING, SEE inside it
   // (roof off — open floor, real doorway gap, fixtures grounded, nothing buried).
@@ -672,7 +725,7 @@ export function makeKilnUnifiedTools(
         code: buffer.code,
         ...(n ? { nodeName: n } : {}),
       });
-      return toCallbackResult(interiorDef, out);
+      return toCallbackResult(interiorDef, out, opts);
     },
   });
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -81,6 +81,9 @@ async function observedMediaResult(
       pngs,
       json,
       ...(context.intent ? { intent: context.intent } : {}),
+      ...(context.generationCallBudget
+        ? { generationCallBudget: context.generationCallBudget }
+        : {}),
     });
     return [
       new JsonBlock({

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -98,7 +98,45 @@ export interface KilnToolContext {
    * Never throws into the render path: a host callback that throws is swallowed.
    */
   onViewsRendered?(event: InLoopViewRender): void;
+  /**
+   * Optional host-owned visual observer for authors that cannot consume image
+   * input. When present, media-bearing tool results are sent here out of band
+   * and the author receives only the returned structured observation plus the
+   * ordinary JSON metrics. Raw pixels never enter the author transcript.
+   *
+   * The engine does not construct a model or network client. Studio owns the
+   * observer model, prompt, schema validation, deadline, accounting, and retry
+   * policy. A port failure degrades to an explicit unavailable marker rather
+   * than leaking the image or failing the render tool.
+   */
+  renderObservationPort?: RenderObservationPort;
 }
+
+/** JSON-safe value accepted from a host visual observer. */
+export type RenderObservationValue =
+  | null
+  | boolean
+  | number
+  | string
+  | RenderObservationValue[]
+  | { [key: string]: RenderObservationValue };
+
+/** Evidence passed to a host visual observer, never to the author model. */
+export interface RenderObservationInput {
+  /** Model-facing tool that produced the evidence. */
+  toolName: string;
+  /** One grid PNG for ordinary render/inspect, or multiple animation frames. */
+  pngs: readonly Uint8Array[];
+  /** The same base64-free metrics JSON a direct-vision author would receive. */
+  json: unknown;
+  /** Trusted request intent, when the host supplied one. */
+  intent?: AssetIntentV1;
+}
+
+/** Host-injected, model-free engine seam for a bounded VLM observer. */
+export type RenderObservationPort = (
+  input: RenderObservationInput,
+) => Promise<RenderObservationValue>;
 
 /** One in-loop grid, and who drew it. Counted by the host, never shown to the model. */
 export interface InLoopViewRender {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -28,6 +28,7 @@ import type { AssetQaReportV1 } from '../qa';
 import type { PbrRenderPort } from '../composer/render-port';
 import type { ViewGridResult } from '../views';
 import { sceneNeedsPbrShading } from '../material-resources';
+import type { GenerationCallBudget } from '../agent/call-budget';
 
 // =============================================================================
 // Tool definition contract
@@ -110,6 +111,8 @@ export interface KilnToolContext {
    * than leaking the image or failing the render tool.
    */
   renderObservationPort?: RenderObservationPort;
+  /** Shared generation-global allowance, forwarded to the host observer port. */
+  generationCallBudget?: GenerationCallBudget;
 }
 
 /** JSON-safe value accepted from a host visual observer. */
@@ -131,6 +134,12 @@ export interface RenderObservationInput {
   json: unknown;
   /** Trusted request intent, when the host supplied one. */
   intent?: AssetIntentV1;
+  /**
+   * Shared generation-global allowance. The host must debit role `observer`
+   * immediately before each actual provider dispatch; image preparation,
+   * sub-cap rejection, and other pre-dispatch failures must not consume it.
+   */
+  generationCallBudget?: GenerationCallBudget;
 }
 
 /** Host-injected, model-free engine seam for a bounded VLM observer. */


### PR DESCRIPTION
Adds the Engine-owned generation-wide provider-call budget shared by author, observer, repair, retry, and fallback roles. Preserves the existing default aggregate ceiling of 40 and forwards the budget through the host observation port without double-debiting observer work.\n\nValidation: 1,219 tests passed, 2 documented skips, coverage 96.00% functions / 92.59% lines, typecheck and lint passed.