### PR TITLE
feat: add Composer visual observer port

### DIFF
--- a/src/__tests__/composer-agent-tools.test.ts
+++ b/src/__tests__/composer-agent-tools.test.ts
@@ -7,7 +7,9 @@
  * image tools call the injected render port and return content blocks.
  */
 import { describe, expect, test } from 'bun:test';
-import type { Tool } from '@strands-agents/sdk';
+import { JsonBlock, type Tool } from '@strands-agents/sdk';
+
+import { createGenerationCallBudget } from '../agent/call-budget';
 
 import {
   type CatalogEntry,
@@ -265,6 +267,61 @@ describe('render tools call the port and return content blocks', () => {
       target: [0, 0, 0],
       fovDeg: 45,
     });
+  });
+
+  test('text-only author gets bounded observer evidence, never image blocks, on the shared budget', async () => {
+    const model = new PlacementModel('T', { catalog: [asset('well')] });
+    const sink: ComposerSink = {};
+    const budget = createGenerationCallBudget(3);
+    let observed: unknown;
+    const render: SceneRenderPort = async () => ({ ok: true, pngBase64: PNG_B64 });
+    const tools = makeSceneComposerTools({
+      model,
+      render,
+      sink,
+      generationCallBudget: budget,
+      renderObservationPort: async (input) => {
+        observed = input;
+        expect(input.generationCallBudget).toBe(budget);
+        expect(input.generationCallBudget?.tryConsume('observer')).toBe(true);
+        return { verdict: 'cohesive', findings: [] };
+      },
+    });
+    await call(tools, 'scene_place', { asset: 'well', at: [0, 0] });
+    const result = await call(tools, 'scene_render');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(JsonBlock);
+    expect(result[0].json.visualObservation).toEqual({
+      ok: true,
+      value: { verdict: 'cohesive', findings: [] },
+    });
+    expect(JSON.stringify(result)).not.toContain(PNG_B64);
+    expect((observed as { pngs: Uint8Array[] }).pngs[0]).toEqual(
+      new Uint8Array(Buffer.from(PNG_B64, 'base64')),
+    );
+    expect(budget.receipt()).toMatchObject({ consumed: 1, byRole: { observer: 1 } });
+  });
+
+  test('observer failure is in-band and still never exposes image blocks', async () => {
+    const model = new PlacementModel('T', { catalog: [asset('well')] });
+    const sink: ComposerSink = {};
+    const render: SceneRenderPort = async () => ({ ok: true, pngBase64: PNG_B64 });
+    const tools = makeSceneComposerTools({
+      model,
+      render,
+      sink,
+      renderObservationPort: async () => {
+        throw new Error('provider detail');
+      },
+    });
+    await call(tools, 'scene_place', { asset: 'well', at: [0, 0] });
+    const result = await call(tools, 'scene_render');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(JsonBlock);
+    expect(result[0].json.visualObservation).toEqual({ ok: false, reason: 'observer-unavailable' });
+    expect(JSON.stringify(result)).not.toContain('provider detail');
+    expect(JSON.stringify(result)).not.toContain(PNG_B64);
   });
 
   test('a render failure returns an in-band ok:false (no image)', async () => {

--- a/src/composer/agent/run.ts
+++ b/src/composer/agent/run.ts
@@ -30,7 +30,7 @@ import {
   type SceneModelJSON,
 } from '../model';
 import type { OverlapViolation } from '../overlap';
-import type { PbrRenderPort, SceneRenderPort } from '../render-port';
+import type { PbrRenderPort, SceneRenderObservationPort, SceneRenderPort } from '../render-port';
 import { buildComposerUserPrompt, COMPOSER_SYSTEM_PROMPT } from './prompt';
 import { type ComposerSink, makeSceneComposerTools, type SceneRenderCandidate } from './tools';
 
@@ -72,6 +72,9 @@ export interface RunKilnComposerOptions {
   maxSteps?: number;
   /** Shared aggregate allowance across compose, integration, observer, and repair phases. */
   generationCallBudget?: GenerationCallBudget;
+  /** Optional host visual observer for a text-only composer author. When set, scene render PNGs
+   * are converted to bounded structured evidence and never included in author tool results. */
+  renderObservationPort?: SceneRenderObservationPort;
 }
 
 export interface RunKilnComposerResult {
@@ -162,6 +165,8 @@ export async function runKilnComposer(
       render: opts.render,
       sink,
       ...(opts.onCandidate ? { onCandidate: opts.onCandidate } : {}),
+      ...(opts.renderObservationPort ? { renderObservationPort: opts.renderObservationPort } : {}),
+      ...(opts.generationCallBudget ? { generationCallBudget: opts.generationCallBudget } : {}),
     });
     const allTools: unknown[] = opts.extraTools ? [...tools, ...opts.extraTools] : tools;
 

--- a/src/composer/agent/tools.ts
+++ b/src/composer/agent/tools.ts
@@ -34,9 +34,11 @@ import type {
 import type { OverlapViolation } from '../overlap';
 import type {
   DerivativeReviewFidelityV1,
+  SceneRenderObservationPort,
   SceneRenderPort,
   SceneRenderResult,
 } from '../render-port';
+import type { GenerationCallBudget } from '../../agent/call-budget';
 import { ViewEvidenceHistoryStore } from '../../views/evidence-history';
 
 /**
@@ -156,11 +158,20 @@ function composerViewFidelity(res: SceneRenderResult): DerivativeReviewFidelityV
  *  returned view (perCamera grid or single frame) + a JsonBlock of metadata, or a
  *  plain `{ok:false}` when the render failed. Block arrays are a valid (untyped)
  *  Strands callback return — cast past JSONValue, same as the kiln_* tools. */
-function renderToCallback(
+function withVisualObservation(json: unknown, visualObservation: JSONValue): JSONValue {
+  if (json && typeof json === 'object' && !Array.isArray(json)) {
+    return { ...(json as Record<string, JSONValue>), visualObservation } as JSONValue;
+  }
+  return { result: json as JSONValue, visualObservation } as JSONValue;
+}
+
+async function renderToCallback(
   res: SceneRenderResult,
   surface: 'scene_render' | 'scene_screenshot_camera',
   evidenceHistory: ViewEvidenceHistoryStore,
-): JSONValue {
+  renderObservationPort?: SceneRenderObservationPort,
+  generationCallBudget?: GenerationCallBudget,
+): Promise<JSONValue> {
   if (!res.ok) {
     return { ok: false, error: res.error ?? 'render failed' } as JSONValue;
   }
@@ -177,6 +188,30 @@ function renderToCallback(
     viewEvidence: evidenceHistory.record(surface, viewFidelity),
     ...(res.tris != null ? { tris: res.tris } : {}),
   };
+  if (renderObservationPort) {
+    try {
+      const value = await renderObservationPort({
+        toolName: surface,
+        pngs: frames.map(png),
+        json: json as unknown as import('../render-port').SceneRenderObservationValue,
+        ...(generationCallBudget ? { generationCallBudget } : {}),
+      });
+      return [
+        new JsonBlock({
+          json: withVisualObservation(json, { ok: true, value } as JSONValue),
+        }),
+      ] as unknown as JSONValue;
+    } catch {
+      return [
+        new JsonBlock({
+          json: withVisualObservation(json, {
+            ok: false,
+            reason: 'observer-unavailable',
+          } as JSONValue),
+        }),
+      ] as unknown as JSONValue;
+    }
+  }
   return [
     ...frames.map((b64) => new ImageBlock({ format: 'png', source: { bytes: png(b64) } })),
     new JsonBlock({ json: json as unknown as JSONValue }),
@@ -203,6 +238,10 @@ export interface MakeComposerToolsOptions {
   sink: ComposerSink;
   /** Best-effort live render candidates (one per successful scene_render). */
   onCandidate?: (c: SceneRenderCandidate) => void;
+  /** Host VLM seam for text-only authors; strips all image blocks from tool output. */
+  renderObservationPort?: SceneRenderObservationPort;
+  /** Shared author/observer aggregate model-call budget. */
+  generationCallBudget?: GenerationCallBudget;
   /** Shared bounded hash-only material evidence ledger for this composer run. */
   viewEvidenceHistory?: ViewEvidenceHistoryStore;
 }
@@ -327,7 +366,13 @@ export function makeSceneComposerTools(opts: MakeComposerToolsOptions): Tool[] {
           }
         }
       }
-      return renderToCallback(res, 'scene_render', evidenceHistory);
+      return renderToCallback(
+        res,
+        'scene_render',
+        evidenceHistory,
+        opts.renderObservationPort,
+        opts.generationCallBudget,
+      );
     },
   });
 
@@ -360,7 +405,13 @@ export function makeSceneComposerTools(opts: MakeComposerToolsOptions): Tool[] {
           },
         ],
       });
