### PR TITLE
Preserve animation review clips through evaluator GLB

### DIFF
--- a/src/__tests__/inspect.test.ts
+++ b/src/__tests__/inspect.test.ts
@@ -107,10 +107,14 @@ describe('kiln.inspect', () => {
     expect(track?.targetResolved).toBe(true);
   });
 
-  test('reports an evaluator warning when an unresolved track is omitted from final GLB', async () => {
+  test('preserves an unresolved review track and reports the evaluator warning', async () => {
     const r = await inspect(BROKEN_JOINT_CODE);
 
-    expect(r.animationTracks.length).toBe(0);
+    expect(r.animationTracks).toHaveLength(1);
+    expect(r.animationTracks[0]).toMatchObject({
+      targetName: 'Joint_DoesNotExist',
+      targetResolved: false,
+    });
     expect(r.warnings.length).toBeGreaterThan(0);
     expect(r.warnings.some((w) => w.includes('Joint_DoesNotExist'))).toBe(true);
   });

--- a/src/render.ts
+++ b/src/render.ts
@@ -815,6 +815,51 @@ function bridgeAnimations(
   }
 }
 
+const REVIEW_CLIPS_EXTRAS_KEY = 'kilnReviewClipsV1';
+const REVIEW_CLIP_LIMITS = {
+  clips: 32,
+  tracks: 256,
+  samplesPerTrack: 4_096,
+  valuesPerTrack: 16_384,
+} as const;
+
+/** Preserve the authored review clip vocabulary in artifact bytes, including
+ * unresolved tracks that glTF cannot encode as native channels. Review tools
+ * use this bounded data only to reconstruct deterministic poses/warnings; it
+ * is not executable source and native valid channels remain authoritative to
+ * ordinary glTF consumers. */
+function reviewClipExtras(clips: THREE.AnimationClip[]): Record<string, unknown> {
+  if (clips.length > REVIEW_CLIP_LIMITS.clips) {
+    throw new Error(`Animation review clip limit exceeded (${REVIEW_CLIP_LIMITS.clips}).`);
+  }
+  let trackCount = 0;
+  return {
+    version: 1,
+    clips: clips.map((clip) => ({
+      name: clip.name,
+      duration: clip.duration,
+      tracks: clip.tracks.map((track) => {
+        trackCount++;
+        if (trackCount > REVIEW_CLIP_LIMITS.tracks) {
+          throw new Error(`Animation review track limit exceeded (${REVIEW_CLIP_LIMITS.tracks}).`);
+        }
+        if (
+          track.times.length > REVIEW_CLIP_LIMITS.samplesPerTrack ||
+          track.values.length > REVIEW_CLIP_LIMITS.valuesPerTrack
+        ) {
+          throw new Error('Animation review sample limit exceeded.');
+        }
+        const times = Array.from(track.times);
+        const values = Array.from(track.values);
+        if (!times.every(Number.isFinite) || !values.every(Number.isFinite)) {
+          throw new Error('Animation review tracks must contain only finite values.');
+        }
+        return { name: track.name, times, values };
+      }),
+    })),
+  };
+}
+
 // =============================================================================
 // Public API
 // =============================================================================
@@ -1187,6 +1232,7 @@ export async function renderSceneToGLB(
   doc.getRoot().setDefaultScene(gltfScene);
 
   if (clips.length > 0) {
+    gltfScene.setExtras({ [REVIEW_CLIPS_EXTRAS_KEY]: reviewClipExtras(clips) });
     bridgeAnimations(doc, buf, clips, nodeMap, warnings);
   }
 

--- a/src/tools/__tests__/registry-derivative-views.test.ts
+++ b/src/tools/__tests__/registry-derivative-views.test.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { describe, expect, spyOn, test } from 'bun:test';
 
 import * as renderModule from '../../render';
+import { trustedInProcessEvaluatorPortV1 } from '../../evaluator';
 import type { PbrRenderPort, PbrRenderRequest } from '../../composer/render-port';
 import { encodePng } from '../../views';
 import {
@@ -45,6 +46,20 @@ function solidPng(size: number): Uint8Array {
 }
 
 describe('derivative review surfaces', () => {
+  test('evaluator GLB preserves a bare pivot-name clip and reports its unresolved track', async () => {
+    const result = (await createKilnScreenshotAnimationDef({
+      evaluatorPort: trustedInProcessEvaluatorPortV1,
+      evaluatorProfile: 'evaluator-required',
+    }).run({
+      code: ANIMATED.replace("rotationTrack('Joint_Arm'", "rotationTrack('Arm'"),
+      clip: 'move',
+    })) as KilnScreenshotAnimationResult;
+    expect(result.ok).toBe(true);
+    expect(result.clip).toBe('move');
+    expect(result.frames).toBe(6);
+    expect(result.unresolvedTracks).toEqual(['Arm.quaternion']);
+  });
+
   test('animation evaluates once and never re-executes source while binding derivative receipts', async () => {
     const requests: PbrRenderRequest[] = [];
     const port: PbrRenderPort = async (request) => {

--- a/src/views/glb.ts
+++ b/src/views/glb.ts
@@ -48,6 +48,13 @@ const REASON_ORDER: readonly GlbGeometryFlatReasonCode[] = [
   GLB_GEOMETRY_FLAT_REASON.SKIN_DEFORMATION_UNSUPPORTED,
   GLB_GEOMETRY_FLAT_REASON.MORPH_TARGETS_UNSUPPORTED,
 ];
+const REVIEW_CLIPS_EXTRAS_KEY = 'kilnReviewClipsV1';
+const REVIEW_CLIP_LIMITS = {
+  clips: 32,
+  tracks: 256,
+  samplesPerTrack: 4_096,
+  valuesPerTrack: 16_384,
+} as const;
 
 export type GlbGeometryFlatErrorCode =
   | 'GLB_FLAT_PARSE_FAILED'
@@ -112,6 +119,59 @@ export interface LoadedGlbReviewScene extends LoadedGlbGeometryFlatScene {
 
 const glbIO = (): WebIO =>
   new WebIO().registerExtensions([EXTMeshGPUInstancing, KHRMaterialsVariants, KHRTextureBasisu]);
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function reviewClipsFromExtras(extras: unknown): AnimationClip[] | undefined {
+  if (!record(extras)) return undefined;
+  const envelope = extras[REVIEW_CLIPS_EXTRAS_KEY];
+  if (!record(envelope) || envelope.version !== 1 || !Array.isArray(envelope.clips)) {
+    return undefined;
+  }
+  if (envelope.clips.length > REVIEW_CLIP_LIMITS.clips) {
+    throw new GlbGeometryFlatError(
+      'GLB_FLAT_PARSE_FAILED',
+      'Animation review clip limit exceeded.',
+    );
+  }
+  let trackCount = 0;
+  return envelope.clips.map((candidate) => {
+    if (
+      !record(candidate) ||
+      typeof candidate.name !== 'string' ||
+      candidate.name.length > 256 ||
+      typeof candidate.duration !== 'number' ||
+      !Number.isFinite(candidate.duration) ||
+      candidate.duration < 0 ||
+      !Array.isArray(candidate.tracks)
+    ) {
+      throw new GlbGeometryFlatError('GLB_FLAT_PARSE_FAILED', 'Invalid animation review clip.');
+    }
+    const tracks = candidate.tracks.map((track) => {
+      trackCount++;
+      if (
+        trackCount > REVIEW_CLIP_LIMITS.tracks ||
+        !record(track) ||
+        typeof track.name !== 'string' ||
+        track.name.length > 512 ||
+        !Array.isArray(track.times) ||
+        !Array.isArray(track.values) ||
+        track.times.length > REVIEW_CLIP_LIMITS.samplesPerTrack ||
+        track.values.length > REVIEW_CLIP_LIMITS.valuesPerTrack ||
+        !track.times.every((value) => typeof value === 'number' && Number.isFinite(value)) ||
+        !track.values.every((value) => typeof value === 'number' && Number.isFinite(value))
+      ) {
+        throw new GlbGeometryFlatError('GLB_FLAT_PARSE_FAILED', 'Invalid animation review track.');
+      }
+      const property = track.name.slice(track.name.lastIndexOf('.') + 1);
+      const Track = property === 'quaternion' ? QuaternionKeyframeTrack : VectorKeyframeTrack;
+      return new Track(track.name, track.times, track.values);
+    });
+    return new AnimationClip(candidate.name, candidate.duration, tracks);
+  });
+}
 
 export function geometryFlatTextureReasonCode(mimeType: string | null): GlbGeometryFlatReasonCode {
   return mimeType === 'image/ktx2'
@@ -538,7 +598,7 @@ export async function loadGlbReviewScene(bytes: Uint8Array): Promise<LoadedGlbRe
       'Final GLB contains no renderable geometry.',
     );
 
-  const clips = document
+  const nativeClips = document
     .getRoot()
     .listAnimations()
     .map(
@@ -560,6 +620,7 @@ export async function loadGlbReviewScene(bytes: Uint8Array): Promise<LoadedGlbRe
           }),
         ),
     );
+  const clips = reviewClipsFromExtras(sourceScene.getExtras()) ?? nativeClips;
   return {
     root,
     clips,


### PR DESCRIPTION
## Summary
- serialize a bounded, non-executable review clip envelope into animated GLB scene extras
- reconstruct review clips from exact evaluator GLB bytes, including unresolved tracks glTF cannot encode as native channels
- restore animation screenshot parity without local source re-execution or evaluator protocol changes

## Verification
- regression through trustedInProcessEvaluatorPortV1: six frames and explicit unresolved track
- bun test --bail: 1404 pass, 2 skip, 0 fail
- bun run typecheck
- bun run lint (exit 0; existing informational diagnostics)
- git diff --check