### PR TITLE
fix: enforce material authoring contracts

### DIFF
--- a/src/agent/__tests__/run-loop.test.ts
+++ b/src/agent/__tests__/run-loop.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { runKilnAgent } from '../run';
+import { createGenerationCallBudget } from '../call-budget';
 import { ScriptedModel } from './scripted-model';
 
 const BOX_CODE = `
@@ -101,6 +102,7 @@ describe('runKilnAgent over a ScriptedModel (unified surface)', () => {
       { toolCalls: [{ name: 'kiln_draft', input: { code: BOX_CODE } }, { name: 'kiln_view' }] },
       // Turn 2: the model follows the guard's instruction — mutator alone.
       { toolCalls: [{ name: 'kiln_draft', input: { code: BOX_CODE } }] },
+      { toolCalls: [{ name: 'kiln_render' }] },
       { toolCalls: [{ name: 'kiln_finalize' }] },
       { text: 'done' },
     ]);
@@ -116,11 +118,15 @@ describe('runKilnAgent over a ScriptedModel (unified surface)', () => {
     // The rejected batch never wrote the buffer; the retry did, and finalize
     // locked it in — so the run still converges on the drafted program.
     expect(result.code).toBe(BOX_CODE);
-    expect(result.steps).toBe(4);
+    expect(result.steps).toBe(5);
   });
 
   test('refine framing keeps the directive INSIDE the (cacheable) system prompt text', async () => {
-    const model = new ScriptedModel([{ toolCalls: [{ name: 'kiln_finalize' }] }, { text: 'done' }]);
+    const model = new ScriptedModel([
+      { toolCalls: [{ name: 'kiln_render' }] },
+      { toolCalls: [{ name: 'kiln_finalize' }] },
+      { text: 'done' },
+    ]);
 
     await runKilnAgent({
       model,
@@ -135,5 +141,58 @@ describe('runKilnAgent over a ScriptedModel (unified surface)', () => {
     // The refine directive is prepended to the same string that becomes the
     // cached TextBlock for cache-point providers.
     expect(sp.startsWith('You are MODIFYING an existing Kiln asset')).toBe(true);
+  });
+
+  test('a finalize admitted on the exact last call succeeds without a paid follow-up turn', async () => {
+    const budget = createGenerationCallBudget(3);
+    const model = new ScriptedModel([
+      { toolCalls: [{ name: 'kiln_draft', input: { code: BOX_CODE } }] },
+      { toolCalls: [{ name: 'kiln_render' }] },
+      { toolCalls: [{ name: 'kiln_finalize' }] },
+      { text: 'unreachable paid follow-up' },
+    ]);
+
+    const result = await runKilnAgent({
+      model,
+      prompt: 'a red test box',
+      toolSurface: 'unified',
+      generationCallBudget: budget,
+      gradeRefine: 'off',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.code).toBe(BOX_CODE);
+    expect(result.steps).toBe(3);
+    expect(result.toolCalls).toEqual(['kiln_draft', 'kiln_render', 'kiln_finalize']);
+    expect(budget.receipt()).toMatchObject({ consumed: 3, denied: 0, exhausted: true });
+  });
+
+  test('step-cap salvage refuses source mutated after the last successful render', async () => {
+    const budget = createGenerationCallBudget(3);
+    const model = new ScriptedModel([
+      { toolCalls: [{ name: 'kiln_draft', input: { code: BOX_CODE } }] },
+      { toolCalls: [{ name: 'kiln_render' }] },
+      {
+        toolCalls: [
+          {
+            name: 'kiln_edit',
+            input: { oldString: "gameMaterial('#ff0000')", newString: "gameMaterial('#0000ff')" },
+          },
+        ],
+      },
+      { text: 'unreachable paid follow-up' },
+    ]);
+
+    const result = await runKilnAgent({
+      model,
+      prompt: 'a blue test box',
+      toolSurface: 'unified',
+      generationCallBudget: budget,
+      gradeRefine: 'off',
+    });
+
+    expect(result.code).toBeUndefined();
+    expect(result.error).toContain('step cap');
+    expect(budget.receipt()).toMatchObject({ consumed: 3, denied: 0, exhausted: true });
   });
 });

--- a/src/agent/concurrency.test.ts
+++ b/src/agent/concurrency.test.ts
@@ -116,6 +116,7 @@ describe('installMutatorBatchGuard on a real Agent (concurrent executor)', () =>
     const model = new ScriptedModel([
       { toolCalls: [{ name: 'kiln_draft', input: { code: BOX_CODE } }] },
       { toolCalls: [{ name: 'kiln_view' }, { name: 'kiln_view' }] },
+      { toolCalls: [{ name: 'kiln_render' }] },
       { toolCalls: [{ name: 'kiln_finalize' }] },
       { text: 'done' },
     ]);
@@ -130,9 +131,9 @@ describe('installMutatorBatchGuard on a real Agent (concurrent executor)', () =>
 
     expect(sink.code).toBe(BOX_CODE);
     expect(sink.finalized).toBe(true);
-    // Solo mutator + both readers + finalize all produced SUCCESS results.
+    // Solo mutator + both readers + render + finalize all produced SUCCESS results.
     const results = toolResults(agent.messages);
-    expect(results).toHaveLength(4);
+    expect(results).toHaveLength(5);
     expect(results.every((r) => r.status === 'success')).toBe(true);
   });
 });

--- a/src/agent/run.ts
+++ b/src/agent/run.ts
@@ -68,6 +68,7 @@ import {
   gradeRank,
   shouldGradeRefine,
 } from './grade-refine';
+import type { RequiredProceduralTextureUsage } from '../tools/registry';
 
 /** How the agent learns Kiln conventions. */
 export type KilnKnowhow = 'inline' | 'skill';
@@ -183,6 +184,8 @@ export interface RunKilnAgentOptions
   gradeRefine?: 'auto' | 'off';
   /** Attribution role for this invocation within the shared generation budget. */
   modelCallRole?: GenerationModelCallRole;
+  /** Exact host-owned procedural texture usages that the rendered GLB must bind. */
+  requiredProceduralTextureUsages?: readonly RequiredProceduralTextureUsage[];
   /** Host-owned pre-dispatch admission. Used by quoted operations to bind
    * provider execution to their reserved-cost envelope. */
   modelCallAdmission?: GenerationModelCallAdmission;
@@ -374,6 +377,17 @@ export async function runKilnAgent(opts: RunKilnAgentOptions): Promise<RunKilnAg
           'wrong, then call the kiln_submit tool exactly once with your final, complete ' +
           'Kiln program.';
 
+    const materialContractNote = opts.requiredProceduralTextureUsages?.length
+      ? '\n\n## Required material contract\n' +
+        `The final GLB must contain exact baked procedural texture bindings for: ${[
+          ...new Set(opts.requiredProceduralTextureUsages),
+        ].join(', ')}. ` +
+        'This is a deterministic acceptance constraint, not optional visual guidance. ' +
+        'Use proceduralTexture with explicit usage values, bind the textures through pbrMaterial, ' +
+        'derive normal data with normalMapFromHeight when appropriate, and keep repairing until ' +
+        'kiln_render reports the material contract satisfied.'
+      : '';
+
     const userPrompt =
       buildUserPrompt({
         prompt: promptText,
@@ -393,6 +407,7 @@ export async function runKilnAgent(opts: RunKilnAgentOptions): Promise<RunKilnAg
               : KILN_REFERENCE_IMAGE_DIRECTIVE
           }`
         : '') +
