### PR TITLE
Say that the program is passed in on every call

### DIFF
--- a/site/src/Home.tsx
+++ b/site/src/Home.tsx
@@ -191,6 +191,13 @@ bun run kiln render examples/crate.kiln.js \\
           Seven of them, and the whole surface is here. Four exist so the model can look at what it
           built, which is the part most asset pipelines leave out.
         </p>
+        <p>
+          Every one except <code>kiln_list_primitives</code> takes the program itself as its{' '}
+          <code>code</code> argument. There is no session on the server holding a half-finished
+          asset. The model keeps the source in its own context and sends it with each call, so the
+          program is the only state, and the same tools behave identically whether they reach you
+          over MCP, through the CLI, or imported straight into your process.
+        </p>
         <dl className="tools">
           {TOOLS.map((t) => (
             <div key={t.name}>

--- a/site/src/Home.tsx
+++ b/site/src/Home.tsx
@@ -193,10 +193,17 @@ bun run kiln render examples/crate.kiln.js \\
         </p>
         <p>
           Every one except <code>kiln_list_primitives</code> takes the program itself as its{' '}
-          <code>code</code> argument. There is no session on the server holding a half-finished
-          asset. The model keeps the source in its own context and sends it with each call, so the
-          program is the only state, and the same tools behave identically whether they reach you
-          over MCP, through the CLI, or imported straight into your process.
+          <code>code</code> argument. Nothing on the server holds a half-finished asset between
+          calls, which is why the same tools behave identically whether they reach you over MCP,
+          through the CLI, or imported straight into your process.
+        </p>
+        <p>
+          That does not mean writing it again to change it. <code>kiln_edit</code> is the second
+          verb for a reason: it takes the current source plus exact-string replacements, so the
+          model patches rather than re-emits, every line it did not touch comes back byte for byte,
+          and the reply is a diff. A rewrite cannot promise that, and what it quietly loses is
+          invisible in a render: a constant that shifted, a part that lost its name, a comment
+          carrying the reason for a number.
         </p>
         <dl className="tools">
           {TOOLS.map((t) => (


### PR DESCRIPTION
Someone reading the tool list asked which call the model hands the program to, which means the page did not answer it.

The answer is all of them bar `kiln_list_primitives`: each takes the program as its `code` argument. That is worth stating outright because it is the design. There is no server-side session holding a half-finished asset, so the program is the only state, and the model keeps the source in its own context and sends it with every call.

It is also why the surface behaves identically over MCP, through the CLI, and imported in process. Nothing on the other side is remembering anything.

Verified against a live `tools/list` handshake rather than the source: `kiln_validate`, `kiln_render`, `kiln_screenshot_animation`, `kiln_view_interior`, `kiln_inspect` and `kiln_edit` all declare `code` as required; `kiln_list_primitives` takes only an optional `category`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)