### PR TITLE
fix: recognize valid KTX2 QA evidence

### DIFF
--- a/src/qa/gltf.test.ts
+++ b/src/qa/gltf.test.ts
@@ -38,6 +38,80 @@ const INVALID_ACCESSOR_GLTF = new TextEncoder().encode(
 );
 
 describe('Khronos final-byte conformance fixtures', () => {
+  test('ignores only exact KTX2 validator limitations on a required BasisU artifact', () => {
+    const report = {
+      issues: {
+        numErrors: 0,
+        numWarnings: 3,
+        numInfos: 1,
+        numHints: 0,
+        messages: [
+          {
+            code: 'VALUE_NOT_IN_LIST',
+            message: "Invalid value 'image/ktx2'. Valid values are ('image/jpeg', 'image/png').",
+            severity: 1,
+            pointer: '/images/0/mimeType',
+          },
+          {
+            code: 'IMAGE_UNRECOGNIZED_FORMAT',
+            message: 'Image format not recognized.',
+            severity: 1,
+            pointer: '/images/0',
+          },
+          {
+            code: 'ACCESSOR_INVALID_FLOAT',
+            message: 'Accessor contains an invalid float.',
+            severity: 1,
+            pointer: '/accessors/0',
+          },
+        ],
+      },
+      info: { extensionsRequired: ['KHR_texture_basisu'] },
+    };
+
+    expect(gltfReportFindings(report, 'prop.default')).toEqual([
+      expect.objectContaining({ code: 'GLTF_ACCESSOR_INVALID_FLOAT', disposition: 'warn' }),
+    ]);
+    const intent = createAssetIntentV1({ category: 'prop' });
+    const finalReport = appendFinalGltfQa(
+      intent,
+      createAssetQaReportV1(intent, { evaluatedDimensions: ['categoryReadiness'] }),
+      report,
+    );
+    expect(finalReport.dimensions.exportIntegrity.metrics).toMatchObject({
+      gltfErrors: 0,
+      gltfWarnings: 1,
+    });
+  });
+
+  test('does not suppress lookalike KTX2 warnings without the exact extension and pointers', () => {
+    const base = {
+      issues: {
+        numErrors: 0,
+        numWarnings: 2,
+        numInfos: 0,
+        numHints: 0,
+        messages: [
+          {
+            code: 'VALUE_NOT_IN_LIST',
+            message: "Invalid value 'image/ktx2'. Valid values are ('image/jpeg', 'image/png').",
+            severity: 1,
+            pointer: '/materials/0/mimeType',
+          },
+          {
+            code: 'IMAGE_UNRECOGNIZED_FORMAT',
+            message: 'Image format not recognized.',
+            severity: 1,
+            pointer: '/images/not-an-index',
+          },
+        ],
+      },
+      info: { extensionsRequired: ['KHR_texture_basisu'] },
+    };
+    expect(gltfReportFindings(base, 'prop.default')).toHaveLength(2);
+    expect(gltfReportFindings({ ...base, info: {} }, 'prop.default')).toHaveLength(2);
+  });
+
   test('localizes a parsed but out-of-bounds accessor as a deterministic blocker', async () => {
     const validation = await validateFinalGlbBytes(INVALID_ACCESSOR_GLTF, 'invalid-accessor.gltf');
     expect(validation.issues.numErrors).toBeGreaterThan(0);

--- a/src/qa/run.ts
+++ b/src/qa/run.ts
@@ -26,6 +26,7 @@ import {
 } from './types';
 import { UNIVERSAL_QA_RULES } from './universal';
 import type { KhronosGltfValidationReport } from './gltf';
+import type { KhronosGltfIssue } from './gltf';
 import type { MaterialBudgetWarningV1, MaterialMetricsV1 } from '../material-metrics';
 
 export const DETERMINISTIC_QA_REGISTRY = new QaRegistry([
@@ -61,6 +62,7 @@ export function gltfReportFindings(
 ): QaFinding[] {
   return report.issues.messages
     .filter((issue) => issue.severity === 0 || issue.severity === 1)
+    .filter((issue) => !isExpectedKtx2ValidatorLimitation(report, issue))
     .map((issue) => ({
       code: `GLTF_${issue.code}`.replace(/[^A-Z0-9_]/g, '_'),
       disposition: issue.severity === 0 ? ('block' as const) : ('warn' as const),
@@ -71,20 +73,43 @@ export function gltfReportFindings(
     }));
 }
 
+/** gltf-validator 2.0.0-dev.3.10 does not understand the image/ktx2 MIME used by
+ * KHR_texture_basisu. Ignore only its exact, pointer-bound false warnings when
+ * the artifact explicitly requires that extension; every other warning remains. */
+function isExpectedKtx2ValidatorLimitation(
+  report: KhronosGltfValidationReport,
+  issue: KhronosGltfIssue,
+): boolean {
+  const required = report.info?.['extensionsRequired'];
+  if (!Array.isArray(required) || !required.includes('KHR_texture_basisu')) return false;
+  if (issue.code === 'VALUE_NOT_IN_LIST') {
+    return (
+      /^\/images\/\d+\/mimeType$/.test(issue.pointer ?? '') &&
+      issue.message === "Invalid value 'image/ktx2'. Valid values are ('image/jpeg', 'image/png')."
+    );
+  }
+  return (
+    issue.code === 'IMAGE_UNRECOGNIZED_FORMAT' &&
+    /^\/images\/\d+$/.test(issue.pointer ?? '') &&
+    issue.message === 'Image format not recognized.'
+  );
+}
+
 export function appendFinalGltfQa(
   intent: AssetIntentV1,
   sceneReport: AssetQaReportV1,
   gltfReport: KhronosGltfValidationReport,
 ): AssetQaReportV1 {
   const findings = Object.values(sceneReport.dimensions).flatMap((dimension) => dimension.findings);
-  findings.push(...gltfReportFindings(gltfReport, intent.qaProfile));
+  const gltfFindings = gltfReportFindings(gltfReport, intent.qaProfile);
+  findings.push(...gltfFindings);
   return createAssetQaReportV1(intent, {
     findings,
     evaluatedDimensions: ['exportIntegrity', 'categoryReadiness'],
     metrics: {
       exportIntegrity: {
         gltfErrors: gltfReport.issues.numErrors,
-        gltfWarnings: gltfReport.issues.numWarnings,
+        gltfWarnings: gltfFindings.filter((finding) => finding.disposition === 'warn').length,
       },
     },
   });


### PR DESCRIPTION
Outcome: ignores only the two exact glTF Validator 2.0.0-dev.3.10 warnings for image/ktx2 when KHR_texture_basisu is required; retains every lookalike warning, real warning, and error; reports actionable warning counts. Verification: full Engine suite 1416 pass with 2 expected skips, QA suite 306 pass, typecheck and Biome green.