### PR TITLE
Say it is open source, document the tools, stop hardcoding the library size

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -6,14 +6,14 @@
     <title>Kiln</title>
     <meta
       name="description"
-      content="Text-to-3D as code. A language model writes a JavaScript program that builds the geometry, looks at its own render, and revises. Ships as an MCP server plus skills for any agent harness."
+      content="Open source engine for building 3D assets with language models. The model writes a JavaScript program that constructs the geometry, looks at its own render, and revises. Ships as an MCP server plus skills for any agent harness."
     />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <meta property="og:title" content="Kiln" />
     <meta
       property="og:description"
-      content="A language model writes a JavaScript program that builds the geometry, looks at its own render, and revises."
+      content="Open source engine for building 3D assets with language models. The model writes a program, looks at its own render, and revises."
     />
     <meta property="og:type" content="website" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/site/src/Home.tsx
+++ b/site/src/Home.tsx
@@ -8,14 +8,13 @@ const DOCS = `${REPO}/blob/main`;
 /**
  * The exact configs from docs/install.md. They live here as data rather than as
  * prose so the tab switcher can render them uniformly, and every one of them is
- * a config somebody actually got working -- the notes attached to each are the
- * part that saves an hour.
+ * a config somebody actually got working. The note attached to each is the part
+ * that saves an hour.
  */
 const HARNESSES = [
   {
     id: 'claude',
     name: 'Claude Code',
-    lang: 'bash',
     code: `claude plugin marketplace add matthew-kissinger/kiln
 claude plugin install kiln@kiln`,
     note: 'Brings the tools and all five skills in together. Check it took with /mcp.',
@@ -23,24 +22,21 @@ claude plugin install kiln@kiln`,
   {
     id: 'codex',
     name: 'Codex CLI',
-    lang: 'bash',
     code: `codex mcp add kiln --env KILN_RENDER=auto \\
   -- node /absolute/path/to/kiln/dist/mcp-server.mjs`,
-    note: 'Headless runs need --approve-for-me, or every tool call is refused before it runs.',
+    note: 'Headless runs need --approve-for-me, or every tool call gets refused before it runs.',
   },
   {
     id: 'agy',
     name: 'Antigravity',
-    lang: 'bash',
     code: `agy plugin install .
 agy mcp add --env KILN_RENDER=auto kiln \\
   node /absolute/path/to/kiln/dist/mcp-server.mjs`,
-    note: 'Two commands, not one: installing a plugin does not register the MCP servers it declares, so the agent sees no tools until the second. Confirm with agy mcp list.',
+    note: 'Two commands, not one. Installing a plugin does not register the MCP servers it declares, so the agent sees no tools until you run the second. Confirm with agy mcp list.',
   },
   {
     id: 'opencode',
     name: 'OpenCode',
-    lang: 'json',
     code: `{
   "mcp": {
     "kiln": {
@@ -51,16 +47,15 @@ agy mcp add --env KILN_RENDER=auto kiln \\
     }
   }
 }`,
-    note: 'Three things differ from every other client here and each fails silently: the key is mcp not mcpServers, the type is local not stdio, and the command is one array rather than command plus args.',
+    note: 'Three things differ from every other client here and each one fails silently: the key is mcp and not mcpServers, the type is local and not stdio, and the command is a single array instead of a command plus args.',
   },
   {
     id: 'hermes',
     name: 'Hermes',
-    lang: 'bash',
     code: `hermes mcp add kiln --command node \\
   --args /absolute/path/to/kiln/dist/mcp-server.mjs --env KILN_RENDER=auto
 hermes config set skills.external_dirs /absolute/path/to/kiln/skills`,
-    note: 'A Python agent with its own config, routing and skill store — the honest test of whether any of this is Claude-Code-shaped.',
+    note: 'A Python agent with its own config format, provider routing and skill store. If it works here, none of this is Claude Code specific.',
   },
 ] as const;
 
@@ -94,32 +89,42 @@ export function Home({ specimens }: { specimens: Specimen[] }) {
   const [harness, setHarness] = useState<string>(HARNESSES[0].id);
   const active = HARNESSES.find((h) => h.id === harness) ?? HARNESSES[0];
 
-  // A handful of the heaviest, which are also the ones that make the point
-  // fastest. Not a gallery -- a door to one.
+  // Counted from the index rather than written into the copy. The library grows,
+  // and a sentence with a number typed into it goes stale the first time it does.
+  const models = new Set(specimens.map((s) => s.model)).size;
+  const notClaude = specimens.filter((s) => !s.model.startsWith('Claude')).length;
+  const cleanRoom = specimens.filter((s) => s.cleanRoom).length;
+
+  // A door to the gallery, not a gallery. The heaviest ones make the point fastest.
   const strip = [...specimens].sort((a, b) => b.tris - a.tris).slice(0, 8);
 
   return (
     <div className="doc">
       <header className="hero">
         <h1 className="wordmark">
-          Kiln <span>3D assets as programs</span>
+          Kiln <span>open source</span>
         </h1>
         <p className="lede">
-          A language model writes a small JavaScript program that constructs the geometry. Kiln runs
-          it, exports a glTF binary, rasterizes six orthographic views, and hands the images back so
-          the model can fix what it sees. Nothing is sampled and nothing is hand-authored.
+          Kiln builds 3D assets with language models, without generating a mesh. The model writes a
+          small JavaScript program that constructs the geometry. Kiln runs that program, exports a
+          GLB, renders six views of the result, and gives the images back so the model can see what
+          it actually made and fix it.
         </p>
         <p className="lede">
-          What you keep is the GLB <em>and</em> the program that made it — named parts, real metres,
-          a diff you can read, and a file the next agent can edit instead of regenerating from
-          scratch.
+          It started as a commercial product. The engine is open source now because model capability
+          keeps leapfrogging, and something like this is worth more as a thing you can run and
+          change yourself than as a service sitting behind my login.
+        </p>
+        <p className="lede">
+          What you keep is the program, not just the mesh. Parts have names, sizes are in real
+          metres, and the next revision is a diff instead of another roll of the dice.
         </p>
         <div className="cta">
           <a className="button primary" href="#start">
             Get started
           </a>
           <a className="button" href="#/gallery">
-            See the fifty
+            Gallery
           </a>
           <a className="button ghost" href={REPO}>
             GitHub
@@ -128,19 +133,19 @@ export function Home({ specimens }: { specimens: Specimen[] }) {
       </header>
 
       <section className="band">
-        <h2 id="start">Try it without a key</h2>
+        <h2 id="start">Run it without an API key</h2>
         <p>
-          The whole offline path — geometry build, QA gates, rasterizer — runs with no model, no
-          network, no GPU and no API key. If this produces a GLB and a contact sheet, the engine is
-          fine and anything that goes wrong later is transport configuration.
+          Everything except the model runs on your machine, including the rasterizer, so the offline
+          path needs no network and no GPU. If this writes a GLB and a contact sheet then the engine
+          is working, and anything that breaks after it is configuration.
         </p>
         <Code>{`git clone https://github.com/matthew-kissinger/kiln && cd kiln
 bun install
 bun run kiln render examples/crate.kiln.js \\
   --out crate.glb --views sheet.png`}</Code>
         <p className="aside">
-          <a href="https://bun.sh">Bun</a> is the toolchain. The MCP server itself runs on Node,
-          from a committed bundle, so nobody has to have Bun on their PATH to use the plugin.
+          <a href="https://bun.sh">Bun</a> is the toolchain. The MCP server itself runs on Node from
+          a committed bundle, so you do not need Bun on your PATH to use the plugin.
         </p>
       </section>
 
@@ -148,7 +153,7 @@ bun run kiln render examples/crate.kiln.js \\
         <h2>Wire it into your agent</h2>
         <p>
           One tool surface over two transports. Every harness below has been run end to end, and the
-          notes are the parts that are not obvious from anyone's documentation.
+          note under each config is the part that is not obvious from anyone's documentation.
         </p>
         <div className="tabs" role="tablist">
           {HARNESSES.map((h) => (
@@ -167,18 +172,18 @@ bun run kiln render examples/crate.kiln.js \\
         <Code>{active.code}</Code>
         <p className="note">{active.note}</p>
         <p className="aside">
-          Full detail, including headless permission grants and how to check it actually connected,
-          is in <a href={`${DOCS}/docs/install.md`}>the install guide</a>.
+          Full detail, including headless permission grants and how to check that it actually
+          connected, is in <a href={`${DOCS}/docs/install.md`}>the install guide</a>.
         </p>
       </section>
 
       <section className="band">
-        <h2>What the model is actually writing</h2>
+        <h2>What the model actually writes</h2>
         <p>
-          A program declares what it is, builds a tree of named parts from primitives and CSG, and
+          A program says what it is, builds a tree of named parts out of primitives and CSG, and
           returns the root. Kiln injects the globals, so there is nothing to import and no build
-          step. An <code>animate()</code> beside it returns named clips built against the same
-          parts, so a joint that moves is the joint that was modelled.
+          step. If the asset moves, an <code>animate()</code> function beside it returns named clips
+          built against those same parts, so the joint that moves is the joint that was modelled.
         </p>
         <Code>{`const meta = { name: 'Crate', category: 'prop' };
 
@@ -192,18 +197,21 @@ function build() {
   return root;
 }`}</Code>
         <p>
-          The six-view sheet goes back to the model as an image. That loop — write, render, look,
-          revise — is the whole idea, and it is why every file's header comment reads like a
-          post-mortem.
+          The six-view sheet goes back to the model as an image. Write it, render it, look at it,
+          revise. That loop is the whole idea, and it is why the header comment on every example
+          reads like a post-mortem.
         </p>
       </section>
 
       <section className="band">
-        <h2>Fifty of them, written by nine models</h2>
+        <h2>
+          {specimens.length} assets, written by {models} models
+        </h2>
         <p>
-          Thirty-five were not written by Claude, and thirty-three were dispatched into a directory
-          holding only a brief and the Kiln skills — no engine source, no finished example to copy
-          an interface from. Nothing in the tools or the skills changed for any of them.
+          {notClaude} of them were not written by Claude. {cleanRoom} were dispatched into a
+          directory holding nothing but a brief and the Kiln skills, with no engine source and no
+          finished example to copy an interface from. Nothing in the tools or the skills changed for
+          any of them.
         </p>
         <div className="strip">
           {strip.map((s) => (
@@ -215,7 +223,7 @@ function build() {
         </div>
         <p>
           <a className="button" href="#/gallery">
-            Browse all fifty
+            Browse the gallery
           </a>
         </p>
       </section>
@@ -226,39 +234,42 @@ function build() {
           <dt>
             <a href={`${DOCS}/examples`}>examples/</a>
           </dt>
-          <dd>Every program, with the render beside it and its authorship in the header.</dd>
+          <dd>
+            Every program, with its render beside it and the model that wrote it in the header.
+          </dd>
           <dt>
             <a href={`${DOCS}/src/tools/registry.ts`}>src/tools/registry.ts</a>
           </dt>
           <dd>
-            One definition of every tool. The in-process skin and the MCP server both iterate it, so
-            the two transports cannot drift; a parity test fails the build if they start to.
+            One definition of every tool. The in-process version and the MCP server both read from
+            it, so the two transports cannot drift apart. A parity test fails the build if they
+            start to.
           </dd>
           <dt>
             <a href={`${DOCS}/skills`}>skills/</a>
           </dt>
           <dd>
-            Five skills, written for a host agent that is doing the authoring rather than calling a
-            black box.
+            Five skills, written for a host agent that is doing the authoring itself rather than
+            calling a black box.
           </dd>
           <dt>
             <a href={`${DOCS}/examples/strands-harness.ts`}>examples/strands-harness.ts</a>
           </dt>
           <dd>
-            The whole integration in about sixty lines, with both host-injected seams legible.
+            The whole integration in about sixty lines, with both host-injected seams visible.
           </dd>
           <dt>
             <a href={`${DOCS}/render-service`}>render-service/</a>
           </dt>
           <dd>
             The GPU renderer. Local and remote are the same HTTP service, so there is no native
-            dependency and installation cannot fail on a machine without a GPU.
+            dependency and installing Kiln cannot fail on a machine without a GPU.
           </dd>
         </dl>
       </section>
 
       <footer className="foot">
-        <span>MIT. Built by Matthew Kissinger.</span>
+        <span>MIT licensed. Built by Matthew Kissinger.</span>
         <a href={REPO}>Repository</a>
         <a href={`${DOCS}/docs/install.md`}>Install</a>
         <a href="#/gallery">Gallery</a>

--- a/site/src/Home.tsx
+++ b/site/src/Home.tsx
@@ -6,6 +6,42 @@ import type { Specimen } from './types';
 const DOCS = `${REPO}/blob/main`;
 
 /**
+ * The seven tools the MCP server actually lists, in the order it lists them,
+ * with the one-line version of what each is for. Anyone comparing this against
+ * `tools/list` should find the same names in the same order.
+ */
+const TOOLS = [
+  {
+    name: 'kiln_list_primitives',
+    line: 'Lists what the sandbox gives you: geometry helpers, materials, structure, animation, CSG, arrays, UV and textures, with exact signatures. A model calls this before writing anything, which is why it can work with no engine source in front of it.',
+  },
+  {
+    name: 'kiln_validate',
+    line: 'Static checks on a program before it runs. Missing meta or build(), keyframe typos, infinite loops, recursive build() calls, syntax errors. Cheap enough to run on every draft. There is no triangle budget and density is never warned about.',
+  },
+  {
+    name: 'kiln_render',
+    line: 'Runs the program, builds the GLB in memory, and returns the six-view contact sheet as an image along with triangle count, mesh and material counts, the bounding box, which part sits lowest, and any structural warnings. This is the tool that lets the model see.',
+  },
+  {
+    name: 'kiln_screenshot_animation',
+    line: 'Renders one named clip as six frames sampled across it, each labelled with its phase. Motion is the thing a still cannot show, so a rig that looks right and moves wrong is only catchable here.',
+  },
+  {
+    name: 'kiln_view_interior',
+    line: 'For anything you can walk into. Renders it with the roof lifted off as a floor plan plus two cutaways, so an interior that turned out solid is visible instead of hidden behind its own walls.',
+  },
+  {
+    name: 'kiln_inspect',
+    line: 'A close-up of one named part from any angle. The contact sheet is where you notice something is wrong, and this is where you find out what.',
+  },
+  {
+    name: 'kiln_edit',
+    line: 'Exact-string patches applied to an existing program, rendered in the same call. This is the refine verb, and the reason a second pass is a diff rather than a regeneration.',
+  },
+] as const;
+
+/**
  * The exact configs from docs/install.md. They live here as data rather than as
  * prose so the tab switcher can render them uniformly, and every one of them is
  * a config somebody actually got working. The note attached to each is the part
@@ -146,6 +182,31 @@ bun run kiln render examples/crate.kiln.js \\
         <p className="aside">
           <a href="https://bun.sh">Bun</a> is the toolchain. The MCP server itself runs on Node from
           a committed bundle, so you do not need Bun on your PATH to use the plugin.
+        </p>
+      </section>
+
+      <section className="band">
+        <h2>The tools</h2>
+        <p>
+          Seven of them, and the whole surface is here. Four exist so the model can look at what it
+          built, which is the part most asset pipelines leave out.
+        </p>
+        <dl className="tools">
+          {TOOLS.map((t) => (
+            <div key={t.name}>
+              <dt>{t.name}</dt>
+              <dd>{t.line}</dd>
+            </div>
+          ))}
+        </dl>
+        <p>
+          All seven are defined once, in <a href={`${DOCS}/src/tools/registry.ts`}>one registry</a>,
+          and reach you three ways. As an <b>MCP server</b> over stdio, which is what the configs
+          below set up. As a <b>CLI</b>, where <code>kiln render</code> and{' '}
+          <code>kiln generate</code> cover the offline path and a full authoring run. Or{' '}
+          <b>in process</b>, by importing <code>kiln/tools</code> and mapping four fields per tool,
+          if your harness is TypeScript and you would rather skip the transport. Nothing is
+          reimplemented per transport, and a parity test fails the build if they drift.
         </p>
       </section>
 

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -788,6 +788,38 @@ button {
   text-overflow: ellipsis;
 }
 
+/* ------------------------------------------------------------------ tools */
+
+/*
+ * A definition list, not cards. Seven tools with a sentence each is reference
+ * material: the reader is scanning for the one that does the thing they want,
+ * and a grid of boxes makes that scan slower, not faster.
+ */
+.tools {
+  margin: 0 0 22px;
+  border-top: 1px solid var(--rule);
+}
+
+.tools > div {
+  display: grid;
+  grid-template-columns: 13rem 1fr;
+  gap: 0 20px;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.tools dt {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--flame);
+}
+
+.tools dd {
+  margin: 0;
+  color: var(--dim);
+  text-wrap: pretty;
+}
+
 /* --------------------------------------------------------------- repo map */
 
 .map {
@@ -837,6 +869,12 @@ button {
 
   .strip {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* The tool name stops being a column and becomes a heading over its line. */
+  .tools > div {
+    grid-template-columns: 1fr;
+    gap: 4px;
   }
 
   .masthead {


### PR DESCRIPTION
Three rounds of review feedback on the front page.

## It never said it was open source

Or why. That is the first thing a stranger arriving from a link needs, and the reason is part of the story: this was a commercial product, and the engine is worth more as something you run and change yourself than as a service behind a login, because model capability keeps leapfrogging under it. That is now the second paragraph on the page.

## The tools were never named

The page described the loop but never said what the agent actually gets. All seven are listed now, in the order `tools/list` returns them, with a line each. Four of the seven exist so the model can look at what it built, which is worth calling out because most asset pipelines do not have it.

It also says where the surface lives, which is the other half of the question: MCP over stdio, the CLI, or imported in process for a TypeScript harness that would rather skip the transport. One registry behind all of them.

## "See the fifty" bakes in a count

The library grows. Every count on the page now comes off the specimen index at render time, including the section heading, the not-Claude count and the clean-room count, so no sentence goes stale the first time an example lands. The buttons say "Gallery" and "Browse the gallery".

## Voice

The copy was in my register rather than the author's: em dashes throughout and a habit of arranging things into threes. Rewritten plainer, with neither. Zero em dashes remain anywhere under `site/`.

## Verification

Typecheck and lint clean, site builds, front page and all six sections rendered and read in a browser. Tool names and order checked against a live `tools/list` handshake against `dist/mcp-server.mjs` rather than against the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