-      return renderToCallback(res, 'scene_screenshot_camera', evidenceHistory);
+      return renderToCallback(
+        res,
+        'scene_screenshot_camera',
+        evidenceHistory,
+        opts.renderObservationPort,
+        opts.generationCallBudget,
+      );
     },
   });
 

--- a/src/composer/render-port.ts
+++ b/src/composer/render-port.ts
@@ -6,6 +6,33 @@
  */
 import type { Placement } from './model';
 import type { WorldDocumentV2 } from './world-document';
+import type { GenerationCallBudget } from '../agent/call-budget';
+
+/** JSON-safe evidence a host visual observer may return to a text-only author. */
+export type SceneRenderObservationValue =
+  | null
+  | boolean
+  | number
+  | string
+  | SceneRenderObservationValue[]
+  | { [key: string]: SceneRenderObservationValue };
+
+/** Evidence passed only to a host visual observer, never to the author model. */
+export interface SceneRenderObservationInput {
+  /** Model-facing scene tool that produced the render. */
+  toolName: 'scene_render' | 'scene_screenshot_camera';
+  /** Rendered PNG frames as bytes, never base64 and never sent to a text-only author. */
+  pngs: readonly Uint8Array[];
+  /** The base64-free metadata a direct-vision author would receive alongside images. */
+  json: SceneRenderObservationValue;
+  /** One aggregate host-owned call allowance shared with author and observer calls. */
+  generationCallBudget?: GenerationCallBudget;
+}
+
+/** Host-injected, model-free seam for bounded visual observations during composing. */
+export type SceneRenderObservationPort = (
+  input: SceneRenderObservationInput,
+) => Promise<SceneRenderObservationValue>;
 
 export interface SceneCamera {
   position: [number, number, number];


### PR DESCRIPTION
## Summary
- add a host-injected Composer scene render observation port for text-only authors
- strip render PNG blocks and return bounded observer evidence while preserving direct-vision behavior
- forward the shared call budget and cover success/failure no-image paths

## Validation
- bun test src/__tests__/composer-agent-tools.test.ts
- bun run typecheck
- bunx biome check src/composer/render-port.ts src/composer/agent/tools.ts src/composer/agent/run.ts src/__tests__/composer-agent-tools.test.ts

Full lint currently reports pre-existing repository diagnostics outside this change.