+      materialContractNote +
       reviewNote;
 
     // With a reference image, send a [text, image] content-block pair (the same
@@ -434,9 +449,13 @@ export async function runKilnAgent(opts: RunKilnAgentOptions): Promise<RunKilnAg
       // it flagged `capped` (an honest best effort); only a cap with nothing
       // renderable stays a hard failure.
       const captured = readSinkCode();
-      const salvage = captured
-        ? await assessProgramGrade(captured, gradeAssessmentOptions)
-        : undefined;
+      const currentUnifiedRender =
+        surface !== 'unified' ||
+        (unifiedSink.rendered === true && unifiedSink.renderedCode === captured);
+      const salvage =
+        captured && currentUnifiedRender
+          ? await assessProgramGrade(captured, gradeAssessmentOptions)
+          : undefined;
       if (!salvage?.ok) {
         const collected = metrics.readMetrics();
         // A QA-blocked program is not a broken program — say so (the block
@@ -454,6 +473,15 @@ export async function runKilnAgent(opts: RunKilnAgentOptions): Promise<RunKilnAg
       }
       capped = true;
       code = captured;
+    } else if (surface === 'unified' && !unifiedSink.finalized) {
+      const collected = metrics.readMetrics();
+      return {
+        toolCalls: collected.toolCalls,
+        steps: collected.steps,
+        ...(collected.usage ? { usage: collected.usage } : {}),
+        ...(counters ? { counters } : {}),
+        error: 'kiln agent ended without a successful kiln_finalize of the current rendered buffer',
+      };
     } else if ((opts.gradeRefine ?? 'auto') === 'auto') {
       // M1b grade-aware refine (plan/05 §3.2): bake + grade the finalized program
       // exactly as the final artifact will be graded (auto consolidation). If it
@@ -563,7 +591,10 @@ export async function runKilnAgent(opts: RunKilnAgentOptions): Promise<RunKilnAg
     // a hard failure.
     const captured =
       surface === 'unified' ? unifiedSink.code : editMode ? editSink.code : sink.code;
-    if (captured) {
+    const currentUnifiedRender =
+      surface !== 'unified' ||
+      (unifiedSink.rendered === true && unifiedSink.renderedCode === captured);
+    if (captured && currentUnifiedRender) {
       const salvage = await assessProgramGrade(captured, gradeAssessmentOptions);
       if (salvage.ok) {
         return { ...base, code: captured, salvaged: 'error' as const, error: message };

--- a/src/agent/surface.ts
+++ b/src/agent/surface.ts
@@ -71,6 +71,9 @@ export function buildAgentTools(
   const trustedContext = {
     ...(opts.intent ? { intent: opts.intent } : {}),
     ...(opts.category ? { category: opts.category } : {}),
+    ...(opts.requiredProceduralTextureUsages?.length
+      ? { requiredProceduralTextureUsages: opts.requiredProceduralTextureUsages }
+      : {}),
     ...(opts.viewRenderPort ? { viewRenderPort: opts.viewRenderPort } : {}),
     ...(opts.viewRenderTimeoutMs !== undefined
       ? { viewRenderTimeoutMs: opts.viewRenderTimeoutMs }

--- a/src/agent/tools-unified.test.ts
+++ b/src/agent/tools-unified.test.ts
@@ -21,6 +21,26 @@ function build() {
 }
 `;
 
+const TEXTURED_BOX_CODE = `
+const meta = { name: 'textured-box', category: 'prop' };
+function build() {
+  const root = createRoot('Root');
+  const albedo = proceduralTexture({
+    schemaVersion: 2,
+    size: 8,
+    usage: 'albedo',
+    name: 'PaintedSteel',
+    layers: [{ op: 'solid', color: 0x5b7088 }],
+  });
+  const normal = normalMapFromHeight(albedo, { strength: 2 });
+  createPart('Mesh_Box', boxGeo(1, 1, 1), pbrMaterial({ albedo, normal }), {
+    parent: root,
+    position: [0, 0.5, 0],
+  });
+  return root;
+}
+`;
+
 // Two named parts under one root — the shape kiln_inspect frames by name.
 const TWO_PART_CODE = `
 const meta = { name: 'test-hammer', category: 'prop' };
@@ -187,6 +207,42 @@ describe('makeKilnUnifiedTools', () => {
     expect(json['ok']).toBe(true);
     expect(json['tris']).toBeGreaterThan(0); // metrics ride alongside the image
     expect('pngBase64' in json).toBe(false);
+  });
+
+  test('kiln_render fails closed with exact missing procedural texture usages', async () => {
+    const sink: UnifiedSink = { edits: [] };
+    const tools = makeKilnUnifiedTools({
+      seedCode: TEXTURED_BOX_CODE,
+      sink,
+      requiredProceduralTextureUsages: ['albedo', 'normal', 'metallicRoughness'],
+    });
+    const out = (await findTool(tools, 'kiln_render').invoke({})) as {
+      ok: boolean;
+      error?: string;
+      materialContract?: { required: string[]; present: string[]; missing: string[] };
+    };
+    expect(Array.isArray(out)).toBe(false);
+    expect(out.ok).toBe(false);
+    expect(out.error).toContain('metallicRoughness');
+    expect(out.materialContract).toEqual({
+      required: ['albedo', 'normal', 'metallicRoughness'],
+      present: ['albedo', 'normal'],
+      missing: ['metallicRoughness'],
+    });
+    expect(sink.rendered).toBeUndefined();
+  });
+
+  test('kiln_render accepts the exact required procedural usages and records current code', async () => {
+    const sink: UnifiedSink = { edits: [] };
+    const tools = makeKilnUnifiedTools({
+      seedCode: TEXTURED_BOX_CODE,
+      sink,
+      requiredProceduralTextureUsages: ['normal', 'albedo'],
+    });
+    const out = (await findTool(tools, 'kiln_render').invoke({})) as unknown[];
+    expect(Array.isArray(out)).toBe(true);
+    expect(sink.rendered).toBe(true);
+    expect(sink.renderedCode).toBe(TEXTURED_BOX_CODE);
   });
 
   test('kiln_render exposes and honors the bounded capture contract on the working buffer', async () => {
@@ -463,10 +519,19 @@ describe('makeKilnUnifiedTools', () => {
     expect(warnings).toContain('createRoofPlanes');
   });
 
-  test('kiln_finalize captures the buffer and marks finalized', async () => {
+  test('kiln_finalize requires the current buffer to have rendered successfully', async () => {
     const sink: UnifiedSink = { edits: [] };
     const tools = makeKilnUnifiedTools({ sink });
     await findTool(tools, 'kiln_draft').invoke({ code: BOX_CODE });
+    const premature = (await findTool(tools, 'kiln_finalize').invoke({})) as {
+      ok: boolean;
+      error?: string;
+    };
+    expect(premature.ok).toBe(false);
+    expect(premature.error).toContain('kiln_render');
+    expect(sink.finalized).toBeUndefined();
+
+    await findTool(tools, 'kiln_render').invoke({});
     const fin = (await findTool(tools, 'kiln_finalize').invoke({})) as {
       ok: boolean;
       recorded: boolean;
@@ -476,5 +541,46 @@ describe('makeKilnUnifiedTools', () => {
     expect(fin.recorded).toBe(true);
     expect(sink.code).toBe(BOX_CODE);
     expect(sink.finalized).toBe(true);
+  });
+
+  test('a mutation invalidates the render receipt until the exact new buffer renders', async () => {
+    const sink: UnifiedSink = { edits: [] };
+    const tools = makeKilnUnifiedTools({ seedCode: BOX_CODE, sink });
+    await findTool(tools, 'kiln_render').invoke({});
+    await findTool(tools, 'kiln_edit').invoke({
+      oldString: 'boxGeo(1, 1, 1)',
+      newString: 'boxGeo(2, 1, 1)',
+    });
+    const stale = (await findTool(tools, 'kiln_finalize').invoke({})) as {
+      ok: boolean;
+      error?: string;
+    };
+    expect(stale.ok).toBe(false);
+    expect(stale.error).toContain('current buffer');
+    await findTool(tools, 'kiln_render').invoke({});
+    expect((await findTool(tools, 'kiln_finalize').invoke({})) as { ok: boolean }).toMatchObject({
+      ok: true,
+    });
+  });
+
+  test('after a successful render, repeated whole rewrites are bounded and preserve the last buffer', async () => {
+    const sink: UnifiedSink = { edits: [] };
+    const tools = makeKilnUnifiedTools({ seedCode: BOX_CODE, sink });
+    const draft = findTool(tools, 'kiln_draft');
+    await findTool(tools, 'kiln_render').invoke({});
+    expect(
+      (await draft.invoke({ code: BOX_CODE.replace('1, 1, 1', '2, 1, 1') })) as { ok: boolean },
+    ).toMatchObject({ ok: true });
+    expect(
+      (await draft.invoke({ code: BOX_CODE.replace('1, 1, 1', '3, 1, 1') })) as { ok: boolean },
+    ).toMatchObject({ ok: true });
+    const beforeRejectedRewrite = sink.code;
+    const rejected = (await draft.invoke({
+      code: BOX_CODE.replace('1, 1, 1', '4, 1, 1'),
+    })) as { ok: boolean; error?: string; hint?: string };
+    expect(rejected.ok).toBe(false);
+    expect(rejected.error).toContain('whole-program rewrite limit');
+    expect(rejected.hint).toContain('kiln_edit');
+    expect(sink.code).toBe(beforeRejectedRewrite);
   });
 });

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -546,10 +546,20 @@ export interface UnifiedSink {
   /** True after at least one successful unified render. This distinguishes a
    * successful default-layout render from a run that never produced a view. */
   rendered?: boolean;
+  /** Exact source bytes that produced the last successful kiln_render. */
+  renderedCode?: string;
+  /** True after any successful render, even when a later mutation invalidates it. */
+  everRendered?: boolean;
+  /** Whole-program rewrites admitted after the first successful render. */
+  postRenderRewrites?: number;
   /** Capture requested by the most recent successful unified render. Undefined
    * means that render used the standard 3x2 layout. */
   capture?: CaptureConfig;
 }
+
+/** Once a program renders, repair should become surgical. Repeated wholesale
+ * rewrites were the exact production churn pattern that consumed 40 calls. */
+export const MAX_POST_RENDER_REWRITES = 2;
 
 /**
  * A live render candidate surfaced out-of-band from the unified `kiln_render`
@@ -615,6 +625,12 @@ export function makeKilnUnifiedTools(
       warnings: string[];
     };
 
+  const invalidateCurrentRender = (): void => {
+    opts.sink.rendered = undefined;
+    opts.sink.renderedCode = undefined;
+    opts.sink.capture = undefined;
+  };
+
   const draftTool: Tool = tool({
     name: 'kiln_draft',
     description:
@@ -625,7 +641,26 @@ export function makeKilnUnifiedTools(
       '({ valid, errors, warnings }); fix any errors before rendering.',
     inputSchema: draftInput,
     callback: async (input) => {
-      const r = buffer.draft((input as { code: string }).code);
+      const nextCode = (input as { code: string }).code;
+      const changesCode = nextCode !== buffer.code;
+      if (
+        changesCode &&
+        opts.sink.everRendered &&
+        (opts.sink.postRenderRewrites ?? 0) >= MAX_POST_RENDER_REWRITES
+      ) {
+        return {
+          ok: false,
+          error: `whole-program rewrite limit reached after a successful render (${MAX_POST_RENDER_REWRITES})`,
+          hint: 'Keep the current working buffer, use kiln_view plus kiln_edit for targeted repairs, render it again, then finalize.',
+        } as JSONValue;
+      }
+      const r = buffer.draft(nextCode);
+      if (changesCode) {
+        if (opts.sink.everRendered) {
+          opts.sink.postRenderRewrites = (opts.sink.postRenderRewrites ?? 0) + 1;
+        }
+        invalidateCurrentRender();
+      }
       opts.sink.code = buffer.code; // capture the live buffer even if finalize is skipped
       return { ...r, validation: await validateBuffer() } as JSONValue;
     },
@@ -655,6 +690,7 @@ export function makeKilnUnifiedTools(
         input as { oldString: string; newString: string; replaceAll?: boolean },
       );
       if (r.ok) {
+        invalidateCurrentRender();
         opts.sink.code = buffer.code; // capture the live buffer even if finalize is skipped
         return { ...r, validation: await validateBuffer() } as JSONValue;
       }
@@ -681,6 +717,8 @@ export function makeKilnUnifiedTools(
         // Preserve only a validated, successful render request. A later default
         // render deliberately clears an earlier custom layout.
         opts.sink.rendered = true;
+        opts.sink.renderedCode = buffer.code;
+        opts.sink.everRendered = true;
         opts.sink.capture = i.capture as CaptureConfig | undefined;
       }
       // Out-of-band: surface a SUCCESSFUL render as a live candidate (the working
@@ -769,6 +807,14 @@ export function makeKilnUnifiedTools(
       'edited. Returns { ok, recorded, bytes, edits }.',
     inputSchema: viewInput,
     callback: () => {
+      if (!opts.sink.rendered || opts.sink.renderedCode !== buffer.code) {
+        return {
+          ok: false,
+          recorded: false,
+          error:
+            'The current buffer has not passed kiln_render. Render these exact source bytes, repair any build/QA/material contract error, then finalize.',
+        } as JSONValue;
+      }
       opts.sink.code = buffer.code;
       opts.sink.finalized = true;
       return {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -44,6 +44,7 @@ import {
   type ViewRenderTimeoutResolver,
 } from '../agent/view-render-timeout';
 import { ViewEvidenceHistoryStore } from '../views/evidence-history';
+import type { TextureUsage } from '../textures';
 
 // =============================================================================
 // Tool definition contract
@@ -84,6 +85,10 @@ export interface KilnToolDef {
 export interface KilnToolContext {
   intent?: AssetIntentV1;
   category?: AssetCategory;
+  /** Host-owned material acceptance contract. The model cannot weaken it through
+   * generated source or tool input. Each required usage must be backed by an
+   * exact baked procedural texture binding in the rendered GLB. */
+  requiredProceduralTextureUsages?: readonly RequiredProceduralTextureUsage[];
   /**
    * Host-injected GPU renderer for the in-loop view grid. Absent by default, and
    * absent means every render stays on the CPU rasterizer — byte-identical to the
@@ -139,6 +144,58 @@ export interface KilnToolContext {
    * compatibility profile. */
   evaluatorPort?: EvaluatorPortV1;
   evaluatorProfile?: EvaluatorExecutionProfileV1;
+}
+
+export type RequiredProceduralTextureUsage = Extract<
+  TextureUsage,
+  'albedo' | 'normal' | 'metallicRoughness' | 'emissive'
+>;
+
+export interface ProceduralTextureMaterialContract {
+  required: RequiredProceduralTextureUsage[];
+  present: RequiredProceduralTextureUsage[];
+  missing: RequiredProceduralTextureUsage[];
+}
+
+function proceduralTextureMaterialContract(
+  rendered: RenderResult,
+  context: KilnToolContext,
+): ProceduralTextureMaterialContract | undefined {
+  const required = [...new Set(context.requiredProceduralTextureUsages ?? [])];
+  if (required.length === 0) return undefined;
+  const available = new Set(
+    (rendered.bakedTextures ?? []).map((entry) => entry.usage as RequiredProceduralTextureUsage),
+  );
+  const present = required.filter((usage) => available.has(usage));
+  const missing = required.filter((usage) => !available.has(usage));
+  return { required, present, missing };
+}
+
+function missingProceduralTextureResult(
+  rendered: RenderResult,
+  context: KilnToolContext,
+):
+  | {
+      ok: false;
+      error: string;
+      materialContract: ProceduralTextureMaterialContract;
+      warnings: string[];
+      qaReport?: AssetQaReportV1;
+    }
+  | undefined {
+  const materialContract = proceduralTextureMaterialContract(rendered, context);
+  if (!materialContract || materialContract.missing.length === 0) return undefined;
+  const missing = materialContract.missing.join(', ');
+  return {
+    ok: false,
+    error:
+      `Material contract missing procedural texture usages: ${missing}. ` +
+      'Create and bind each missing usage through pbrMaterial; derive a normal with ' +
+      'normalMapFromHeight when appropriate, then render the corrected buffer again.',
+    materialContract,
+    warnings: [...rendered.warnings],
+    ...(rendered.meta.qaReport ? { qaReport: rendered.meta.qaReport as AssetQaReportV1 } : {}),
+  };
 }
 
 /** JSON-safe value accepted from a host visual observer. */
@@ -631,6 +688,8 @@ async function runRender(
 ): Promise<KilnRenderMetrics> {
   try {
     const { root, rendered } = await loadEvaluatedReviewScene(input.code, context);
+    const materialContractFailure = missingProceduralTextureResult(rendered, context);
+    if (materialContractFailure) return materialContractFailure;
     const category = trustedCategory(context);
 
     // Structural advisories (floating parts / stray planes at origin).
@@ -743,6 +802,7 @@ export interface KilnRenderViewsResult {
   instanceability?: { grade: string; summary: string };
   /** Structured deterministic report; five dimensions remain separate. */
   qaReport?: AssetQaReportV1;
+  materialContract?: ProceduralTextureMaterialContract;
   /** View names in grid order (row-major). Defaults to Front, Right, Back, Left, Top, 3/4. */
   views?: string[];
   /** Grid shape actually rendered — echoes the capture config back, or `3x2` by default. */
@@ -783,6 +843,8 @@ async function runRenderViews(
       '../views'
     );
     const { root, rendered, reasonCodes } = await loadEvaluatedReviewScene(input.code, context);
+    const materialContractFailure = missingProceduralTextureResult(rendered, context);
+    if (materialContractFailure) return materialContractFailure;
     const category = trustedCategory(context);
 
     const structuralWarnings = inspectSceneStructure(root, { category });
@@ -887,6 +949,7 @@ async function runRenderViews(
     }
 
     const warnings = [...structuralWarnings, ...rendered.warnings];
+    const materialContract = proceduralTextureMaterialContract(rendered, context);
 
     return {
       ok: true,
@@ -912,6 +975,7 @@ async function runRenderViews(
       ...(viewEvidence ? { viewEvidence } : {}),
       warnings,
       qaReport: rendered.meta.qaReport as AssetQaReportV1 | undefined,
+      ...(materialContract ? { materialContract } : {}),
     };
   } catch (err) {
     return {


### PR DESCRIPTION
## Outcome
- fail each render until every host-required baked material usage is present
- require finalization of the exact last successfully rendered source
- bound post-render whole-program rewrites while preserving surgical repair
- refuse cap/error salvage after an unrendered mutation

## Evidence
- focused agent tests: 45 pass
- full suite: 1,414 pass / 2 expected skip
- coverage: functions 95.89%, lines 92.73%
- TypeScript, Biome, diff check green

No provider calls or deployment mutations.