### PR TITLE
feat(composer): accept visual scene references

### DIFF
--- a/src/__tests__/composer-run-port.test.ts
+++ b/src/__tests__/composer-run-port.test.ts
@@ -32,11 +32,13 @@ const asset = (id: string): CatalogEntry => ({
 /** ScriptedModel that also records the tool surface offered on every model call. */
 class ToolCapturingModel extends ScriptedModel {
   readonly toolNames: string[][] = [];
+  readonly seenMessages: Message[][] = [];
 
   override async *stream(
     messages: Message[],
     options?: StreamOptions,
   ): AsyncIterable<ModelStreamEvent> {
+    this.seenMessages.push(messages);
     this.toolNames.push((options?.toolSpecs ?? []).map((t) => t.name));
     yield* super.stream(messages, options);
   }
@@ -59,6 +61,31 @@ async function runOnce(pbrRender?: PbrRenderPort) {
 }
 
 describe('composer pbrRender seam (B3a)', () => {
+  test('reference images enter the initial composer turn as typed multimodal content', async () => {
+    const model = new ToolCapturingModel([{ text: 'scene looks good' }]);
+    await runKilnComposer({
+      model,
+      prompt: 'recreate the attached switchyard layout with the selected kit',
+      sceneName: 'Reference switchyard',
+      catalog: [asset('gantry'), asset('transformer')],
+      render,
+      inputImage: {
+        mime: 'image/jpeg',
+        base64: Buffer.from([0xff, 0xd8, 0xff, 0xd9]).toString('base64'),
+      },
+    });
+
+    const initial = model.seenMessages[0]?.find((message) => message.role === 'user');
+    expect(initial?.content.map((block) => (block as { type?: string }).type)).toEqual([
+      'textBlock',
+      'imageBlock',
+    ]);
+    expect((initial?.content[0] as { text?: string }).text).toContain(
+      'Use the attached scene reference as visual evidence',
+    );
+    expect((initial?.content[1] as { format?: string }).format).toBe('jpeg');
+  });
+
   test('PbrRenderPort types express the render-service contract', async () => {
     // Type-level: a conforming implementation assigns cleanly and round-trips.
     const port: PbrRenderPort = async (req: PbrRenderRequest): Promise<PbrRenderResult> => ({

--- a/src/__tests__/composer-run-port.test.ts
+++ b/src/__tests__/composer-run-port.test.ts
@@ -80,10 +80,11 @@ describe('composer pbrRender seam (B3a)', () => {
       'textBlock',
       'imageBlock',
     ]);
-    expect((initial?.content[0] as { text?: string }).text).toContain(
+    if (!initial) throw new Error('composer did not send an initial message');
+    expect((initial.content[0] as { text?: string }).text).toContain(
       'Use the attached scene reference as visual evidence',
     );
-    expect((initial?.content[1] as { format?: string }).format).toBe('jpeg');
+    expect((initial.content[1] as { format?: string }).format).toBe('jpeg');
   });
 
   test('PbrRenderPort types express the render-service contract', async () => {

--- a/src/composer/agent/run.ts
+++ b/src/composer/agent/run.ts
@@ -13,9 +13,10 @@
  * captured beforehand (a step-capped or erroring run still returns its partial
  * program + placements).
  */
-import { Agent, type Message, type Tool } from '@strands-agents/sdk';
+import { Agent, ImageBlock, TextBlock, type Message, type Tool } from '@strands-agents/sdk';
 
 import { unifiedDiff } from '../../agent/diff';
+import type { KilnInputImage } from '../../agent/run';
 import type { GenerationCallBudget, GenerationCallBudgetReceipt } from '../../agent/call-budget';
 import { type AgentUsage, type KilnAgentEvent, MetricsCollector } from '../../agent/hooks';
 import { toCachedSystemPrompt } from '../../agent/providers';
@@ -39,6 +40,10 @@ export interface RunKilnComposerOptions {
   model: unknown;
   /** Natural-language description of the scene to compose. */
   prompt: string;
+  /** Optional scene reference. Direct-vision authors receive these exact bytes in
+   * the initial turn; observer-backed hosts should omit it and inject their bounded
+   * structured observation into `prompt` instead. */
+  inputImage?: KilnInputImage;
   /** The selectable asset catalog (generationId + asset-local bbox). The agent may
    *  ONLY place these. Optional when `seedScene` already carries a catalog. */
   catalog?: CatalogEntry[];
@@ -121,6 +126,14 @@ function lastMessageText(message: Message | undefined): string | undefined {
   }
   const joined = parts.join('\n').trim();
   return joined.length ? joined : undefined;
+}
+
+function imageFormatFromMime(mime: string): 'png' | 'jpeg' | 'gif' | 'webp' {
+  const normalized = mime.toLowerCase();
+  if (normalized.includes('jpeg') || normalized.includes('jpg')) return 'jpeg';
+  if (normalized.includes('gif')) return 'gif';
+  if (normalized.includes('webp')) return 'webp';
+  return 'png';
 }
 
 /** Build the model from a fresh catalog or a seeded scene (merging extra catalog). */
@@ -207,9 +220,20 @@ export async function runKilnComposer(
       ...(opts.sceneName ? { sceneName: opts.sceneName } : {}),
       ...(catalogLines ? { catalogSummary: catalogLines } : {}),
       ...(parentProgram ? { existingProgram: parentProgram } : {}),
-    });
+    }) + (opts.inputImage
+      ? '\n\nUse the attached scene reference as visual evidence for object identity, relative placement, scale, materials, and composition. Preserve ambiguity instead of inventing occluded geometry or exact depth.'
+      : '');
 
-    const result = await agent.invoke(userPrompt as never);
+    const initialTurn = opts.inputImage
+      ? [
+          new TextBlock(userPrompt),
+          new ImageBlock({
+            format: imageFormatFromMime(opts.inputImage.mime),
+            source: { bytes: new Uint8Array(Buffer.from(opts.inputImage.base64, 'base64')) },
+          }),
+        ]
+      : userPrompt;
+    const result = await agent.invoke(initialTurn as never);
     metrics.recordResultUsage(result.metrics?.latestAgentInvocation?.usage);
     const lastText = lastMessageText(result.lastMessage);
 

--- a/src/composer/agent/run.ts
+++ b/src/composer/agent/run.ts
@@ -215,14 +215,16 @@ export async function runKilnComposer(
       })
       .join('\n');
 
-    const userPrompt = buildComposerUserPrompt({
-      prompt: opts.prompt,
-      ...(opts.sceneName ? { sceneName: opts.sceneName } : {}),
-      ...(catalogLines ? { catalogSummary: catalogLines } : {}),
-      ...(parentProgram ? { existingProgram: parentProgram } : {}),
-    }) + (opts.inputImage
-      ? '\n\nUse the attached scene reference as visual evidence for object identity, relative placement, scale, materials, and composition. Preserve ambiguity instead of inventing occluded geometry or exact depth.'
-      : '');
+    const userPrompt =
+      buildComposerUserPrompt({
+        prompt: opts.prompt,
+        ...(opts.sceneName ? { sceneName: opts.sceneName } : {}),
+        ...(catalogLines ? { catalogSummary: catalogLines } : {}),
+        ...(parentProgram ? { existingProgram: parentProgram } : {}),
+      }) +
+      (opts.inputImage
+        ? '\n\nUse the attached scene reference as visual evidence for object identity, relative placement, scale, materials, and composition. Preserve ambiguity instead of inventing occluded geometry or exact depth.'
+        : '');
 
     const initialTurn = opts.inputImage
       ? [


### PR DESCRIPTION
## What changed

- adds an optional typed image reference to the Composer run contract
- sends direct-vision authors an initial `TextBlock` plus `ImageBlock`
- keeps text-only/observer routing outside the Engine contract
- documents that image evidence informs identity, relative placement, scale, materials, and composition without claiming exact monocular depth or hidden geometry

## Why

Kiln Studio needs one durable image-to-scene path where uploaded and in-product-generated images can guide scene composition. The Engine previously accepted image context for asset generation but not for Composer.

## Integration order

1. Merge this Engine PR.
2. Merge the dependent Kiln Studio PR [matthew-kissinger/kiln-studio#278](https://github.com/matthew-kissinger/kiln-studio/pull/278), which vendors this PR's current head (`639d2c2`).

## Validation

- `bun run lint`
- `bun test src/__tests__/composer-run-port.test.ts` — 4 passed, 31 assertions
- `bun run typecheck`

No provider call, AWS mutation, or deployment was performed for this change.

## Follow-ups

- Studio owns retained image artifacts, structured scene analysis, observer routing, review-before-spend pack planning, and artifact lifecycle.
