### PR TITLE
fix(composer): let host select inspection lighting

### DIFF
--- a/src/__tests__/composer-world-run.test.ts
+++ b/src/__tests__/composer-world-run.test.ts
@@ -52,6 +52,8 @@ function world() {
 
 describe('runKilnWorldIntegration', () => {
   test('mutates, renders, and finalizes one canonical world authority', async () => {
+    const initialWorld = world();
+    expect(initialWorld.environment.lightingPresetId).toBe('legacy-scene-v1');
     const model = new ToolCapturingModel([
       {
         toolCalls: [
@@ -85,7 +87,7 @@ describe('runKilnWorldIntegration', () => {
     const result = await runKilnWorldIntegration({
       model,
       prompt: 'add a cargo anchor',
-      world: world(),
+      world: initialWorld,
       render,
       maxSteps: 8,
     });
@@ -99,6 +101,7 @@ describe('runKilnWorldIntegration', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]!.worldHash).toBe(result.worldHash);
     expect(calls[0]!.worldDocument).toEqual(result.world);
+    expect(calls[0]).not.toHaveProperty('lightingPresetId');
     expect(model.toolNames[0]).toEqual(
       expect.arrayContaining(['scene_world_snap', 'scene_world_render', 'scene_world_finalize']),
     );
@@ -131,11 +134,13 @@ describe('runKilnWorldIntegration', () => {
       { text: 'done' },
     ]);
     let receipt: (typeof receiptBase & { worldHash: `sha256:${string}` }) | undefined;
+    let requestedLighting = false;
     const result = await runKilnWorldIntegration({
       model,
       prompt: 'inspect the world',
       world: world(),
       render: async (request) => {
+        requestedLighting = Object.hasOwn(request, 'lightingPresetId');
         receipt = { ...receiptBase, worldHash: request.worldHash! };
         return {
           ok: true,
@@ -155,6 +160,8 @@ describe('runKilnWorldIntegration', () => {
         receipt,
       },
     ]);
+    expect(requestedLighting).toBe(false);
+    expect(result.renderEvidence[0]!.receipt!.lightingPresetId).toBe('studio-day-v2');
     const modelContext = JSON.stringify(model.messages);
     expect(modelContext).toContain('dawn-vulkan:test');
     expect(modelContext).toContain('outputSha256');

--- a/src/composer/agent/world-run.ts
+++ b/src/composer/agent/world-run.ts
@@ -126,7 +126,7 @@ function lifecycleTools(
     tool({
       name: 'scene_world_render',
       description:
-        'Render the current canonical world after integration edits; inspect before finalizing.',
+        'Render the current canonical world with the host inspection profile; inspect before finalizing.',
       inputSchema: empty,
       callback: async () => {
         const worldHash = await hashWorldDocumentV2(state.world);
@@ -134,7 +134,6 @@ function lifecycleTools(
           placements: placements(state.world),
           worldDocument: state.world,
           worldHash,
-          lightingPresetId: state.world.environment.lightingPresetId,
         });
         if (!result.ok) return { ok: false, error: result.error ?? 'render failed' } as JSONValue;
         const frames = result.perCameraBase64?.length

--- a/src/composer/render-port.ts
+++ b/src/composer/render-port.ts
@@ -41,6 +41,8 @@ export interface SceneRenderRequest {
   height?: number;
   /** Canonical input identity for an immutable GPU milestone. */
   worldHash?: `sha256:${string}`;
+  /** Optional future explicit presentation request. Phase 1 world integration
+   * omits this so the host selects its fixed material/terrain inspection profile. */
   lightingPresetId?: string;
   /** Requested host backend, e.g. `webgpu` or `vulkan`; host reports actual backend. */
   backendPreference?: string;
@@ -52,6 +54,7 @@ export interface SceneRenderReceipt {
   cameras: ResolvedSceneCamera[];
   width: number;
   height: number;
+  /** Actual host-selected presentation profile used for these pixels. */
   lightingPresetId: string;
   backend: string;
   rendererId: string;


### PR DESCRIPTION
## Summary
- omit world authoring lighting from Phase 1 inspection render requests
- document host-selected presentation profile receipt semantics
- prove migrated legacy lighting no longer forces degradation while actual receipt lighting is surfaced

## Gates
- focused composer world-run/port tests: 8 pass, 0 fail
- bun run typecheck
- bun run lint (existing warnings/infos only)
- bun run test:coverage: 1254 pass, 2 skip, 0 fail; 95.99% functions, 92.70% lines
- git diff --check