### PR TITLE
Keep gallery builds consistent with reviewed artifact hashes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,9 +15,17 @@ on:
       - 'README.md'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'examples/**'
+      - 'site/**'
+      - 'src/**'
+      - 'scripts/authorship.ts'
+      - 'README.md'
+      - '.github/workflows/pages.yml'
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -31,7 +39,9 @@ env:
 jobs:
   build:
     name: build the gallery
-    runs-on: ubuntu-latest
+    # Poster receipts bind exact GLB bytes captured on Windows. Platform math
+    # can change the last digit of serialized rotations without changing meshes.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
@@ -66,12 +76,15 @@ jobs:
         working-directory: site
 
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+        if: github.event_name != 'pull_request'
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        if: github.event_name != 'pull_request'
         with:
           path: site/dist
 
   deploy:
     name: deploy to Pages
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/docs/example-provenance.md
+++ b/docs/example-provenance.md
@@ -71,7 +71,14 @@ presented as the current gallery source.
 See [the evaluation notes](dogfooding.md) for completed authoring runs and their
 limits, and [clean-room setup](clean-room.md) for how to create a separate project.
 
-The public gallery excludes the tidal observatory after visual review. Its source
-and historical evaluation records remain in the repository archive; archive
-presence does not imply gallery selection. The current public collection contains
-54 examples. New gallery thumbnails are framed as whole assets, without cropping.
+The public gallery excludes Tidal Observatory, Fire Lookout Tower, Brass Tellurion,
+and Victorian Greenhouse after visual review. Their source and historical records
+remain archived; archive presence does not imply gallery selection. See the
+[current collection](examples.md). Thumbnails show whole assets without cropping.
+
+Gallery publishing uses Windows and pinned Bun/dependencies to match the reviewed
+GLB bytes. Linux can serialize the last decimal place of a rotation differently
+even when the binary mesh data is identical. The build therefore records its
+platform and keeps source, GLB, and poster hash checks strict. CLI and MCP package
+support on Linux and macOS is tested separately; rebuilding on those platforms
+does not promise byte-identical GLB serialization.

--- a/site/scripts/build-assets.mjs
+++ b/site/scripts/build-assets.mjs
@@ -175,7 +175,7 @@ await writeFile(
       engineVersion: buildInputs.engineVersion,
       engineSourceHash: buildInputs.sourceHash,
       dependencyLockHash: buildInputs.dependencyHash,
-      runtime: { bun: process.versions.bun, node: process.versions.node },
+      runtime: { bun: process.versions.bun, node: process.versions.node, platform: process.platform, arch: process.arch },
       evaluator: 'trusted-local',
       indexHash: sha256(await readFile(join(OUT, 'index.json'))),
       note: 'Source and GLB hashes bind each downloadable pair. Poster receipts separately record the image, camera and renderer. The lock hash records dependency intent, not the installed dependency closure.',


### PR DESCRIPTION
The Pages build rejected the reviewed asset hashes on Linux: the first GLB had identical binary mesh data but 19 JSON rotation values differed by roughly 1e-16 from the Windows capture build. Source and poster hashes matched.

Build the gallery on Windows with the existing pinned Bun version and frozen dependency lock, preserving the exact source/GLB/poster checks. Record the build platform and architecture, and run the gallery workflow on pull requests without publishing so this failure is caught before merge. Document the distinction between cross-platform package support and byte-identical artifact serialization.

Validation: reproduced the Linux mismatch from an isolated checkout; compared GLB JSON and binary chunks; the full 62-asset Windows build and verification pass locally. Hosted Windows gallery validation runs on this PR before deployment.
