### PR TITLE
Ignore local agent config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ tmp/
 site/public/assets/
 site/public/thumbs/
 site/dist/
+
+# Local agent config (launch profiles, per-machine settings). The shipped
+# plugin manifest lives in .claude-plugin/, which is tracked.
+.claude/


### PR DESCRIPTION
`.claude/` holds per-machine launch profiles and settings. The repository is public now, so a directory nobody meant to publish should be ignored rather than sitting untracked and one `git add .` away from being committed. The shipped plugin manifest is in `.claude-plugin/` and stays tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)