### PR TITLE
Make a bare clone usable by any of five agent harnesses

### DIFF
--- a/.agents/skills/kiln-setup-workspace/SKILL.md
+++ b/.agents/skills/kiln-setup-workspace/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: kiln-setup-workspace
+description: Create and verify a Kiln asset workspace for a chosen coding-agent harness. Use before authoring when the current directory is the engine repository, an empty folder, or any project without a working kiln_workspace server.
+license: MIT
+---
+
+# Set up a workspace for asset authoring
+
+This repository is the engine. Asset authoring happens in a separate workspace, and the two are different tasks with different tools. Establish which one is being asked before running anything.
+
+Authoring an asset needs a workspace. Changing the engine's own behaviour does not; read `AGENTS.md` at the repository root instead and stay in the checkout.
+
+Do not author assets inside the engine checkout. The authoring skills assume a workspace, and giving a model the engine implementation and the example collection alongside its task changes what it produces.
+
+## Create the workspace
+
+Choose an absolute path to an empty directory outside the checkout.
+
+```bash
+node scripts/create-workspace.mjs /absolute/empty-workspace --harness claude
+```
+
+From an installed package, the equivalent is `kiln-init /absolute/empty-workspace --harness claude`. Author, refine and QA skills are installed by default; `--skills compose,batch` adds the optional scene-composition and trial-dispatch workflows. Ask the user which harness they use rather than assuming; the choice writes different configuration and cannot be changed afterwards without a fresh workspace.
+
+| `--harness` | Launch from the workspace |
+| --- | --- |
+| `claude` | `claude` |
+| `codex` | `codex` |
+| `opencode` | `opencode` |
+| `agy` | `node agy.mjs` |
+| `hermes` | `node hermes.mjs --ignore-rules` |
+
+Antigravity and Hermes get a generated launcher because each needs arguments or a separate profile that the bare command does not supply. Hermes authenticates in its own profile; setup copies no credentials.
+
+## Verify the loadout before authoring
+
+Accept the project and MCP trust prompts, then confirm the server is actually live rather than assuming it from configuration. Call `kiln_list_primitives` on `kiln_workspace` with `capabilities: true`; it returns the runtime, source, export and camera contract and proves the tools resolved. A server named `kiln` from a global installation is a different thing. Do not substitute it silently; report the setup problem instead.
+
+Confirm the installed skills are readable at `skills/` in the workspace, and read the relevant one from there rather than a global copy. Whether the harness also registers them natively depends on the harness.
+
+## Relocation and repair
+
+Moving the workspace or the engine installation breaks the generated absolute paths, and so does replacing the Node that setup validated.
+
+```bash
+node /current/kiln/scripts/create-workspace.mjs /absolute/empty-workspace --repair
+```
+
+Repair rewrites generated runtime paths only. It preserves copied skills, saved revisions and assets, refuses configuration that was edited by hand, and does not upgrade the skills. To evaluate a different engine version, create a fresh workspace from that version so instructions and tools match.
+
+## What isolation means
+
+A separate workspace limits task context. It is not an operating-system sandbox, and it is not a git repository. User-level instructions, memory, authentication and filesystem permissions still apply. For comparing harnesses or models, read `skills/kiln-batch-dispatch/references/clean-room-evaluation.md` in the engine checkout, which covers recording inherited context and reporting trials.

--- a/.claude/skills/kiln-setup-workspace/SKILL.md
+++ b/.claude/skills/kiln-setup-workspace/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: kiln-setup-workspace
+description: Create and verify a Kiln asset workspace for a chosen coding-agent harness. Use before authoring when the current directory is the engine repository, an empty folder, or any project without a working kiln_workspace server.
+license: MIT
+---
+
+# Set up a workspace for asset authoring
+
+This repository is the engine. Asset authoring happens in a separate workspace, and the two are different tasks with different tools. Establish which one is being asked before running anything.
+
+Authoring an asset needs a workspace. Changing the engine's own behaviour does not; read `AGENTS.md` at the repository root instead and stay in the checkout.
+
+Do not author assets inside the engine checkout. The authoring skills assume a workspace, and giving a model the engine implementation and the example collection alongside its task changes what it produces.
+
+## Create the workspace
+
+Choose an absolute path to an empty directory outside the checkout.
+
+```bash
+node scripts/create-workspace.mjs /absolute/empty-workspace --harness claude
+```
+
+From an installed package, the equivalent is `kiln-init /absolute/empty-workspace --harness claude`. Author, refine and QA skills are installed by default; `--skills compose,batch` adds the optional scene-composition and trial-dispatch workflows. Ask the user which harness they use rather than assuming; the choice writes different configuration and cannot be changed afterwards without a fresh workspace.
+
+| `--harness` | Launch from the workspace |
+| --- | --- |
+| `claude` | `claude` |
+| `codex` | `codex` |
+| `opencode` | `opencode` |
+| `agy` | `node agy.mjs` |
+| `hermes` | `node hermes.mjs --ignore-rules` |
+
+Antigravity and Hermes get a generated launcher because each needs arguments or a separate profile that the bare command does not supply. Hermes authenticates in its own profile; setup copies no credentials.
+
+## Verify the loadout before authoring
+
+Accept the project and MCP trust prompts, then confirm the server is actually live rather than assuming it from configuration. Call `kiln_list_primitives` on `kiln_workspace` with `capabilities: true`; it returns the runtime, source, export and camera contract and proves the tools resolved. A server named `kiln` from a global installation is a different thing. Do not substitute it silently; report the setup problem instead.
+
+Confirm the installed skills are readable at `skills/` in the workspace, and read the relevant one from there rather than a global copy. Whether the harness also registers them natively depends on the harness.
+
+## Relocation and repair
+
+Moving the workspace or the engine installation breaks the generated absolute paths, and so does replacing the Node that setup validated.
+
+```bash
+node /current/kiln/scripts/create-workspace.mjs /absolute/empty-workspace --repair
+```
+
+Repair rewrites generated runtime paths only. It preserves copied skills, saved revisions and assets, refuses configuration that was edited by hand, and does not upgrade the skills. To evaluate a different engine version, create a fresh workspace from that version so instructions and tools match.
+
+## What isolation means
+
+A separate workspace limits task context. It is not an operating-system sandbox, and it is not a git repository. User-level instructions, memory, authentication and filesystem permissions still apply. For comparing harnesses or models, read `skills/kiln-batch-dispatch/references/clean-room-evaluation.md` in the engine checkout, which covers recording inherited context and reporting trials.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -12,9 +12,26 @@
     "longDescription": "Author JavaScript, inspect camera views, and save GLBs with source revisions for later refinement.",
     "developerName": "Matthew Kissinger",
     "category": "Developer Tools",
-    "capabilities": ["Read", "Write"],
-    "defaultPrompt": ["Create a game prop and save its editable GLB bundle.", "Browse my collection and refine an existing asset."]
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Create a game prop and save its editable GLB bundle.",
+      "Browse my collection and refine an existing asset."
+    ]
   },
-  "mcpServers": "./.mcp.json",
+  "mcpServers": {
+    "kiln": {
+      "command": "node",
+      "args": [
+        "dist/mcp-server.mjs"
+      ],
+      "cwd": ".",
+      "env": {
+        "KILN_RENDER": "auto"
+      }
+    }
+  },
   "license": "MIT"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Check toolchain metadata
         run: bun run check:toolchain
 
+      - name: Check skills against the Agent Skills specification
+        run: bun run check:skills
+
       - name: Install
         run: bun install --frozen-lockfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,11 @@ site/dist/
 
 # Local agent config (launch profiles, per-machine settings). The shipped
 # plugin manifest lives in .claude-plugin/, which is tracked.
-.claude/
+# .claude/ is local state. The exception is .claude/skills/, which is committed so
+# a bare clone registers the setup skill; git will not descend into a wholly
+# excluded directory, hence the `/*` form rather than `.claude/`.
+.claude/*
+!.claude/skills/
 
 # Gallery posters are fetched from R2 by site/scripts/verify-assets.mjs and cached here.
 .poster-cache/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
     "kiln": {
+      "type": "stdio",
       "command": "node",
-      "args": ["${PLUGIN_ROOT}/dist/mcp-server.mjs"],
+      "args": ["${CLAUDE_PROJECT_DIR:-.}/dist/mcp-server.mjs"],
       "env": { "KILN_RENDER": "auto" }
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,18 @@ Read [README.md](./README.md) before changing exports or package contents. Runti
 `scripts/`. The package intentionally ships TypeScript source through the explicit `files` and
 `exports` lists in `package.json`.
 
+## Authoring an asset is a different task from changing the engine
+
+This guide covers changing the engine. Authoring an asset does not happen here: it happens in a
+separate workspace, because the authoring skills assume a live `kiln_workspace` server, and giving a
+model this implementation and the example collection alongside an asset brief changes what it
+produces.
+
+If the request is to make or refine an asset, read the `kiln-setup-workspace` skill and create a
+workspace first. It is registered for a bare clone at `.claude/skills/` and `.agents/skills/`, and
+the maintained copy is `skills/kiln-setup-workspace/`. Everything else in this file assumes you are
+working on the engine itself.
+
 ## The tool registry is the single source of truth
 
 `src/tools/registry.ts` owns tool names, descriptions, and schemas. Two skins consume it: the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Kiln
+
+`AGENTS.md` is the maintained agent guide for this repository. It is imported below rather than duplicated, so there is one source of truth for every harness.
+
+@AGENTS.md

--- a/dist/agent-run.mjs
+++ b/dist/agent-run.mjs
@@ -16,6 +16,928 @@ var __export = (target, all) => {
 var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
 var __require = /* @__PURE__ */ createRequire(import.meta.url);
 
+// src/geometry-catalog.ts
+var geometryPrimitives;
+var init_geometry_catalog = __esm(() => {
+  geometryPrimitives = [
+    {
+      name: "copyGeometry",
+      signature: "copyGeometry(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "instancing",
+      description: "Returns an independent geometry with copied vertex buffers. Use before direct mutation of a cached primitive.",
+      example: "const editable = copyGeometry(boxGeo(1, 1, 1)); editable.translate(0, 0.5, 0);"
+    },
+    {
+      name: "copyMaterial",
+      signature: "copyMaterial(material: Material)",
+      returns: "THREE.Material (same subtype)",
+      category: "instancing",
+      description: "Copies material properties so edits do not change other parts. Referenced textures remain shared.",
+      example: "const red = copyMaterial(steel); red.color.set(0xaa2222);"
+    },
+    {
+      name: "meshGeo",
+      signature: "meshGeo({ positions: number[], indices?: number[], normals?: number[], uvs?: number[], tangents?: number[] })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Builds an owned triangle mesh from flat numeric arrays. Validates finite values, attribute lengths and indices; computes normals if absent. Counterclockwise winding.",
+      example: "const triangle = meshGeo({ positions: [0,0,0, 1,0,0, 0,1,0], indices: [0,1,2] });"
+    },
+    {
+      name: "parametricSurface",
+      signature: "parametricSurface(sample: (u,v) => [x,y,z], opts?: { u?: [0,1], v?: [0,1], uSegments?: 24, vSegments?: 24, periodicU?: false, periodicV?: false, orientation?: 'uv'|'vu' })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Samples an equation into an owned surface with UVs. Periodic endpoints must coincide; UV seams retain matching normals. A surface is not automatically a watertight solid.",
+      example: "const canopy = parametricSurface((u,v) => [u, 0.3*Math.sin(u*3)*Math.cos(v*2), v], { u: [-2,2], v: [-1,1] });"
+    },
+    {
+      name: "geometryDiagnostics",
+      signature: "geometryDiagnostics(geometry: BufferGeometry, tolerance?: 1e-6)",
+      returns: "{ vertices, triangles, boundaryEdges, nonManifoldEdges, orientationConflicts, degenerateTriangles, invalidIndices, nonFiniteVertices }",
+      category: "utility",
+      description: "Counts mesh topology problems after position-based seam matching. Open boundaries are valid for sheets; closed edges alone do not prove a self-intersection-free solid.",
+      example: "const topology = geometryDiagnostics(shell);"
+    },
+    {
+      name: "creaseNormals",
+      signature: "creaseNormals(geometry: BufferGeometry, opts?: { angle?: 60, tolerance?: number })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Returns owned geometry with angle-limited smooth normals, preserving UV corners. Angle is degrees. Invalidates tangents; use after shaping for sharp rims and smooth walls.",
+      example: "const shell = creaseNormals(cylinderGeo(1,1,2,32), { angle: 45 });"
+    },
+    {
+      name: "bend",
+      signature: "bend(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Bends local +Y toward +X through angle degrees. Returns owned geometry and updated normals/bounds; preserves UVs, invalidates tangents. Frame rotation is Euler XYZ degrees.",
+      promptNotes: "Deformation interval uses local Y distances; outside vertices stay unchanged. Add enough segments before bending. Falloff returns 0..1; use it to avoid a discontinuity at a selected interval boundary.",
+      example: "const arch = bend(planeGeo(1,4,4,32), { angle: 90 });"
+    },
+    {
+      name: "twist",
+      signature: "twist(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Rotates the cross-section progressively around local +Y, reaching angle degrees at the end. Returns owned geometry; frame rotation uses Euler XYZ degrees.",
+      example: "const spiral = twist(column, { angle: 120 });"
+    },
+    {
+      name: "taper",
+      signature: "taper(geometry, { startScale?: [1,1], endScale: [x,z], frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Scales local X/Z across the local Y interval using positive start/end scale pairs. Returns owned geometry; preserves UVs and invalidates tangents.",
+      example: "const narrowed = taper(column, { endScale: [0.4,0.7] });"
+    },
+    {
+      name: "displace",
+      signature: "displace(geometry, offset: ([x,y,z], t) => [dx,dy,dz], opts?: { frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Adds an authored displacement vector in the chosen local frame. Returns owned geometry; callback coordinates are local and t is normalized along the interval.",
+      example: "const rippled = displace(surface, ([x,y,z]) => [0, 0.1*Math.sin(x*8), 0]);"
+    },
+    {
+      name: "sweepProfile",
+      signature: "sweepProfile(profile: [x,z][], path: [x,y,z][], opts?: { cap?: true, closed?: false, up?: [x,y,z], twist?: 0, scale?: number | [x,z][] })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Sweeps a simple noncircular profile along polyline stations using transported frames. Supports total twist in degrees and per-station scales. Generates UVs and optional caps.",
+      promptNotes: "First version supports one simple profile without holes. Closed paths omit the repeated endpoint and require twist to be a multiple of 360. up sets the initial profile +Z direction and cannot parallel the path. Tight-turn warnings do not replace visual inspection for self-intersections.",
+      example: "const rail = sweepProfile([[-.1,-.2],[.1,-.2],[.1,.2],[-.1,.2]], [[0,0,0],[0,1,0],[1,2,0]]);"
+    },
+    {
+      name: "loftProfiles",
+      signature: "loftProfiles(sections: { profile: [x,z][], frame?: { origin, rotation } }[], opts?: { cap?: true })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Joins corresponding simple profiles in explicit local XZ planes. Each frame uses Euler XYZ degrees and local +Y along the loft. Profiles need equal point counts and corresponding vertices.",
+      promptNotes: "No holes or automatic profile correspondence. Opposite winding is normalized while preserving the first point. Caps close boundaries but do not prove the loft has no self-intersections.",
+      example: "const hull = loftProfiles([{ profile: wide }, { profile: narrow, frame: { origin: [0,2,0] } }]);"
+    },
+    {
+      name: "implicitSurface",
+      signature: "await implicitSurface(sample: ([x,y,z]) => signedValue, { bounds: { min, max }, edgeLength, maxCells?: 1000000, maxEvaluations?: 8000000, level?: 0, tolerance?: -1, smooth?: true })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "geometry",
+      description: "Experimental positive-inside implicit field sampled into a solid mesh. Requires explicit bounds and resolution; checks grid size and actual evaluation count. Output has no UVs.",
+      promptNotes: "Use async build and await. Smaller edgeLength increases cost sharply. This helper cannot stop a callback that never returns; the host evaluator process provides that boundary. Thin features and geometric accuracy require inspection.",
+      example: "const blob = await implicitSurface(([x,y,z]) => 1-Math.hypot(x,y,z), { bounds: { min: [-1.2,-1.2,-1.2], max: [1.2,1.2,1.2] }, edgeLength: 0.15 });"
+    }
+  ];
+});
+
+// src/list-primitives.ts
+function listPrimitives() {
+  return PRIMITIVES.map((p) => ({ ...p }));
+}
+var PRIMITIVES;
+var init_list_primitives = __esm(() => {
+  init_geometry_catalog();
+  PRIMITIVES = [
+    ...geometryPrimitives,
+    {
+      name: "createRoot",
+      signature: "createRoot(name: string)",
+      returns: "THREE.Object3D",
+      category: "structure",
+      description: "Creates the root Object3D for an asset. Call first in build().",
+      example: "const root = createRoot('FuelDrum');"
+    },
+    {
+      name: "createPivot",
+      signature: "createPivot(name: string, position?: [x, y, z], parent?: Object3D)",
+      returns: "THREE.Object3D (prefixed `Joint_`)",
+      category: "structure",
+      description: "Creates an empty pivot node for skeletal animation. Name is auto-prefixed with `Joint_`.",
+      example: "const hip = createPivot('Hip', [0, 1, 0], root);"
+    },
+    {
+      name: "createJointChain",
+      signature: "createJointChain(name, segments: { role, offset, aliases?, side?, localForwardAxis?, localBendAxis?, endEffector?, contact? }[], opts?: { parent?, parentRole? })",
+      returns: "{ root, end, nodes, byRole, descriptors }",
+      category: "structure",
+      description: "Creates one body-plan-neutral deterministic Joint_* chain with explicit parent edges, rest frames, local axes, end effectors, contacts, and semantic metadata.",
+      example: "const leg = createJointChain('LegL', [{ role: 'hip.left', offset: [0, 1, -0.2], side: 'left' }, { role: 'knee.left', offset: [0, -0.5, 0], side: 'left' }, { role: 'ankle.left', offset: [0, -0.5, 0], side: 'left', endEffector: true, contact: true }], { parent: root });",
+      promptNotes: "Use only the resolved body-plan graph. Offsets are local to the previous joint; contact end effectors must land at world Y=0."
+    },
+    {
+      name: "createVehicleFrame",
+      signature: "createVehicleFrame(name, opts?: { chassis?, axles?, seats?, contacts?, steering?, propulsion?, parent? })",
+      returns: "{ root, chassis, axles, seats, contacts, steering, propulsion }",
+      category: "structure",
+      description: "Creates a canonical +X-forward/+Y-up/+Z-right vehicle frame with typed semantic sockets for chassis, support, steering, and propulsion.",
+      example: "const frame = createVehicleFrame('CarFrame', { axles: [{ id: 'front', position: [1.2, 0.45, 0] }, { id: 'rear', position: [-1.2, 0.45, 0] }], parent: root });",
+      promptNotes: "Generated vehicles keep +X as front. Boats and other non-wheeled subtypes use declared support/propulsion sockets, not wheel rules."
+    },
+    {
+      name: "createWheelGeometrySet",
+      signature: "createWheelGeometrySet(radius: number, width: number)",
+      returns: "{ tire, rim, hub } shared THREE.BufferGeometry set",
+      category: "instancing",
+      description: "Creates one reusable +Z-axle tire/rim/hub geometry set for instanced wheel assemblies.",
+      example: "const wheelGeo = createWheelGeometrySet(0.45, 0.22);"
+    },
+    {
+      name: "createWheelAssembly",
+      signature: "createWheelAssembly(name, { tire, rim, hub? }, { radius, width, side, index, position?, rimRadius?, hubRadius?, steering?, loadBearing?, geometries?, parent? })",
+      returns: "{ root, steeringPivot?, spinPivot, tire, rim, hub, contact, radius, width, side, index, spinAxis }",
+      category: "structure",
+      description: "Creates one axle-centered wheel pivot containing concentric tire/rim/hub roles, a contact marker, +Z spin frame, and optional steering pivot.",
+      example: "createWheelAssembly('FrontLeft', { tire: rubber, rim: metal }, { radius: 0.45, width: 0.22, side: 'left', index: 'front', position: [1.2, 0.45, -0.9], steering: true, geometries: wheelGeo, parent: frame.root });",
+      promptNotes: "Keep tire, rim, and hub descendants concentric at the axle pivot. Reuse one geometry set across matching wheels."
+    },
+    {
+      name: "createPart",
+      signature: "createPart(name, geometry, material, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, pivot, parent })",
+      returns: "THREE.Object3D (mesh or wrapping pivot)",
+      category: "structure",
+      description: "Creates a mesh, optionally wrapped in a pivot, and attaches it to `opts.parent`. `rotation` is in DEGREES (like rotationTrack), NOT radians: [0, 0, 90] is a quarter turn; [0, 0, 1.57] is a no-op.",
+      example: "createPart('Barrel', cylinderGeo(0.1, 0.1, 1), gameMaterial(0x556b2f), { position: [0, 0.5, 0], rotation: [0, 0, 90], parent: root });",
+      promptNotes: "AUTO-ADDS to opts.parent. NEVER call parent.add(createPart(...)) — pass { parent } instead. rotation is DEGREES — writing radians (e.g. 0.785 or Math.PI/4) silently produces ~zero rotation."
+    },
+    {
+      name: "beamBetween",
+      signature: "beamBetween(name, start: [x,y,z], end: [x,y,z], radius, material, opts?: { segments, parent })",
+      returns: "THREE.Object3D (prefixed `Mesh_`)",
+      category: "structure",
+      description: "Creates a cylindrical rail/strut exactly between two endpoints. Use for braces, gun barrels, skid struts, cables, and scaffolding.",
+      example: "beamBetween('SkidBraceA', [0.8, 0.3, 0.7], [0.8, 1.0, 0.45], 0.025, black, { parent: root });"
+    },
+    {
+      name: "snapTo",
+      signature: "snapTo(part: Object3D, host: Object3D, opts?: { axis?: 'x'|'y'|'z', overlap?: 0.02 })",
+      returns: "THREE.Object3D (the part, for chaining)",
+      category: "structure",
+      description: 'Translates `part` by the minimal vector that brings its bounding box into contact with `host` (plus a small overlap). The direct cure for a "Floating parts" warning — attach the part instead of eyeballing a corrective offset. No-op if they already touch.',
+      example: `const scope = createPart('Scope', cylinderXGeo(0.04, 0.04, 0.3), steel, { parent: root, position: [0.1, 0.32, 0] });
+snapTo(scope, receiver);`
+    },
+    {
+      name: "createLadder",
+      signature: "createLadder(name, { bottom, top, material, width?, rungCount?, railRadius?, rungRadius?, widthAxis?, parent? })",
+      returns: "{ leftRail: Object3D, rightRail: Object3D, rungs: Object3D[] }",
+      category: "structure",
+      description: "Builds two continuous rails plus evenly-spaced rungs. Use this instead of loose boxes for ladders.",
+      example: "createLadder('TowerLadder', { bottom: [0,0,0], top: [0,2.2,0], width: 0.45, rungCount: 7, material: steel, parent: root });"
+    },
+    {
+      name: "createWingPair",
+      signature: "createWingPair(name, material, { rootZ, span, rootChord, tipChord, sweep?, thickness?, dihedral?, rootX?, rootY?, parent? })",
+      returns: "{ right: Object3D, left: Object3D }",
+      category: "structure",
+      description: "Creates mirrored trapezoid aircraft wings with roots attached at +/-rootZ. Use for aircraft wings and helicopter stub wings.",
+      example: "createWingPair('MainWing', olive, { rootX: 0, rootY: 1.0, rootZ: 0.42, span: 2.4, rootChord: 0.9, tipChord: 0.35, sweep: 0.25, dihedral: 0.08, parent: root });"
+    },
+    {
+      name: "room",
+      signature: "room(name, material, { width?, depth?, height?, wallThickness?, floor?, floorThickness?, openings?: [{ wall: 'front'|'back'|'left'|'right', kind?: 'door'|'window', offset?, width?, height?, sill? }], parent? })",
+      returns: "{ root: Object3D, walls: { front, back, left, right }, floor: Object3D | null }",
+      category: "structure",
+      description: "Builds a HOLLOW, enterable room: four thin walls + a floor, human-scaled (defaults: 2.8m ceiling, a centered 1.1x2.1m front door so it is enterable by default). `front` faces +X; the floor sits on the ground. The keystone of an architecture asset — add a roof with createRoofPlanes and fixtures as separate parts.",
+      example: "const { root: hut } = room('Hut', wood, { width: 5, depth: 4, height: 2.8, openings: [{ wall: 'front', kind: 'door' }, { wall: 'right', kind: 'window' }], parent: root });",
+      promptNotes: "Use for any building the player enters. Do NOT model a building as a solid block — room() guarantees real interior space and a doorway gap. Pass openings to add windows / side doors."
+    },
+    {
+      name: "wallWithOpening",
+      signature: "wallWithOpening(name, material, { length, height, thickness, axis?: 'x'|'z', opening?: { kind?: 'door'|'window', offset?, width?, height?, sill? }, parent? })",
+      returns: "THREE.Object3D (wall container)",
+      category: "structure",
+      description: "A single wall panel with an optional real door/window cut, composed from solid box segments (side panels + lintel + window sill) — no CSG. Base at local Y=0, centered on the run axis. Use to compose custom building layouts or interior dividing walls beyond the default room().",
+      example: "wallWithOpening('Partition', plaster, { length: 4, height: 2.8, thickness: 0.12, axis: 'x', opening: { kind: 'door', offset: 0.5 }, parent: root });"
+    },
+    {
+      name: "createRoofPlanes",
+      signature: "createRoofPlanes(name, material, { width, depth, height, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
+      returns: "{ root: Object3D, slopes: [Object3D, Object3D] }",
+      category: "structure",
+      description: "A pitched roof: two thin slopes meeting at one ridge and falling DOWN-AND-OUTWARD (opposite tilts — never mirrored the same way), footprint-matched with an eave overhang. Eave at local Y=0, ridge at Y=height, so position the group at Y=wallHeight. Returns a named group (e.g. `Roof`) the engine can lift to reveal the interior.",
+      example: `const { root: roof } = createRoofPlanes('Roof', shingle, { width: 5, depth: 4, height: 1.6, overhang: 0.4, ridgeAxis: 'x', parent: root });
+roof.position.y = 2.8;`,
+      promptNotes: "The two slopes must fall AWAY from each other from the ridge — createRoofPlanes does this for you. Drop it onto the walls (position.y = wall height)."
+    },
+    {
+      name: "createGableRoof",
+      signature: "createGableRoof(name, material, { spanX, spanZ, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
+      returns: "{ root, slopes: [Object3D, Object3D], faces: [RoofFaceFrame, RoofFaceFrame], rise, pitchDegrees }",
+      category: "structure",
+      description: "Explicit-axis gable roof using unambiguous footprint spans. Each face owns a rigid frame with ridge tangent, outward normal, downhill direction, ridge/eave endpoints, dimensions, and a live local-to-world transform.",
+      example: "const roof = createGableRoof('Roof', shingles, { spanX: 8, spanZ: 5, pitchDegrees: 35, overhang: 0.35, ridgeAxis: 'x', parent: root });",
+      promptNotes: "Prefer this over width/depth roof math. ridgeAxis is the direction of the ridge; roof panels run along each returned face downhill direction."
+    },
+    {
+      name: "createGableEndPanel",
+      signature: "createGableEndPanel(name, material, { span, rise, thickness?, ridgeAxis?: 'x'|'z', side?: 'positive'|'negative', openings?: [{ id?, offset?, bottom?, width, height }], parent? })",
+      returns: "{ root, geometry, openings }",
+      category: "structure",
+      description: "Exact thick triangular end closure for a gable roof, with optional rectangular openings cut from the geometry and semantic boundary metadata.",
+      example: "createGableEndPanel('FrontGable', siding, { span: 5, rise: 1.8, ridgeAxis: 'x', side: 'positive', parent: root });"
+    },
+    {
+      name: "createGableShell",
+      signature: "createGableShell(name, { wall, roof, floor?, gable? }, { spanX, spanZ, wallHeight?, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, wallThickness?, floorThickness?, closedEnds?, enterable?, openings?, gableOpenings?, parent? })",
+      returns: "{ root, walls, floor, roof, gables, openings }",
+      category: "structure",
+      description: "Closed-by-default, correct-by-construction gable building: hollow room, floor, two opposing roof slopes, two complete gable ends, and a real front doorway when enterable.",
+      example: "const house = createGableShell('House', { wall: plaster, roof: shingles }, { spanX: 8, spanZ: 5, wallHeight: 2.8, pitchDegrees: 35, ridgeAxis: 'x', parent: root });",
+      promptNotes: "Use for complete gable buildings. It stamps wall, floor, slope, gable, opening, adjacency, coverage, and separability semantics for deterministic QA and roof-off views."
+    },
+    {
+      name: "createRoofSurfaceLayout",
+      signature: "createRoofSurfaceLayout(name, material, { face, kind: 'panels'|'shingles'|'seams'|'corrugations', parent?, panelWidth?, rowHeight?, spacing?, thickness? })",
+      returns: "{ root, items: Object3D[] }",
+      category: "structure",
+      description: "Places roof-local panels, shingles, seams, or corrugations from a returned RoofFaceFrame, so repeated elements run ridge-to-eave for either ridge axis without manual Euler rotations.",
+      example: "for (const face of roof.faces) createRoofSurfaceLayout('Panels_' + face.side, metal, { face, kind: 'panels', parent: roof.root });",
+      promptNotes: "Always pass the face object returned by createGableRoof/createGableShell. Never infer the panel rotation from world axes."
+    },
+    {
+      name: "createStairs",
+      signature: "createStairs(name, material, { steps?, totalRise, totalRun, width, axis?: 'x'|'z', treadThickness?, riser?, parent? })",
+      returns: "{ root: Object3D, steps: Object3D[] }",
+      category: "structure",
+      description: "A straight flight of stairs: box treads (with optional risers) climbing totalRise over totalRun from local origin toward +axis. Use for porch/entry steps or to connect storeys in a multi-storey building.",
+      example: "createStairs('Porch', stone, { steps: 4, totalRise: 0.6, totalRun: 1.0, width: 1.4, axis: 'x', parent: root });"
+    },
+    {
+      name: "boxGeo",
+      signature: "boxGeo(width: number, height: number, depth: number)",
+      returns: "THREE.BoxGeometry",
+      category: "geometry",
+      description: "6-face box. 12 tris regardless of size. Cheapest geometry.",
+      example: "const geo = boxGeo(1, 0.5, 2);"
+    },
+    {
+      name: "sphereGeo",
+      signature: "sphereGeo(radius: number, widthSegments?: 8, heightSegments?: 6)",
+      returns: "THREE.SphereGeometry",
+      category: "geometry",
+      description: "UV sphere. Default 8x6 segments = 84 tris. Bump segments for smoother curves.",
+      example: "const geo = sphereGeo(0.5, 12, 8);"
+    },
+    {
+      name: "cylinderGeo",
+      signature: "cylinderGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Y-axis cylinder. Use radiusTop != radiusBottom for cones / tapered pieces.",
+      example: "const geo = cylinderGeo(0.25, 0.25, 1, 12);"
+    },
+    {
+      name: "cylinderYGeo",
+      signature: "cylinderYGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Alias for cylinderGeo — a Y-axis cylinder. Provided because the sandbox exposes cylinderXGeo / cylinderZGeo and the symmetric Y form is commonly reached for.",
+      example: "const geo = cylinderYGeo(0.25, 0.25, 1, 12);"
+    },
+    {
+      name: "cylinderXGeo",
+      signature: "cylinderXGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Cylinder pre-rotated to run along +X/-X. Use for fuselages, cannons, barrels, axles, and forward-facing tubes.",
+      example: "const geo = cylinderXGeo(0.1, 0.1, 1.2, 12);"
+    },
+    {
+      name: "cylinderZGeo",
+      signature: "cylinderZGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Cylinder pre-rotated to run along +Z/-Z. Use for side-mounted weapons, rails, crossbars, and pipes.",
+      example: "const geo = cylinderZGeo(0.08, 0.08, 0.9, 10);"
+    },
+    {
+      name: "cylinderOnAxis",
+      signature: "cylinderOnAxis(center: [x,y,z], normal: [x,y,z], radiusBottom: number, height: number, opts?: { radiusTop?, segments? })",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Frame-first cylinder: position + axis specified directly, no post-hoc rotation. Use when the cylinder needs to point along a non-cardinal direction (struts inside CSG operands, antennas off a tilted surface). For cardinal axes prefer the terser cylinderXGeo / cylinderYGeo / cylinderZGeo helpers.",
+      example: "const strut = cylinderOnAxis([0.5, 0.7, 0], [1, 1, 0.3], 0.05, 0.9);"
+    },
+    {
+      name: "capsuleGeo",
+      signature: "capsuleGeo(radius: number, height: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Stadium shape (cylinder with hemispherical caps). Good for limbs.",
+      example: "const geo = capsuleGeo(0.1, 0.5, 6);"
+    },
+    {
+      name: "capsuleYGeo",
+      signature: "capsuleYGeo(radius: number, height: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Alias for capsuleGeo — a Y-axis capsule. Provided for symmetry with capsuleXGeo / capsuleZGeo.",
+      example: "const geo = capsuleYGeo(0.1, 0.5, 6);"
+    },
+    {
+      name: "capsuleXGeo",
+      signature: "capsuleXGeo(radius: number, length: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Capsule pre-rotated to run along +X/-X. Use for aircraft bodies, rounded vehicle hulls, and missiles.",
+      example: "const geo = capsuleXGeo(0.35, 2.4, 10);"
+    },
+    {
+      name: "capsuleZGeo",
+      signature: "capsuleZGeo(radius: number, length: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Capsule pre-rotated to run along +Z/-Z. Use for lateral pods, floats, and side tanks.",
+      example: "const geo = capsuleZGeo(0.18, 1.1, 8);"
+    },
+    {
+      name: "coneGeo",
+      signature: "coneGeo(radius: number, height: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Y-axis cone (pointed up). Use for spikes, roofs, projectiles.",
+      example: "const geo = coneGeo(0.3, 0.8, 8);"
+    },
+    {
+      name: "coneYGeo",
+      signature: "coneYGeo(radius: number, height: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Alias for coneGeo — a Y-axis cone (point +Y). Provided for symmetry with coneXGeo / coneZGeo.",
+      example: "const geo = coneYGeo(0.3, 0.8, 8);"
+    },
+    {
+      name: "coneXGeo",
+      signature: "coneXGeo(radius: number, length: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Cone pre-rotated so its point faces +X. Use for noses, rockets, shells, and forward-facing tips.",
+      example: "const geo = coneXGeo(0.18, 0.45, 12);"
+    },
+    {
+      name: "coneZGeo",
+      signature: "coneZGeo(radius: number, length: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Cone pre-rotated so its point faces +Z. Use for side-facing projectiles and tips.",
+      example: "const geo = coneZGeo(0.12, 0.35, 10);"
+    },
+    {
+      name: "taperConeGeo",
+      signature: "taperConeGeo(radiusBottom: number, radiusTop: number, height: number, axis?: 'x'|'y'|'z', segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Truncated cone (frustum) — exposes both bottom and top radius. radiusTop=0 matches coneGeo, radiusTop=radiusBottom matches cylinderGeo. Use for pylon caps, soda cans, lampshades, anything tapered that does not come to a point. axis selects orientation (default Y).",
+      example: "const cap = taperConeGeo(0.3, 0.18, 0.4);  // frustum"
+    },
+    {
+      name: "torusGeo",
+      signature: "torusGeo(radius: number, tube: number, radialSegments?: 8, tubularSegments?: 12)",
+      returns: "THREE.TorusGeometry",
+      category: "geometry",
+      description: "Donut shape. For rings, tyres, barrel ribs.",
+      example: "const geo = torusGeo(0.4, 0.04, 8, 16);"
+    },
+    {
+      name: "planeGeo",
+      signature: "planeGeo(width: number, height: number, widthSegments?: 1, heightSegments?: 1)",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Flat quad for TEXTURED surfaces (ground, signs, walls with albedo maps). For solid-color decals like red stars, hull numbers, stamps, or window cutouts on no-texture assets use decalBox — a bare planeGeo without a texture will render as a disconnected 2-tri square and get flagged as a stray plane.",
+      example: "const geo = planeGeo(4, 4);"
+    },
+    {
+      name: "decalBox",
+      signature: "decalBox(width: number, height: number, depth?: 0.01)",
+      returns: "THREE.BoxGeometry",
+      category: "geometry",
+      description: "Thin box for solid-color surface decals: red stars, hull numbers, stamps, no-texture windows. Unlike planeGeo, has real depth so it visibly attaches to its host surface. Must be placed on a surface with position + rotation.",
+      example: `const star = decalBox(0.18, 0.18, 0.01);
+createPart('Mesh_StarPort', star, gameMaterial(0xc61f2a), { position: [0.4, 0.6, 0.41], parent: fuselage });`,
+      promptNotes: "Offset at least 0.01 outside the host surface to avoid z-fighting (a 0.8-wide hull has faces at z=±0.4, so place the decal at z=±0.41)."
+    },
+    {
+      name: "foliageCardGeo",
+      signature: "foliageCardGeo(opts?: { width?, height?, yPivot?: 0..1 })",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Single-quad foliage card with a configurable Y pivot. yPivot=0 plants the quad on the ground. Pair with an alpha-tested material and a leaf/plant sprite.",
+      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
+const quad = foliageCardGeo({ width: 4, height: 6, yPivot: 0 });
+createPart('Mesh_Fern', quad, leaves, { parent: root });`
+    },
+    {
+      name: "crossedQuadsGeo",
+      signature: "crossedQuadsGeo(opts?: { width?, height?, planes?: 2 | 3, yPivot? })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Cross-billboard bush primitive: 2 or 3 planes intersecting along the Y axis. Reads as a dense plant from any angle, cheaper than real geometry.",
+      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
+const bush = crossedQuadsGeo({ width: 2, height: 2, planes: 3 });
+createPart('Mesh_Bush', bush, leaves, { parent: root });`
+    },
+    {
+      name: "octaGridPlane",
+      signature: "octaGridPlane({ tilesX, tilesY, width?, height?, yPivot? })",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Atlas-ready billboard quad. UVs are pre-scaled to cover one tile of a tilesX×tilesY atlas; the consumer shader adds per-instance tile offsets at draw time.",
+      example: "const card = octaGridPlane({ tilesX: 4, tilesY: 4, width: 6, height: 6 });"
+    },
+    {
+      name: "wingGeo",
+      signature: "wingGeo(opts?: { span, rootChord, tipChord, sweep, thickness, dihedral })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Trapezoid wing panel. Local root edge is at Z=0, span extends toward +Z, positive sweep moves the tip aft along -X.",
+      example: "const geo = wingGeo({ span: 2.2, rootChord: 0.8, tipChord: 0.3, sweep: 0.25, dihedral: 0.08 });"
+    },
+    {
+      name: "gearGeo",
+      signature: "gearGeo(opts?: { teeth?: 12, rootRadius?: 0.8, tipRadius?: 1.0, boreRadius?: 0.2, height?: 0.3, toothWidthFrac?: 0.5 })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Stylized gear with flat edges and an optional center bore; no CSG. Use boreRadius < rootRadius < tipRadius. Radii are absolute: an omitted rootRadius stays 0.8 when tipRadius changes. Set all three radii for small gears.",
+      example: `const g = gearGeo({ teeth: 28, rootRadius: 0.063, tipRadius: 0.075, boreRadius: 0.012, height: 0.024 });
+createPart('Gear', g, gameMaterial(0x909090, { metalness: 0.8 }), { parent: root });`
+    },
+    {
+      name: "bladeGeo",
+      signature: "bladeGeo(opts?: { length?: 1.5, baseWidth?: 0.1, thickness?: 0.015, tipLength?: 0.25, edgeBevel?: 0 })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Parametric sword blade: rectangular base tapering to a point over tipLength. edgeBevel > 0 pinches the cross-section toward a diamond ridge.",
+      example: `const b = bladeGeo({ length: 1.6, baseWidth: 0.09, tipLength: 0.3, edgeBevel: 0.5 });
+createPart('Blade', b, steel, { position: [0, 0, 0], parent: root });`
+    },
+    {
+      name: "gameMaterial",
+      signature: "gameMaterial(color, opts?: { metalness, roughness, emissive, emissiveIntensity, flatShading })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Flat-shaded PBR material. Default for game-ready low-poly. Use for 95% of parts.",
+      example: "const mat = gameMaterial(0x8b7355, { roughness: 0.9 });"
+    },
+    {
+      name: "materialRecipe",
+      signature: "await materialRecipe(recipeId, overrides?: { baseColor?, roughness?, metalness?, opacity?, alphaCutoff?, doubleSided?, emissiveColor?, emissiveIntensity?, textureResources? })",
+      returns: "Promise<THREE.MeshStandardMaterial>",
+      category: "material",
+      description: "Resolves a versioned portable bark/leaf/wood/stone/rubber/painted-metal/cloth/skin/glass/emissive recipe to standard glTF PBR.",
+      example: "const bark = await materialRecipe('kiln.material.bark.v1', { baseColor: '#6b4328' });",
+      promptNotes: "Use only listed kiln.material.*.v1 IDs and approved kiln.texture.* resource IDs. Leaf is MASK, glass is BLEND, and host file paths are forbidden."
+    },
+    {
+      name: "compilePortableMaterialSpecV2",
+      signature: "await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', name?, baseColor?, roughness?, metalness?, emissive?, emissiveIntensity?, alphaMode?, alphaCutoff?, doubleSided?, textures?: { baseColor?, normal?, metallicRoughness?, emissive?, occlusion? } })",
+      returns: "Promise<THREE.MeshStandardMaterial>",
+      category: "material",
+      description: "Compiles the strict portable material contract. Texture refs are either typed procedural V2 specs or closed approved kiln.texture.* IDs; paths, URLs, raw textures, callbacks, and shader source are rejected.",
+      example: "const steel = await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', roughness: 0.45, metalness: 0.85, textures: { metallicRoughness: { kind: 'procedural', spec: { schemaVersion: 2, usage: 'metallicRoughness', size: 64, layers: [{ op: 'solid', color: 0x0080cc }] } } } });",
+      promptNotes: "Use metallicRoughness as one packed G=roughness/B=metalness map. Every procedural ref usage must match its slot; resource refs must be approved for that exact slot."
+    },
+    {
+      name: "basicMaterial",
+      signature: "basicMaterial(color, opts?: { transparent, opacity })",
+      returns: "THREE.MeshBasicMaterial",
+      category: "material",
+      description: "Unlit flat material. For UI / effects where lighting is baked in.",
+      example: "const mat = basicMaterial(0xffffff, { transparent: true, opacity: 0.5 });"
+    },
+    {
+      name: "glassMaterial",
+      signature: "glassMaterial(color, opts?: { opacity, roughness, metalness })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Semi-transparent double-sided material. Panels need ~0.05 offset to avoid z-fighting.",
+      example: "const mat = glassMaterial(0x66ccff, { opacity: 0.3 });"
+    },
+    {
+      name: "lambertMaterial",
+      signature: "lambertMaterial(color, opts?: { flatShading, emissive })",
+      returns: "THREE.MeshLambertMaterial",
+      category: "material",
+      description: "Cheaper than gameMaterial. No metalness/roughness. Use when PBR is overkill.",
+      example: "const mat = lambertMaterial(0x2a4d14, { flatShading: true });"
+    },
+    {
+      name: "rotationTrack",
+      signature: "rotationTrack(jointName: string, keyframes: Array<{ time, rotation: [xDeg, yDeg, zDeg] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.QuaternionKeyframeTrack",
+      category: "animation",
+      description: "Rotation track in degrees, auto-converted to quaternions. Joint name must include `Joint_` prefix.",
+      example: "rotationTrack('Joint_Lid', [{ time: 0, rotation: [0, 0, 0] }, { time: 1, rotation: [90, 0, 0] }]);"
+    },
+    {
+      name: "positionTrack",
+      signature: "positionTrack(jointName: string, keyframes: Array<{ time, position: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.VectorKeyframeTrack",
+      category: "animation",
+      description: "Position track in world units. Always use `position:` not `value:` in keyframes.",
+      example: "positionTrack('Joint_Body', [{ time: 0, position: [0, 0, 0] }, { time: 1, position: [0, 0.1, 0] }]);"
+    },
+    {
+      name: "scaleTrack",
+      signature: "scaleTrack(jointName: string, keyframes: Array<{ time, scale: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.VectorKeyframeTrack",
+      category: "animation",
+      description: "Uniform or per-axis scale track.",
+      example: "scaleTrack('Joint_Chest', [{ time: 0, scale: [1, 1, 1] }, { time: 1, scale: [1.1, 1.1, 1.1] }]);"
+    },
+    {
+      name: "createClip",
+      signature: "createClip(name: string, duration: number, tracks: KeyframeTrack[])",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Collects tracks into a named clip. Returned from animate().",
+      example: "return [createClip('Open', 1, [rotationTrack('Joint_Lid', [...])])];"
+    },
+    {
+      name: "idleBreathing",
+      signature: "idleBreathing(bodyJoint: string, duration?: 2, amount?: 0.02)",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Gentle Y-axis bob. For NPC idle states.",
+      example: "return [idleBreathing('Joint_Body')];"
+    },
+    {
+      name: "bobbingAnimation",
+      signature: "bobbingAnimation(rootName: string, duration?: 2, height?: 0.1)",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Floating / bobbing loop for pickups and effects.",
+      example: "return [bobbingAnimation('Joint_Root', 1.5, 0.08)];"
+    },
+    {
+      name: "spinAnimation",
+      signature: "spinAnimation(jointName: string, duration?: 2, axis?: 'x' | 'y' | 'z')",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "360° rotation over `duration` around `axis`.",
+      example: "return [spinAnimation('Joint_Rotor', 0.5, 'y')];"
+    },
+    {
+      name: "cloneGeometry",
+      signature: "cloneGeometry(geo: BufferGeometry)",
+      returns: "THREE.BufferGeometry (same ref)",
+      category: "instancing",
+      description: "Deprecated name: returns the SAME geometry, without copying. Use copyGeometry for independent vertex edits, or pass the original geometry directly for intentional sharing.",
+      example: "const wheelGeo = cylinderGeo(0.4, 0.4, 0.2, 12);"
+    },
+    {
+      name: "cloneMaterial",
+      signature: "cloneMaterial(mat: Material)",
+      returns: "THREE.Material (same ref)",
+      category: "instancing",
+      description: "Deprecated name: returns the SAME material. Use copyMaterial for independent property edits, or pass the original for intentional sharing.",
+      example: "const rubberMat = gameMaterial(0x1a1a1a, { roughness: 0.95 });"
+    },
+    {
+      name: "createInstance",
+      signature: "createInstance(name, source, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, parent })",
+      returns: "THREE.Object3D",
+      category: "instancing",
+      description: "Creates a new mesh reusing an existing part's geometry + material at a new transform. Cheapest way to replicate wheels / bolts / fence posts / windows. `rotation` is in DEGREES, like createPart.",
+      example: `const wheelFL = createPart('WheelFL', wheelGeo, rubberMat, { position: [-0.8, 0.3, 1.2], parent: root });
+createInstance('WheelFR', wheelFL, { position: [0.8, 0.3, 1.2], parent: root });
+createInstance('WheelRL', wheelFL, { position: [-0.8, 0.3, -1.2], parent: root });
+createInstance('WheelRR', wheelFL, { position: [0.8, 0.3, -1.2], parent: root });`
+    },
+    {
+      name: "boolUnion",
+      signature: "await boolUnion(name: string, ...parts: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Merges two or more parts into one watertight manifold mesh. Default flat shading (hard edges) — pass { smooth: true } as last arg for averaged normals on organic merges.",
+      example: `const body = new THREE.Mesh(boxGeo(2, 1, 1), steel);
+const turret = new THREE.Mesh(cylinderGeo(0.3, 0.3, 0.4, 16), steel);
+turret.position.y = 0.5;
+const hull = await boolUnion('Hull', body, turret);`
+    },
+    {
+      name: "boolDiff",
+      signature: "await boolDiff(name: string, body: Object3D, ...cutters: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Subtracts cutters from a body (holes, button recesses, window slots). Default flat shading for sharp mechanical edges.",
+      example: `const body = new THREE.Mesh(cylinderGeo(1, 1, 0.3, 32), steel);
+const teeth = [...]; // 8 radially-arrayed box meshes
+const gear = await boolDiff('Gear', body, ...teeth);  // hard-edged`
+    },
+    {
+      name: "roundedBoxGeo",
+      signature: "await roundedBoxGeo(width: number, height: number, depth: number, radius: number, opts?: { style?: 'round' | 'chamfer', segments?: 12, smooth?: boolean })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "A box with all twelve edges rounded (or chamfered) at the EXACT outer size requested — roundedBoxGeo(1, 1, 1, 0.1) measures 1x1x1, it does not grow. Use it anywhere boxGeo reads too sharp: consoles, crates, appliances, handheld props, machined blocks.",
+      promptNotes: "Real objects almost never have perfectly sharp box edges, and a small radius is the single cheapest upgrade to how manufactured an asset looks. Prefer this over boxGeo for anything moulded, cast, or machined. Keep radius small relative to the box (5-10% of the smallest dimension); radius must be less than half the smallest dimension or the call throws. style: 'chamfer' reads as machined metal, 'round' as moulded plastic. This is async — build() must be async and the call must use await.",
+      example: `const geo = await roundedBoxGeo(1.2, 0.6, 0.8, 0.05);
+createPart('Console', geo, plastic, { position: [0, 0.3, 0], parent: root });`
+    },
+    {
+      name: "extrudeProfile",
+      signature: "await extrudeProfile(profile: [number, number][], opts?: { depth?: 1, holes?: [number, number][][], bevel?: 0, bevelStyle?: 'round' | 'chamfer', segments?: 12, twist?: 0, taper?: number | [number, number], divisions?: number, axis?: 'x' | 'y' | 'z', center?: true, smooth?: false })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "Sweeps a closed 2D outline into a watertight solid, with optional holes, corner rounding/chamfering, twist, and taper. The way to build any cross-section that is not a box or a cylinder: L-brackets, I-beams, gaskets, washers, star and gear plates, signage, extruded trim.",
+      promptNotes: "The bevel rounds the edges PARALLEL to the sweep axis (the profile corners) — the two flat caps stay sharp. For a box rounded on all twelve edges use roundedBoxGeo instead. Holes are subtracted, so their winding order does not matter. A bevel larger than half the outline's narrowest feature throws rather than silently returning an empty solid. Output is manifold, so it feeds straight into boolUnion / boolDiff / boolIntersect. Async — await it inside an async build().",
+      example: `// L-bracket, inner AND outer corners filleted
+const outline = [[0, 0], [2, 0], [2, 0.4], [0.4, 0.4], [0.4, 2], [0, 2]];
+const geo = await extrudeProfile(outline, { depth: 0.5, bevel: 0.06 });
+createPart('Bracket', geo, steel, { parent: root });`
+    },
+    {
+      name: "revolveProfile",
+      signature: "await revolveProfile(profile: [number, number][], opts?: { segments?: 24, angle?: 360, bevel?: 0, bevelStyle?: 'round' | 'chamfer', bevelSegments?: 12, axis?: 'x' | 'y' | 'z', smooth?: true })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "Revolves a closed 2D outline around an axis into a watertight SOLID, optionally rounding the profile corners first. Bottles, tanks, pressure vessels, wheels, turned wood, domes, buttons, pills.",
+      promptNotes: "Use this instead of lathe/revolveGeo whenever the result must survive a boolean or needs a rounded rim — lathe and revolveGeo build an open surface, this builds a closed solid. Profile convention matches lathe: x is distance from the axis, y is position along it, and only the x >= 0 side is used. Async — await it inside an async build().",
+      example: `// capsule tank with a rounded rim, then carve a port into it
+const profile = [[0, -0.5], [0.4, -0.5], [0.4, 0.5], [0, 0.5]];
+const body = await revolveProfile(profile, { bevel: 0.08, segments: 32 });
+const tank = await boolDiff('Tank', createPart('B', body, steel), portCutter);`
+    },
+    {
+      name: "circleProfile",
+      signature: "circleProfile(radius: number, segments?: 24, center?: [number, number])",
+      returns: "[number, number][]",
+      category: "csg",
+      description: "Builds a closed circular outline for extrudeProfile / revolveProfile, so you never hand-write the trigonometry. Synchronous.",
+      example: `const washer = await extrudeProfile(circleProfile(1), {
+  depth: 0.1,
+  holes: [circleProfile(0.4), circleProfile(0.1, 16, [0.7, 0])],
+});`
+    },
+    {
+      name: "boolIntersect",
+      signature: "await boolIntersect(name: string, a: Object3D, b: Object3D, opts?: { smooth?: false })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Keeps only the volume where both operands overlap. Default flat shading.",
+      example: "const lens = await boolIntersect('Lens', boxMesh, sphereMesh);"
+    },
+    {
+      name: "hull",
+      signature: "await hull(name: string, ...parts: Object3D[], opts?: { smooth?: true })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Tightest convex mesh enclosing all input points. Default smooth shading (rocks, collision volumes). Pass { smooth: false } for a faceted look.",
+      example: `const rockChunks = [...]; // scattered box meshes
+const rock = await hull('Rock', ...rockChunks);`
+    },
+    {
+      name: "arrayLinear",
+      signature: "arrayLinear(namePrefix, source, count, offset: [x,y,z], parent?)",
+      returns: "THREE.Object3D[]",
+      category: "arrays",
+      description: "Places N copies of `source` along a constant offset vector. Copies share geometry + material via createInstance.",
+      example: `const post = createPart('Post0', cylinderGeo(0.05,0.05,1.5,6), wood, { position: [0,0.75,0], parent: root });
+arrayLinear('Post', post, 10, [0.5, 0, 0], root);`
+    },
+    {
+      name: "arrayRadial",
+      signature: "arrayRadial(namePrefix, source, count, axis?: 'x'|'y'|'z', parent?)",
+      returns: "THREE.Object3D[]",
+      category: "arrays",
+      description: "Places N copies of `source` around the given axis. Source's local rotation is oriented outward. Perfect for gear teeth, radial bolts, circle of columns.",
+      example: `const bolt = createPart('Bolt0', cylinderGeo(0.02,0.02,0.1,6), steel, { position: [1,0,0], parent: root });
+arrayRadial('Bolt', bolt, 8, 'y', root);`
+    },
+    {
+      name: "mirror",
+      signature: "mirror(name, source, axis: 'x'|'y'|'z', parent?)",
+      returns: "THREE.Object3D",
+      category: "arrays",
+      description: "Reflects source across the plane whose normal is `axis`. Uses negative scale (winding flip handled by viewers).",
+      example: "mirror('WingR', wingL, 'x', root);"
+    },
+    {
+      name: "subdivide",
+      signature: "subdivide(geometry: BufferGeometry, iterations?: 1, opts?: { preserveUV?: boolean, split?: boolean, uvSmooth?: boolean, preserveEdges?: boolean, flatOnly?: boolean, weld?: boolean })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Loop subdivision returns new geometry; each iteration roughly quadruples triangles and smooths the surface. Use preserveUV:true for textured meshes. Legacy position-only welding discards UVs and reports that loss. This smooths shapes, not selected-edge beveling.",
+      example: "const smoothRock = subdivide(boxGeo(1, 1, 1), 2);"
+    },
+    {
+      name: "mergeVertices",
+      signature: "mergeVertices(geometry: BufferGeometry, opts?: { tolerance?: 1e-4, positionOnly?: boolean } | number)",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Returns indexed geometry. Default welding preserves attribute seams, so a textured cube retains separate face corners. positionOnly:true welds coincident positions and discards other attributes; use it explicitly when changing topology and regenerate shading/UVs afterward.",
+      example: `const welded = mergeVertices(boxGeo(1, 1, 1), { positionOnly: true });
+const rock = displace(subdivide(welded, 2), ([x,y,z]) => [0.08*Math.sin(y*7+z*3), 0.04*Math.sin(x*9), 0]);`
+    },
+    {
+      name: "curveToMesh",
+      signature: "curveToMesh(points: [x,y,z][], radius, tubularSegs?: 32, radialSegs?: 8, closed?: false)",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Sweeps a circular profile along a path. Equivalent to Blender's Curve to Mesh node with a circle profile. Use for pipes, cables, tubular frames.",
+      example: "const pipe = curveToMesh([[0,0,0],[0,1,0],[1,1,0],[1,2,0]], 0.1);"
+    },
+    {
+      name: "pipeAlongPath",
+      signature: "pipeAlongPath(points: [x,y,z][], radius: number, opts?: { bendRadius?: 0, closed?: false, tubularSegments?: 32, radialSegments?: 8 })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Path-driven swept circle with optional bend smoothing. Generalises beamBetween (point-to-point) and curveToMesh (raw spline) into one helper. bendRadius>0 inserts interpolated waypoints near interior corners so the spline reads as a rounded turn instead of pinching to the control point.",
+      example: "const cable = pipeAlongPath([[0, 0.5, 0], [1, 0.5, 0], [1, 0.5, 2]], 0.02, { bendRadius: 0.1 });"
+    },
+    {
+      name: "lathe",
+      signature: "lathe(profile: [x,y][], segments?: 12)",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Surface of revolution. Spins a 2D profile around the Y axis. For bottles, vases, wheels, turned wood parts.",
+      example: "const vase = lathe([[0.1,0],[0.3,0.5],[0.2,1],[0.1,1.2]], 16);"
+    },
+    {
+      name: "revolveGeo",
+      signature: "revolveGeo(profile: [x,y][], opts?: { angle?: 2π, axis?: [x,y,z]=[0,1,0], segments?: 12 })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Surface of revolution with explicit axis + sweep angle. Generalises lathe — use it when you need a partial sweep (half-dome, 90° wedge) or revolution around a non-Y axis. Profile convention is identical to lathe: x = radial distance, y = position along the axis.",
+      example: `// Half-dome (180° sweep around +Y):
+const quarter = [...Array(8)].map((_, i) => { const t = (i/7)*Math.PI/2; return [Math.cos(t), Math.sin(t)] as [number, number]; });
+const dome = revolveGeo(quarter, { angle: Math.PI });`
+    },
+    {
+      name: "bezierCurve",
+      signature: "bezierCurve(controlPoints: [x,y,z][], samples?: 32)",
+      returns: "[x,y,z][]",
+      category: "curves",
+      description: "Samples a quadratic (3 ctrl pts) or cubic (4 ctrl pts) Bézier into a point list you can feed into curveToMesh.",
+      example: `const path = bezierCurve([[0,0,0],[1,2,0],[3,2,0],[4,0,0]], 24);
+const geo = curveToMesh(path, 0.1);`
+    },
+    {
+      name: "autoUnwrap",
+      signature: "await autoUnwrap(geometry: BufferGeometry, opts?: { resolution?: 1024, padding?: 2, useNormals?: false })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "uv",
+      description: "xatlas-based UV atlas for ANY geometry (CSG output, subdivided, deformed). Output is a packed atlas with arbitrary per-chart rotation — use for non-tileable baked textures. For directional tileable textures on box/cylinder/plane primitives, prefer the shape-aware unwraps below.",
+      example: `const unwrapped = await autoUnwrap(someCsgResult, { resolution: 1024 });
+const mesh = new THREE.Mesh(unwrapped, bakedPbr);`
+    },
+    {
+      name: "boxUnwrap",
+      signature: "boxUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Preserves BoxGeometry's built-in per-face UVs — every face maps [0,1] with consistent orientation. Use for crates/blocks with a tileable texture. Sync; no WASM cost.",
+      example: `const crate = boxUnwrap(boxGeo(1, 1, 1));
+const mesh = new THREE.Mesh(crate, pbrMaterial({ albedo: planksTex }));`
+    },
+    {
+      name: "cylinderUnwrap",
+      signature: "cylinderUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Preserves CylinderGeometry's built-in UVs: u wraps around the axis (horizontal texture features ring the cylinder), v runs up the height. Caps use circle-in-square. Sync; no WASM cost.",
+      example: `const barrel = cylinderUnwrap(cylinderGeo(0.5, 0.5, 1.2, 24));
+const mesh = new THREE.Mesh(barrel, pbrMaterial({ albedo: bandsTex }));`
+    },
+    {
+      name: "planeUnwrap",
+      signature: "planeUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Projects xy-extent of the bbox to [0,1]. Use for signs/decals/posters where you want ONE readable texture and no edge-face bleeding. Sync.",
+      example: `const sign = planeUnwrap(planeGeo(1, 0.6));
+const mesh = new THREE.Mesh(sign, pbrMaterial({ albedo: kilnTextTex }));`
+    },
+    {
+      name: "panelRemapV",
+      signature: "panelRemapV(geo, vScale=0.30, vOffset=0, uScale=1, uOffset=0)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Scales an existing UV attribute so a small mesh samples a sub-region of a SHARED texture. Replaces the broken texture.clone() pattern (Three.js Texture.clone() runs JSON.stringify on userData, mangling encoded PNG bytes — panelRemapV avoids that by remapping UVs on the geometry instead). Typical use: multi-zone albedo where v=0..0.30 is plain panel and v=0.30..1 has windows/markings — small parts call panelRemapV(unwrap(geo), 0.30) to sample only the clean strip.",
+      example: `const cowlGeo = panelRemapV(cylinderUnwrap(capsuleXGeo(0.45, 1.0)), 0.30);
+const cowl = new THREE.Mesh(cowlGeo, bodyMat); // SAME bodyMat as fuselage, no clone needed`
+    },
+    {
+      name: "loadApprovedTexture",
+      signature: "await loadApprovedTexture(resourceId)",
+      returns: "Promise<THREE.DataTexture>",
+      category: "textures",
+      description: "Loads one approved kiln.texture.* resource ID through the host-injected closed resolver. The registry fixes bytes, MIME, usage, dimensions, hash, and deadline; paths, URLs, byte arrays, resolver objects, hashes, and options are rejected.",
+      example: "const bark = await loadApprovedTexture('kiln.texture.bark-brown-01-albedo.v1');",
+      promptNotes: "Use only a concrete resource ID listed in material capabilities; never invent one. Prefer materialRecipe when a recipe already binds the family, or proceduralTexture V2 for authored surfaces. NEVER texture.clone() a loaded texture (clone() corrupts encoded bytes and breaks GLB export)."
+    },
+    {
+      name: "proceduralTexture",
+      signature: "proceduralTexture({ schemaVersion: 2, size?: 4..1024 pow2, usage?, name?, layers: [{ op: 'solid'|'checker'|'stripes'|'gradient'|'bricks'|'noise', ...params, blend?: 'normal'|'multiply'|'screen'|'overlay', opacity?: 0..1 }] })",
+      returns: "THREE.DataTexture (tiling, sRGB or linear per usage)",
+      category: "textures",
+      description: "Builds a tiling texture from a bounded layer stack — no image file needed. Layers composite bottom-first. Noise is seeded and tileable, so the same spec always produces the same bytes and a repeating material shows no seam. Baked to PNG and embedded in the GLB automatically.",
+      example: "const bark = proceduralTexture({ schemaVersion: 2, size: 256, usage: 'albedo', name: 'Bark', layers: [{ op: 'solid', color: 0x5a4632 }, { op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4, blend: 'overlay' }] });",
+      promptNotes: "Sync — no await. Strict V2 JSON boundary: unknown/prototype keys, callbacks, paths, URLs, and shader source are rejected. Prefer this over approved resources for describable surfaces. Max 8 layers, power-of-two size up to 1024. Only the six listed ops exist."
+    },
+    {
+      name: "normalMapFromHeight",
+      signature: "normalMapFromHeight(source: THREE.Texture, { strength?: number, name?: string })",
+      returns: "THREE.DataTexture (linear normal map)",
+      category: "textures",
+      description: "Derives a tangent-space normal map from the source texture's brightness, treating it as height. The cheap way to get real PBR surface relief out of a procedural albedo. Wraps at the edges, so a tiling source gives a tiling normal map.",
+      example: `const bark = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4 }] });
+const mat = pbrMaterial({ albedo: bark, normal: normalMapFromHeight(bark, { strength: 4 }) });`,
+      promptNotes: "strength 1 is subtle, 4-8 reads clearly at normal viewing distance. Output is always linear data — never assign it to an albedo/emissive slot."
+    },
+    {
+      name: "pbrMaterial",
+      signature: "pbrMaterial({ albedo?, normal?, roughness?, metalness?, metallicRoughness?, emissive?, aoMap?, alphaMode?, alphaCutoff?, doubleSided? })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Portable glTF PBR material. Use an explicit packed metallicRoughness texture (G=roughness, B=metalness); separate data maps are rejected instead of silently dropping a channel. Supports OPAQUE/MASK/BLEND and double-sided output.",
+      example: `const wood = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x4f301c, colorB: 0x9a6b3e, scale: 8, octaves: 3, seed: 4 }] });
+const crate = pbrMaterial({ albedo: wood, roughness: 0.85, metalness: 0 });`
+    },
+    {
+      name: "foliageMaterial",
+      signature: "foliageMaterial(albedo, { alphaCutoff?, roughness?, doubleSided? })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Portable foliage material that defaults to glTF MASK, cutoff 0.5, rough nonmetal, and double-sided. Use an alpha-bearing albedo texture.",
+      example: "const mat = await materialRecipe('kiln.material.leaf.v1');"
+    },
+    {
+      name: "countTriangles",
+      signature: "countTriangles(root: Object3D)",
+      returns: "number",
+      category: "utility",
+      description: "Sums triangle count across every mesh in the subtree.",
+      example: "meta.tris = countTriangles(root);"
+    },
+    {
+      name: "countMaterials",
+      signature: "countMaterials(root: Object3D)",
+      returns: "number",
+      category: "utility",
+      description: "Unique material count (by reference) across the subtree.",
+      example: "const mats = countMaterials(root);"
+    },
+    {
+      name: "getJointNames",
+      signature: "getJointNames(root: Object3D)",
+      returns: "string[]",
+      category: "utility",
+      description: "All node names beginning with `Joint_`. Use to sanity-check animation targets.",
+      example: "const joints = getJointNames(root);"
+    },
+    {
+      name: "validateAsset",
+      signature: "validateAsset(root: Object3D, category: 'character' | 'prop' | 'vfx' | 'environment' | 'architecture' | 'vegetation' | 'vehicle')",
+      returns: "{ valid, errors, warnings }",
+      category: "utility",
+      description: "Checks geometry and material costs for the selected category. No default triangle limit; choose detail for the intended runtime and inspect measured draw calls.",
+      example: "const v = validateAsset(root, 'prop');"
+    }
+  ];
+});
+
 // src/contracts/breadth.ts
 function cloneVfxIntentV1(value) {
   return {
@@ -7288,7 +8210,7 @@ function rethrowAuthoringError(error) {
   }
   throw error;
 }
-var UNBOUND_VARIABLE_ADVICE = "Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying.", GEAR_RADII_ORDER_ADVICE = "gearGeo requires boreRadius < rootRadius < tipRadius; specify rootRadius when changing tipRadius. Omitted radii keep their absolute defaults.", ROUNDED_BOX_RADIUS_ADVICE = "roundedBoxGeo: radius must be less than half the smallest dimension. Reduce radius or increase the smallest dimension; equality is invalid.", AuthoringDiagnosticError;
+var UNBOUND_VARIABLE_ADVICE = "Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying. If it was meant to be a Kiln helper, call kiln_list_primitives to confirm the exact name and signature; the sandbox exposes only those globals.", GEAR_RADII_ORDER_ADVICE = "gearGeo requires boreRadius < rootRadius < tipRadius; specify rootRadius when changing tipRadius. Omitted radii keep their absolute defaults.", ROUNDED_BOX_RADIUS_ADVICE = "roundedBoxGeo: radius must be less than half the smallest dimension. Reduce radius or increase the smallest dimension; equality is invalid.", AuthoringDiagnosticError;
 var init_authoring_diagnostic = __esm(() => {
   AuthoringDiagnosticError = class AuthoringDiagnosticError extends Error {
     diagnostic;
@@ -19950,7 +20872,73 @@ function validate(code, _opts = {}) {
       line: smell.line
     });
   }
+  warnings.push(...unknownHelperWarnings(ast));
   return toResult(issues, warnings, analysis.estimatedTris);
+}
+function unknownHelperWarnings(ast) {
+  const declared = new Set;
+  const bind = (node) => {
+    const target = node;
+    if (!target?.type)
+      return;
+    if (target.type === "Identifier")
+      declared.add(target["name"]);
+    else if (target.type === "ObjectPattern")
+      for (const prop of target["properties"])
+        bind(prop.value ?? prop.argument);
+    else if (target.type === "ArrayPattern")
+      for (const el of target["elements"])
+        bind(el);
+    else if (target.type === "AssignmentPattern")
+      bind(target["left"]);
+    else if (target.type === "RestElement")
+      bind(target["argument"]);
+  };
+  const params = (node) => {
+    const fn = node;
+    if (fn.id?.name)
+      declared.add(fn.id.name);
+    for (const param of fn.params ?? [])
+      bind(param);
+  };
+  walk.simple(ast, {
+    VariableDeclarator(node) {
+      bind(node.id);
+    },
+    FunctionDeclaration(node) {
+      params(node);
+    },
+    FunctionExpression(node) {
+      params(node);
+    },
+    ArrowFunctionExpression(node) {
+      params(node);
+    },
+    ClassDeclaration(node) {
+      params(node);
+    },
+    CatchClause(node) {
+      bind(node.param);
+    }
+  });
+  const seen = new Map;
+  walk.simple(ast, {
+    CallExpression(node) {
+      const callee = node.callee;
+      if (callee?.type !== "Identifier" || !callee.name)
+        return;
+      const name = callee.name;
+      if (declared.has(name) || SANDBOX_CALLABLES.has(name) || seen.has(name))
+        return;
+      seen.set(name, node.loc?.start?.line);
+    }
+  });
+  return [...seen].map(([name, line]) => ({
+    code: "UNKNOWN_HELPER",
+    message: `${name}() is not declared in this program and is not a Kiln sandbox global; the build will fail when it runs.`,
+    fixHint: "Call kiln_list_primitives to confirm the helper name and signature, or declare the function in this program.",
+    ...line === undefined ? {} : { line }
+  }));
 }
 function assertGeneratedSourceSafe(code) {
   let ast;
@@ -20466,8 +21454,45 @@ function hasBreak(body) {
   });
   return found;
 }
-var GeneratedSourcePolicyError, FORBIDDEN_AMBIENT_IDENTIFIERS, FORBIDDEN_THREE_CONSTRUCTORS, ROTATION_OPTION_FNS;
+var SANDBOX_CALLABLES, GeneratedSourcePolicyError, FORBIDDEN_AMBIENT_IDENTIFIERS, FORBIDDEN_THREE_CONSTRUCTORS, ROTATION_OPTION_FNS;
 var init_validation = __esm(() => {
+  init_list_primitives();
+  SANDBOX_CALLABLES = new Set([
+    ...listPrimitives().map((primitive) => primitive.name),
+    "Array",
+    "BigInt",
+    "Boolean",
+    "Error",
+    "Float32Array",
+    "Float64Array",
+    "Int16Array",
+    "Int32Array",
+    "Int8Array",
+    "Map",
+    "Number",
+    "Object",
+    "Promise",
+    "Proxy",
+    "RangeError",
+    "Reflect",
+    "RegExp",
+    "Set",
+    "String",
+    "Symbol",
+    "TypeError",
+    "Uint16Array",
+    "Uint32Array",
+    "Uint8Array",
+    "WeakMap",
+    "WeakSet",
+    "decodeURIComponent",
+    "encodeURIComponent",
+    "isFinite",
+    "isNaN",
+    "parseFloat",
+    "parseInt",
+    "structuredClone"
+  ]);
   GeneratedSourcePolicyError = class GeneratedSourcePolicyError extends Error {
     code;
     line;
@@ -25920,920 +26945,8 @@ import {
 } from "@strands-agents/sdk";
 import { AgentSkills } from "@strands-agents/sdk/vended-plugins/skills";
 
-// src/geometry-catalog.ts
-var geometryPrimitives = [
-  {
-    name: "copyGeometry",
-    signature: "copyGeometry(geometry: BufferGeometry)",
-    returns: "THREE.BufferGeometry",
-    category: "instancing",
-    description: "Returns an independent geometry with copied vertex buffers. Use before direct mutation of a cached primitive.",
-    example: "const editable = copyGeometry(boxGeo(1, 1, 1)); editable.translate(0, 0.5, 0);"
-  },
-  {
-    name: "copyMaterial",
-    signature: "copyMaterial(material: Material)",
-    returns: "THREE.Material (same subtype)",
-    category: "instancing",
-    description: "Copies material properties so edits do not change other parts. Referenced textures remain shared.",
-    example: "const red = copyMaterial(steel); red.color.set(0xaa2222);"
-  },
-  {
-    name: "meshGeo",
-    signature: "meshGeo({ positions: number[], indices?: number[], normals?: number[], uvs?: number[], tangents?: number[] })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Builds an owned triangle mesh from flat numeric arrays. Validates finite values, attribute lengths and indices; computes normals if absent. Counterclockwise winding.",
-    example: "const triangle = meshGeo({ positions: [0,0,0, 1,0,0, 0,1,0], indices: [0,1,2] });"
-  },
-  {
-    name: "parametricSurface",
-    signature: "parametricSurface(sample: (u,v) => [x,y,z], opts?: { u?: [0,1], v?: [0,1], uSegments?: 24, vSegments?: 24, periodicU?: false, periodicV?: false, orientation?: 'uv'|'vu' })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Samples an equation into an owned surface with UVs. Periodic endpoints must coincide; UV seams retain matching normals. A surface is not automatically a watertight solid.",
-    example: "const canopy = parametricSurface((u,v) => [u, 0.3*Math.sin(u*3)*Math.cos(v*2), v], { u: [-2,2], v: [-1,1] });"
-  },
-  {
-    name: "geometryDiagnostics",
-    signature: "geometryDiagnostics(geometry: BufferGeometry, tolerance?: 1e-6)",
-    returns: "{ vertices, triangles, boundaryEdges, nonManifoldEdges, orientationConflicts, degenerateTriangles, invalidIndices, nonFiniteVertices }",
-    category: "utility",
-    description: "Counts mesh topology problems after position-based seam matching. Open boundaries are valid for sheets; closed edges alone do not prove a self-intersection-free solid.",
-    example: "const topology = geometryDiagnostics(shell);"
-  },
-  {
-    name: "creaseNormals",
-    signature: "creaseNormals(geometry: BufferGeometry, opts?: { angle?: 60, tolerance?: number })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Returns owned geometry with angle-limited smooth normals, preserving UV corners. Angle is degrees. Invalidates tangents; use after shaping for sharp rims and smooth walls.",
-    example: "const shell = creaseNormals(cylinderGeo(1,1,2,32), { angle: 45 });"
-  },
-  {
-    name: "bend",
-    signature: "bend(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Bends local +Y toward +X through angle degrees. Returns owned geometry and updated normals/bounds; preserves UVs, invalidates tangents. Frame rotation is Euler XYZ degrees.",
-    promptNotes: "Deformation interval uses local Y distances; outside vertices stay unchanged. Add enough segments before bending. Falloff returns 0..1; use it to avoid a discontinuity at a selected interval boundary.",
-    example: "const arch = bend(planeGeo(1,4,4,32), { angle: 90 });"
-  },
-  {
-    name: "twist",
-    signature: "twist(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Rotates the cross-section progressively around local +Y, reaching angle degrees at the end. Returns owned geometry; frame rotation uses Euler XYZ degrees.",
-    example: "const spiral = twist(column, { angle: 120 });"
-  },
-  {
-    name: "taper",
-    signature: "taper(geometry, { startScale?: [1,1], endScale: [x,z], frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Scales local X/Z across the local Y interval using positive start/end scale pairs. Returns owned geometry; preserves UVs and invalidates tangents.",
-    example: "const narrowed = taper(column, { endScale: [0.4,0.7] });"
-  },
-  {
-    name: "displace",
-    signature: "displace(geometry, offset: ([x,y,z], t) => [dx,dy,dz], opts?: { frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Adds an authored displacement vector in the chosen local frame. Returns owned geometry; callback coordinates are local and t is normalized along the interval.",
-    example: "const rippled = displace(surface, ([x,y,z]) => [0, 0.1*Math.sin(x*8), 0]);"
-  },
-  {
-    name: "sweepProfile",
-    signature: "sweepProfile(profile: [x,z][], path: [x,y,z][], opts?: { cap?: true, closed?: false, up?: [x,y,z], twist?: 0, scale?: number | [x,z][] })",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Sweeps a simple noncircular profile along polyline stations using transported frames. Supports total twist in degrees and per-station scales. Generates UVs and optional caps.",
-    promptNotes: "First version supports one simple profile without holes. Closed paths omit the repeated endpoint and require twist to be a multiple of 360. up sets the initial profile +Z direction and cannot parallel the path. Tight-turn warnings do not replace visual inspection for self-intersections.",
-    example: "const rail = sweepProfile([[-.1,-.2],[.1,-.2],[.1,.2],[-.1,.2]], [[0,0,0],[0,1,0],[1,2,0]]);"
-  },
-  {
-    name: "loftProfiles",
-    signature: "loftProfiles(sections: { profile: [x,z][], frame?: { origin, rotation } }[], opts?: { cap?: true })",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Joins corresponding simple profiles in explicit local XZ planes. Each frame uses Euler XYZ degrees and local +Y along the loft. Profiles need equal point counts and corresponding vertices.",
-    promptNotes: "No holes or automatic profile correspondence. Opposite winding is normalized while preserving the first point. Caps close boundaries but do not prove the loft has no self-intersections.",
-    example: "const hull = loftProfiles([{ profile: wide }, { profile: narrow, frame: { origin: [0,2,0] } }]);"
-  },
-  {
-    name: "implicitSurface",
-    signature: "await implicitSurface(sample: ([x,y,z]) => signedValue, { bounds: { min, max }, edgeLength, maxCells?: 1000000, maxEvaluations?: 8000000, level?: 0, tolerance?: -1, smooth?: true })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "geometry",
-    description: "Experimental positive-inside implicit field sampled into a solid mesh. Requires explicit bounds and resolution; checks grid size and actual evaluation count. Output has no UVs.",
-    promptNotes: "Use async build and await. Smaller edgeLength increases cost sharply. This helper cannot stop a callback that never returns; the host evaluator process provides that boundary. Thin features and geometric accuracy require inspection.",
-    example: "const blob = await implicitSurface(([x,y,z]) => 1-Math.hypot(x,y,z), { bounds: { min: [-1.2,-1.2,-1.2], max: [1.2,1.2,1.2] }, edgeLength: 0.15 });"
-  }
-];
-
-// src/list-primitives.ts
-var PRIMITIVES = [
-  ...geometryPrimitives,
-  {
-    name: "createRoot",
-    signature: "createRoot(name: string)",
-    returns: "THREE.Object3D",
-    category: "structure",
-    description: "Creates the root Object3D for an asset. Call first in build().",
-    example: "const root = createRoot('FuelDrum');"
-  },
-  {
-    name: "createPivot",
-    signature: "createPivot(name: string, position?: [x, y, z], parent?: Object3D)",
-    returns: "THREE.Object3D (prefixed `Joint_`)",
-    category: "structure",
-    description: "Creates an empty pivot node for skeletal animation. Name is auto-prefixed with `Joint_`.",
-    example: "const hip = createPivot('Hip', [0, 1, 0], root);"
-  },
-  {
-    name: "createJointChain",
-    signature: "createJointChain(name, segments: { role, offset, aliases?, side?, localForwardAxis?, localBendAxis?, endEffector?, contact? }[], opts?: { parent?, parentRole? })",
-    returns: "{ root, end, nodes, byRole, descriptors }",
-    category: "structure",
-    description: "Creates one body-plan-neutral deterministic Joint_* chain with explicit parent edges, rest frames, local axes, end effectors, contacts, and semantic metadata.",
-    example: "const leg = createJointChain('LegL', [{ role: 'hip.left', offset: [0, 1, -0.2], side: 'left' }, { role: 'knee.left', offset: [0, -0.5, 0], side: 'left' }, { role: 'ankle.left', offset: [0, -0.5, 0], side: 'left', endEffector: true, contact: true }], { parent: root });",
-    promptNotes: "Use only the resolved body-plan graph. Offsets are local to the previous joint; contact end effectors must land at world Y=0."
-  },
-  {
-    name: "createVehicleFrame",
-    signature: "createVehicleFrame(name, opts?: { chassis?, axles?, seats?, contacts?, steering?, propulsion?, parent? })",
-    returns: "{ root, chassis, axles, seats, contacts, steering, propulsion }",
-    category: "structure",
-    description: "Creates a canonical +X-forward/+Y-up/+Z-right vehicle frame with typed semantic sockets for chassis, support, steering, and propulsion.",
-    example: "const frame = createVehicleFrame('CarFrame', { axles: [{ id: 'front', position: [1.2, 0.45, 0] }, { id: 'rear', position: [-1.2, 0.45, 0] }], parent: root });",
-    promptNotes: "Generated vehicles keep +X as front. Boats and other non-wheeled subtypes use declared support/propulsion sockets, not wheel rules."
-  },
-  {
-    name: "createWheelGeometrySet",
-    signature: "createWheelGeometrySet(radius: number, width: number)",
-    returns: "{ tire, rim, hub } shared THREE.BufferGeometry set",
-    category: "instancing",
-    description: "Creates one reusable +Z-axle tire/rim/hub geometry set for instanced wheel assemblies.",
-    example: "const wheelGeo = createWheelGeometrySet(0.45, 0.22);"
-  },
-  {
-    name: "createWheelAssembly",
-    signature: "createWheelAssembly(name, { tire, rim, hub? }, { radius, width, side, index, position?, rimRadius?, hubRadius?, steering?, loadBearing?, geometries?, parent? })",
-    returns: "{ root, steeringPivot?, spinPivot, tire, rim, hub, contact, radius, width, side, index, spinAxis }",
-    category: "structure",
-    description: "Creates one axle-centered wheel pivot containing concentric tire/rim/hub roles, a contact marker, +Z spin frame, and optional steering pivot.",
-    example: "createWheelAssembly('FrontLeft', { tire: rubber, rim: metal }, { radius: 0.45, width: 0.22, side: 'left', index: 'front', position: [1.2, 0.45, -0.9], steering: true, geometries: wheelGeo, parent: frame.root });",
-    promptNotes: "Keep tire, rim, and hub descendants concentric at the axle pivot. Reuse one geometry set across matching wheels."
-  },
-  {
-    name: "createPart",
-    signature: "createPart(name, geometry, material, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, pivot, parent })",
-    returns: "THREE.Object3D (mesh or wrapping pivot)",
-    category: "structure",
-    description: "Creates a mesh, optionally wrapped in a pivot, and attaches it to `opts.parent`. `rotation` is in DEGREES (like rotationTrack), NOT radians: [0, 0, 90] is a quarter turn; [0, 0, 1.57] is a no-op.",
-    example: "createPart('Barrel', cylinderGeo(0.1, 0.1, 1), gameMaterial(0x556b2f), { position: [0, 0.5, 0], rotation: [0, 0, 90], parent: root });",
-    promptNotes: "AUTO-ADDS to opts.parent. NEVER call parent.add(createPart(...)) — pass { parent } instead. rotation is DEGREES — writing radians (e.g. 0.785 or Math.PI/4) silently produces ~zero rotation."
-  },
-  {
-    name: "beamBetween",
-    signature: "beamBetween(name, start: [x,y,z], end: [x,y,z], radius, material, opts?: { segments, parent })",
-    returns: "THREE.Object3D (prefixed `Mesh_`)",
-    category: "structure",
-    description: "Creates a cylindrical rail/strut exactly between two endpoints. Use for braces, gun barrels, skid struts, cables, and scaffolding.",
-    example: "beamBetween('SkidBraceA', [0.8, 0.3, 0.7], [0.8, 1.0, 0.45], 0.025, black, { parent: root });"
-  },
-  {
-    name: "snapTo",
-    signature: "snapTo(part: Object3D, host: Object3D, opts?: { axis?: 'x'|'y'|'z', overlap?: 0.02 })",
-    returns: "THREE.Object3D (the part, for chaining)",
-    category: "structure",
-    description: 'Translates `part` by the minimal vector that brings its bounding box into contact with `host` (plus a small overlap). The direct cure for a "Floating parts" warning — attach the part instead of eyeballing a corrective offset. No-op if they already touch.',
-    example: `const scope = createPart('Scope', cylinderXGeo(0.04, 0.04, 0.3), steel, { parent: root, position: [0.1, 0.32, 0] });
-snapTo(scope, receiver);`
-  },
-  {
-    name: "createLadder",
-    signature: "createLadder(name, { bottom, top, material, width?, rungCount?, railRadius?, rungRadius?, widthAxis?, parent? })",
-    returns: "{ leftRail: Object3D, rightRail: Object3D, rungs: Object3D[] }",
-    category: "structure",
-    description: "Builds two continuous rails plus evenly-spaced rungs. Use this instead of loose boxes for ladders.",
-    example: "createLadder('TowerLadder', { bottom: [0,0,0], top: [0,2.2,0], width: 0.45, rungCount: 7, material: steel, parent: root });"
-  },
-  {
-    name: "createWingPair",
-    signature: "createWingPair(name, material, { rootZ, span, rootChord, tipChord, sweep?, thickness?, dihedral?, rootX?, rootY?, parent? })",
-    returns: "{ right: Object3D, left: Object3D }",
-    category: "structure",
-    description: "Creates mirrored trapezoid aircraft wings with roots attached at +/-rootZ. Use for aircraft wings and helicopter stub wings.",
-    example: "createWingPair('MainWing', olive, { rootX: 0, rootY: 1.0, rootZ: 0.42, span: 2.4, rootChord: 0.9, tipChord: 0.35, sweep: 0.25, dihedral: 0.08, parent: root });"
-  },
-  {
-    name: "room",
-    signature: "room(name, material, { width?, depth?, height?, wallThickness?, floor?, floorThickness?, openings?: [{ wall: 'front'|'back'|'left'|'right', kind?: 'door'|'window', offset?, width?, height?, sill? }], parent? })",
-    returns: "{ root: Object3D, walls: { front, back, left, right }, floor: Object3D | null }",
-    category: "structure",
-    description: "Builds a HOLLOW, enterable room: four thin walls + a floor, human-scaled (defaults: 2.8m ceiling, a centered 1.1x2.1m front door so it is enterable by default). `front` faces +X; the floor sits on the ground. The keystone of an architecture asset — add a roof with createRoofPlanes and fixtures as separate parts.",
-    example: "const { root: hut } = room('Hut', wood, { width: 5, depth: 4, height: 2.8, openings: [{ wall: 'front', kind: 'door' }, { wall: 'right', kind: 'window' }], parent: root });",
-    promptNotes: "Use for any building the player enters. Do NOT model a building as a solid block — room() guarantees real interior space and a doorway gap. Pass openings to add windows / side doors."
-  },
-  {
-    name: "wallWithOpening",
-    signature: "wallWithOpening(name, material, { length, height, thickness, axis?: 'x'|'z', opening?: { kind?: 'door'|'window', offset?, width?, height?, sill? }, parent? })",
-    returns: "THREE.Object3D (wall container)",
-    category: "structure",
-    description: "A single wall panel with an optional real door/window cut, composed from solid box segments (side panels + lintel + window sill) — no CSG. Base at local Y=0, centered on the run axis. Use to compose custom building layouts or interior dividing walls beyond the default room().",
-    example: "wallWithOpening('Partition', plaster, { length: 4, height: 2.8, thickness: 0.12, axis: 'x', opening: { kind: 'door', offset: 0.5 }, parent: root });"
-  },
-  {
-    name: "createRoofPlanes",
-    signature: "createRoofPlanes(name, material, { width, depth, height, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
-    returns: "{ root: Object3D, slopes: [Object3D, Object3D] }",
-    category: "structure",
-    description: "A pitched roof: two thin slopes meeting at one ridge and falling DOWN-AND-OUTWARD (opposite tilts — never mirrored the same way), footprint-matched with an eave overhang. Eave at local Y=0, ridge at Y=height, so position the group at Y=wallHeight. Returns a named group (e.g. `Roof`) the engine can lift to reveal the interior.",
-    example: `const { root: roof } = createRoofPlanes('Roof', shingle, { width: 5, depth: 4, height: 1.6, overhang: 0.4, ridgeAxis: 'x', parent: root });
-roof.position.y = 2.8;`,
-    promptNotes: "The two slopes must fall AWAY from each other from the ridge — createRoofPlanes does this for you. Drop it onto the walls (position.y = wall height)."
-  },
-  {
-    name: "createGableRoof",
-    signature: "createGableRoof(name, material, { spanX, spanZ, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
-    returns: "{ root, slopes: [Object3D, Object3D], faces: [RoofFaceFrame, RoofFaceFrame], rise, pitchDegrees }",
-    category: "structure",
-    description: "Explicit-axis gable roof using unambiguous footprint spans. Each face owns a rigid frame with ridge tangent, outward normal, downhill direction, ridge/eave endpoints, dimensions, and a live local-to-world transform.",
-    example: "const roof = createGableRoof('Roof', shingles, { spanX: 8, spanZ: 5, pitchDegrees: 35, overhang: 0.35, ridgeAxis: 'x', parent: root });",
-    promptNotes: "Prefer this over width/depth roof math. ridgeAxis is the direction of the ridge; roof panels run along each returned face downhill direction."
-  },
-  {
-    name: "createGableEndPanel",
-    signature: "createGableEndPanel(name, material, { span, rise, thickness?, ridgeAxis?: 'x'|'z', side?: 'positive'|'negative', openings?: [{ id?, offset?, bottom?, width, height }], parent? })",
-    returns: "{ root, geometry, openings }",
-    category: "structure",
-    description: "Exact thick triangular end closure for a gable roof, with optional rectangular openings cut from the geometry and semantic boundary metadata.",
-    example: "createGableEndPanel('FrontGable', siding, { span: 5, rise: 1.8, ridgeAxis: 'x', side: 'positive', parent: root });"
-  },
-  {
-    name: "createGableShell",
-    signature: "createGableShell(name, { wall, roof, floor?, gable? }, { spanX, spanZ, wallHeight?, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, wallThickness?, floorThickness?, closedEnds?, enterable?, openings?, gableOpenings?, parent? })",
-    returns: "{ root, walls, floor, roof, gables, openings }",
-    category: "structure",
-    description: "Closed-by-default, correct-by-construction gable building: hollow room, floor, two opposing roof slopes, two complete gable ends, and a real front doorway when enterable.",
-    example: "const house = createGableShell('House', { wall: plaster, roof: shingles }, { spanX: 8, spanZ: 5, wallHeight: 2.8, pitchDegrees: 35, ridgeAxis: 'x', parent: root });",
-    promptNotes: "Use for complete gable buildings. It stamps wall, floor, slope, gable, opening, adjacency, coverage, and separability semantics for deterministic QA and roof-off views."
-  },
-  {
-    name: "createRoofSurfaceLayout",
-    signature: "createRoofSurfaceLayout(name, material, { face, kind: 'panels'|'shingles'|'seams'|'corrugations', parent?, panelWidth?, rowHeight?, spacing?, thickness? })",
-    returns: "{ root, items: Object3D[] }",
-    category: "structure",
-    description: "Places roof-local panels, shingles, seams, or corrugations from a returned RoofFaceFrame, so repeated elements run ridge-to-eave for either ridge axis without manual Euler rotations.",
-    example: "for (const face of roof.faces) createRoofSurfaceLayout('Panels_' + face.side, metal, { face, kind: 'panels', parent: roof.root });",
-    promptNotes: "Always pass the face object returned by createGableRoof/createGableShell. Never infer the panel rotation from world axes."
-  },
-  {
-    name: "createStairs",
-    signature: "createStairs(name, material, { steps?, totalRise, totalRun, width, axis?: 'x'|'z', treadThickness?, riser?, parent? })",
-    returns: "{ root: Object3D, steps: Object3D[] }",
-    category: "structure",
-    description: "A straight flight of stairs: box treads (with optional risers) climbing totalRise over totalRun from local origin toward +axis. Use for porch/entry steps or to connect storeys in a multi-storey building.",
-    example: "createStairs('Porch', stone, { steps: 4, totalRise: 0.6, totalRun: 1.0, width: 1.4, axis: 'x', parent: root });"
-  },
-  {
-    name: "boxGeo",
-    signature: "boxGeo(width: number, height: number, depth: number)",
-    returns: "THREE.BoxGeometry",
-    category: "geometry",
-    description: "6-face box. 12 tris regardless of size. Cheapest geometry.",
-    example: "const geo = boxGeo(1, 0.5, 2);"
-  },
-  {
-    name: "sphereGeo",
-    signature: "sphereGeo(radius: number, widthSegments?: 8, heightSegments?: 6)",
-    returns: "THREE.SphereGeometry",
-    category: "geometry",
-    description: "UV sphere. Default 8x6 segments = 84 tris. Bump segments for smoother curves.",
-    example: "const geo = sphereGeo(0.5, 12, 8);"
-  },
-  {
-    name: "cylinderGeo",
-    signature: "cylinderGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Y-axis cylinder. Use radiusTop != radiusBottom for cones / tapered pieces.",
-    example: "const geo = cylinderGeo(0.25, 0.25, 1, 12);"
-  },
-  {
-    name: "cylinderYGeo",
-    signature: "cylinderYGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Alias for cylinderGeo — a Y-axis cylinder. Provided because the sandbox exposes cylinderXGeo / cylinderZGeo and the symmetric Y form is commonly reached for.",
-    example: "const geo = cylinderYGeo(0.25, 0.25, 1, 12);"
-  },
-  {
-    name: "cylinderXGeo",
-    signature: "cylinderXGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Cylinder pre-rotated to run along +X/-X. Use for fuselages, cannons, barrels, axles, and forward-facing tubes.",
-    example: "const geo = cylinderXGeo(0.1, 0.1, 1.2, 12);"
-  },
-  {
-    name: "cylinderZGeo",
-    signature: "cylinderZGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Cylinder pre-rotated to run along +Z/-Z. Use for side-mounted weapons, rails, crossbars, and pipes.",
-    example: "const geo = cylinderZGeo(0.08, 0.08, 0.9, 10);"
-  },
-  {
-    name: "cylinderOnAxis",
-    signature: "cylinderOnAxis(center: [x,y,z], normal: [x,y,z], radiusBottom: number, height: number, opts?: { radiusTop?, segments? })",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Frame-first cylinder: position + axis specified directly, no post-hoc rotation. Use when the cylinder needs to point along a non-cardinal direction (struts inside CSG operands, antennas off a tilted surface). For cardinal axes prefer the terser cylinderXGeo / cylinderYGeo / cylinderZGeo helpers.",
-    example: "const strut = cylinderOnAxis([0.5, 0.7, 0], [1, 1, 0.3], 0.05, 0.9);"
-  },
-  {
-    name: "capsuleGeo",
-    signature: "capsuleGeo(radius: number, height: number, segments?: 6)",
-    returns: "THREE.CapsuleGeometry",
-    category: "geometry",
-    description: "Stadium shape (cylinder with hemispherical caps). Good for limbs.",
-    example: "const geo = capsuleGeo(0.1, 0.5, 6);"
-  },
-  {
-    name: "capsuleYGeo",
-    signature: "capsuleYGeo(radius: number, height: number, segments?: 6)",
-    returns: "THREE.CapsuleGeometry",
-    category: "geometry",
-    description: "Alias for capsuleGeo — a Y-axis capsule. Provided for symmetry with capsuleXGeo / capsuleZGeo.",
-    example: "const geo = capsuleYGeo(0.1, 0.5, 6);"
-  },
-  {
-    name: "capsuleXGeo",
-    signature: "capsuleXGeo(radius: number, length: number, segments?: 6)",
-    returns: "THREE.CapsuleGeometry",
-    category: "geometry",
-    description: "Capsule pre-rotated to run along +X/-X. Use for aircraft bodies, rounded vehicle hulls, and missiles.",
-    example: "const geo = capsuleXGeo(0.35, 2.4, 10);"
-  },
-  {
-    name: "capsuleZGeo",
-    signature: "capsuleZGeo(radius: number, length: number, segments?: 6)",
-    returns: "THREE.CapsuleGeometry",
-    category: "geometry",
-    description: "Capsule pre-rotated to run along +Z/-Z. Use for lateral pods, floats, and side tanks.",
-    example: "const geo = capsuleZGeo(0.18, 1.1, 8);"
-  },
-  {
-    name: "coneGeo",
-    signature: "coneGeo(radius: number, height: number, segments?: 8)",
-    returns: "THREE.ConeGeometry",
-    category: "geometry",
-    description: "Y-axis cone (pointed up). Use for spikes, roofs, projectiles.",
-    example: "const geo = coneGeo(0.3, 0.8, 8);"
-  },
-  {
-    name: "coneYGeo",
-    signature: "coneYGeo(radius: number, height: number, segments?: 8)",
-    returns: "THREE.ConeGeometry",
-    category: "geometry",
-    description: "Alias for coneGeo — a Y-axis cone (point +Y). Provided for symmetry with coneXGeo / coneZGeo.",
-    example: "const geo = coneYGeo(0.3, 0.8, 8);"
-  },
-  {
-    name: "coneXGeo",
-    signature: "coneXGeo(radius: number, length: number, segments?: 8)",
-    returns: "THREE.ConeGeometry",
-    category: "geometry",
-    description: "Cone pre-rotated so its point faces +X. Use for noses, rockets, shells, and forward-facing tips.",
-    example: "const geo = coneXGeo(0.18, 0.45, 12);"
-  },
-  {
-    name: "coneZGeo",
-    signature: "coneZGeo(radius: number, length: number, segments?: 8)",
-    returns: "THREE.ConeGeometry",
-    category: "geometry",
-    description: "Cone pre-rotated so its point faces +Z. Use for side-facing projectiles and tips.",
-    example: "const geo = coneZGeo(0.12, 0.35, 10);"
-  },
-  {
-    name: "taperConeGeo",
-    signature: "taperConeGeo(radiusBottom: number, radiusTop: number, height: number, axis?: 'x'|'y'|'z', segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Truncated cone (frustum) — exposes both bottom and top radius. radiusTop=0 matches coneGeo, radiusTop=radiusBottom matches cylinderGeo. Use for pylon caps, soda cans, lampshades, anything tapered that does not come to a point. axis selects orientation (default Y).",
-    example: "const cap = taperConeGeo(0.3, 0.18, 0.4);  // frustum"
-  },
-  {
-    name: "torusGeo",
-    signature: "torusGeo(radius: number, tube: number, radialSegments?: 8, tubularSegments?: 12)",
-    returns: "THREE.TorusGeometry",
-    category: "geometry",
-    description: "Donut shape. For rings, tyres, barrel ribs.",
-    example: "const geo = torusGeo(0.4, 0.04, 8, 16);"
-  },
-  {
-    name: "planeGeo",
-    signature: "planeGeo(width: number, height: number, widthSegments?: 1, heightSegments?: 1)",
-    returns: "THREE.PlaneGeometry",
-    category: "geometry",
-    description: "Flat quad for TEXTURED surfaces (ground, signs, walls with albedo maps). For solid-color decals like red stars, hull numbers, stamps, or window cutouts on no-texture assets use decalBox — a bare planeGeo without a texture will render as a disconnected 2-tri square and get flagged as a stray plane.",
-    example: "const geo = planeGeo(4, 4);"
-  },
-  {
-    name: "decalBox",
-    signature: "decalBox(width: number, height: number, depth?: 0.01)",
-    returns: "THREE.BoxGeometry",
-    category: "geometry",
-    description: "Thin box for solid-color surface decals: red stars, hull numbers, stamps, no-texture windows. Unlike planeGeo, has real depth so it visibly attaches to its host surface. Must be placed on a surface with position + rotation.",
-    example: `const star = decalBox(0.18, 0.18, 0.01);
-createPart('Mesh_StarPort', star, gameMaterial(0xc61f2a), { position: [0.4, 0.6, 0.41], parent: fuselage });`,
-    promptNotes: "Offset at least 0.01 outside the host surface to avoid z-fighting (a 0.8-wide hull has faces at z=±0.4, so place the decal at z=±0.41)."
-  },
-  {
-    name: "foliageCardGeo",
-    signature: "foliageCardGeo(opts?: { width?, height?, yPivot?: 0..1 })",
-    returns: "THREE.PlaneGeometry",
-    category: "geometry",
-    description: "Single-quad foliage card with a configurable Y pivot. yPivot=0 plants the quad on the ground. Pair with an alpha-tested material and a leaf/plant sprite.",
-    example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
-const quad = foliageCardGeo({ width: 4, height: 6, yPivot: 0 });
-createPart('Mesh_Fern', quad, leaves, { parent: root });`
-  },
-  {
-    name: "crossedQuadsGeo",
-    signature: "crossedQuadsGeo(opts?: { width?, height?, planes?: 2 | 3, yPivot? })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Cross-billboard bush primitive: 2 or 3 planes intersecting along the Y axis. Reads as a dense plant from any angle, cheaper than real geometry.",
-    example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
-const bush = crossedQuadsGeo({ width: 2, height: 2, planes: 3 });
-createPart('Mesh_Bush', bush, leaves, { parent: root });`
-  },
-  {
-    name: "octaGridPlane",
-    signature: "octaGridPlane({ tilesX, tilesY, width?, height?, yPivot? })",
-    returns: "THREE.PlaneGeometry",
-    category: "geometry",
-    description: "Atlas-ready billboard quad. UVs are pre-scaled to cover one tile of a tilesX×tilesY atlas; the consumer shader adds per-instance tile offsets at draw time.",
-    example: "const card = octaGridPlane({ tilesX: 4, tilesY: 4, width: 6, height: 6 });"
-  },
-  {
-    name: "wingGeo",
-    signature: "wingGeo(opts?: { span, rootChord, tipChord, sweep, thickness, dihedral })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Trapezoid wing panel. Local root edge is at Z=0, span extends toward +Z, positive sweep moves the tip aft along -X.",
-    example: "const geo = wingGeo({ span: 2.2, rootChord: 0.8, tipChord: 0.3, sweep: 0.25, dihedral: 0.08 });"
-  },
-  {
-    name: "gearGeo",
-    signature: "gearGeo(opts?: { teeth?: 12, rootRadius?: 0.8, tipRadius?: 1.0, boreRadius?: 0.2, height?: 0.3, toothWidthFrac?: 0.5 })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Stylized gear with flat edges and an optional center bore; no CSG. Use boreRadius < rootRadius < tipRadius. Radii are absolute: an omitted rootRadius stays 0.8 when tipRadius changes. Set all three radii for small gears.",
-    example: `const g = gearGeo({ teeth: 28, rootRadius: 0.063, tipRadius: 0.075, boreRadius: 0.012, height: 0.024 });
-createPart('Gear', g, gameMaterial(0x909090, { metalness: 0.8 }), { parent: root });`
-  },
-  {
-    name: "bladeGeo",
-    signature: "bladeGeo(opts?: { length?: 1.5, baseWidth?: 0.1, thickness?: 0.015, tipLength?: 0.25, edgeBevel?: 0 })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Parametric sword blade: rectangular base tapering to a point over tipLength. edgeBevel > 0 pinches the cross-section toward a diamond ridge.",
-    example: `const b = bladeGeo({ length: 1.6, baseWidth: 0.09, tipLength: 0.3, edgeBevel: 0.5 });
-createPart('Blade', b, steel, { position: [0, 0, 0], parent: root });`
-  },
-  {
-    name: "gameMaterial",
-    signature: "gameMaterial(color, opts?: { metalness, roughness, emissive, emissiveIntensity, flatShading })",
-    returns: "THREE.MeshStandardMaterial",
-    category: "material",
-    description: "Flat-shaded PBR material. Default for game-ready low-poly. Use for 95% of parts.",
-    example: "const mat = gameMaterial(0x8b7355, { roughness: 0.9 });"
-  },
-  {
-    name: "materialRecipe",
-    signature: "await materialRecipe(recipeId, overrides?: { baseColor?, roughness?, metalness?, opacity?, alphaCutoff?, doubleSided?, emissiveColor?, emissiveIntensity?, textureResources? })",
-    returns: "Promise<THREE.MeshStandardMaterial>",
-    category: "material",
-    description: "Resolves a versioned portable bark/leaf/wood/stone/rubber/painted-metal/cloth/skin/glass/emissive recipe to standard glTF PBR.",
-    example: "const bark = await materialRecipe('kiln.material.bark.v1', { baseColor: '#6b4328' });",
-    promptNotes: "Use only listed kiln.material.*.v1 IDs and approved kiln.texture.* resource IDs. Leaf is MASK, glass is BLEND, and host file paths are forbidden."
-  },
-  {
-    name: "compilePortableMaterialSpecV2",
-    signature: "await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', name?, baseColor?, roughness?, metalness?, emissive?, emissiveIntensity?, alphaMode?, alphaCutoff?, doubleSided?, textures?: { baseColor?, normal?, metallicRoughness?, emissive?, occlusion? } })",
-    returns: "Promise<THREE.MeshStandardMaterial>",
-    category: "material",
-    description: "Compiles the strict portable material contract. Texture refs are either typed procedural V2 specs or closed approved kiln.texture.* IDs; paths, URLs, raw textures, callbacks, and shader source are rejected.",
-    example: "const steel = await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', roughness: 0.45, metalness: 0.85, textures: { metallicRoughness: { kind: 'procedural', spec: { schemaVersion: 2, usage: 'metallicRoughness', size: 64, layers: [{ op: 'solid', color: 0x0080cc }] } } } });",
-    promptNotes: "Use metallicRoughness as one packed G=roughness/B=metalness map. Every procedural ref usage must match its slot; resource refs must be approved for that exact slot."
-  },
-  {
-    name: "basicMaterial",
-    signature: "basicMaterial(color, opts?: { transparent, opacity })",
-    returns: "THREE.MeshBasicMaterial",
-    category: "material",
-    description: "Unlit flat material. For UI / effects where lighting is baked in.",
-    example: "const mat = basicMaterial(0xffffff, { transparent: true, opacity: 0.5 });"
-  },
-  {
-    name: "glassMaterial",
-    signature: "glassMaterial(color, opts?: { opacity, roughness, metalness })",
-    returns: "THREE.MeshStandardMaterial",
-    category: "material",
-    description: "Semi-transparent double-sided material. Panels need ~0.05 offset to avoid z-fighting.",
-    example: "const mat = glassMaterial(0x66ccff, { opacity: 0.3 });"
-  },
-  {
-    name: "lambertMaterial",
-    signature: "lambertMaterial(color, opts?: { flatShading, emissive })",
-    returns: "THREE.MeshLambertMaterial",
-    category: "material",
-    description: "Cheaper than gameMaterial. No metalness/roughness. Use when PBR is overkill.",
-    example: "const mat = lambertMaterial(0x2a4d14, { flatShading: true });"
-  },
-  {
-    name: "rotationTrack",
-    signature: "rotationTrack(jointName: string, keyframes: Array<{ time, rotation: [xDeg, yDeg, zDeg] }>, interp?: 'LINEAR' | 'STEP')",
-    returns: "THREE.QuaternionKeyframeTrack",
-    category: "animation",
-    description: "Rotation track in degrees, auto-converted to quaternions. Joint name must include `Joint_` prefix.",
-    example: "rotationTrack('Joint_Lid', [{ time: 0, rotation: [0, 0, 0] }, { time: 1, rotation: [90, 0, 0] }]);"
-  },
-  {
-    name: "positionTrack",
-    signature: "positionTrack(jointName: string, keyframes: Array<{ time, position: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
-    returns: "THREE.VectorKeyframeTrack",
-    category: "animation",
-    description: "Position track in world units. Always use `position:` not `value:` in keyframes.",
-    example: "positionTrack('Joint_Body', [{ time: 0, position: [0, 0, 0] }, { time: 1, position: [0, 0.1, 0] }]);"
-  },
-  {
-    name: "scaleTrack",
-    signature: "scaleTrack(jointName: string, keyframes: Array<{ time, scale: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
-    returns: "THREE.VectorKeyframeTrack",
-    category: "animation",
-    description: "Uniform or per-axis scale track.",
-    example: "scaleTrack('Joint_Chest', [{ time: 0, scale: [1, 1, 1] }, { time: 1, scale: [1.1, 1.1, 1.1] }]);"
-  },
-  {
-    name: "createClip",
-    signature: "createClip(name: string, duration: number, tracks: KeyframeTrack[])",
-    returns: "THREE.AnimationClip",
-    category: "animation",
-    description: "Collects tracks into a named clip. Returned from animate().",
-    example: "return [createClip('Open', 1, [rotationTrack('Joint_Lid', [...])])];"
-  },
-  {
-    name: "idleBreathing",
-    signature: "idleBreathing(bodyJoint: string, duration?: 2, amount?: 0.02)",
-    returns: "THREE.AnimationClip",
-    category: "animation",
-    description: "Gentle Y-axis bob. For NPC idle states.",
-    example: "return [idleBreathing('Joint_Body')];"
-  },
-  {
-    name: "bobbingAnimation",
-    signature: "bobbingAnimation(rootName: string, duration?: 2, height?: 0.1)",
-    returns: "THREE.AnimationClip",
-    category: "animation",
-    description: "Floating / bobbing loop for pickups and effects.",
-    example: "return [bobbingAnimation('Joint_Root', 1.5, 0.08)];"
-  },
-  {
-    name: "spinAnimation",
-    signature: "spinAnimation(jointName: string, duration?: 2, axis?: 'x' | 'y' | 'z')",
-    returns: "THREE.AnimationClip",
-    category: "animation",
-    description: "360° rotation over `duration` around `axis`.",
-    example: "return [spinAnimation('Joint_Rotor', 0.5, 'y')];"
-  },
-  {
-    name: "cloneGeometry",
-    signature: "cloneGeometry(geo: BufferGeometry)",
-    returns: "THREE.BufferGeometry (same ref)",
-    category: "instancing",
-    description: "Deprecated name: returns the SAME geometry, without copying. Use copyGeometry for independent vertex edits, or pass the original geometry directly for intentional sharing.",
-    example: "const wheelGeo = cylinderGeo(0.4, 0.4, 0.2, 12);"
-  },
-  {
-    name: "cloneMaterial",
-    signature: "cloneMaterial(mat: Material)",
-    returns: "THREE.Material (same ref)",
-    category: "instancing",
-    description: "Deprecated name: returns the SAME material. Use copyMaterial for independent property edits, or pass the original for intentional sharing.",
-    example: "const rubberMat = gameMaterial(0x1a1a1a, { roughness: 0.95 });"
-  },
-  {
-    name: "createInstance",
-    signature: "createInstance(name, source, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, parent })",
-    returns: "THREE.Object3D",
-    category: "instancing",
-    description: "Creates a new mesh reusing an existing part's geometry + material at a new transform. Cheapest way to replicate wheels / bolts / fence posts / windows. `rotation` is in DEGREES, like createPart.",
-    example: `const wheelFL = createPart('WheelFL', wheelGeo, rubberMat, { position: [-0.8, 0.3, 1.2], parent: root });
-createInstance('WheelFR', wheelFL, { position: [0.8, 0.3, 1.2], parent: root });
-createInstance('WheelRL', wheelFL, { position: [-0.8, 0.3, -1.2], parent: root });
-createInstance('WheelRR', wheelFL, { position: [0.8, 0.3, -1.2], parent: root });`
-  },
-  {
-    name: "boolUnion",
-    signature: "await boolUnion(name: string, ...parts: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
-    returns: "Promise<THREE.Mesh>",
-    category: "csg",
-    description: "Merges two or more parts into one watertight manifold mesh. Default flat shading (hard edges) — pass { smooth: true } as last arg for averaged normals on organic merges.",
-    example: `const body = new THREE.Mesh(boxGeo(2, 1, 1), steel);
-const turret = new THREE.Mesh(cylinderGeo(0.3, 0.3, 0.4, 16), steel);
-turret.position.y = 0.5;
-const hull = await boolUnion('Hull', body, turret);`
-  },
-  {
-    name: "boolDiff",
-    signature: "await boolDiff(name: string, body: Object3D, ...cutters: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
-    returns: "Promise<THREE.Mesh>",
-    category: "csg",
-    description: "Subtracts cutters from a body (holes, button recesses, window slots). Default flat shading for sharp mechanical edges.",
-    example: `const body = new THREE.Mesh(cylinderGeo(1, 1, 0.3, 32), steel);
-const teeth = [...]; // 8 radially-arrayed box meshes
-const gear = await boolDiff('Gear', body, ...teeth);  // hard-edged`
-  },
-  {
-    name: "roundedBoxGeo",
-    signature: "await roundedBoxGeo(width: number, height: number, depth: number, radius: number, opts?: { style?: 'round' | 'chamfer', segments?: 12, smooth?: boolean })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "csg",
-    description: "A box with all twelve edges rounded (or chamfered) at the EXACT outer size requested — roundedBoxGeo(1, 1, 1, 0.1) measures 1x1x1, it does not grow. Use it anywhere boxGeo reads too sharp: consoles, crates, appliances, handheld props, machined blocks.",
-    promptNotes: "Real objects almost never have perfectly sharp box edges, and a small radius is the single cheapest upgrade to how manufactured an asset looks. Prefer this over boxGeo for anything moulded, cast, or machined. Keep radius small relative to the box (5-10% of the smallest dimension); radius must be less than half the smallest dimension or the call throws. style: 'chamfer' reads as machined metal, 'round' as moulded plastic. This is async — build() must be async and the call must use await.",
-    example: `const geo = await roundedBoxGeo(1.2, 0.6, 0.8, 0.05);
-createPart('Console', geo, plastic, { position: [0, 0.3, 0], parent: root });`
-  },
-  {
-    name: "extrudeProfile",
-    signature: "await extrudeProfile(profile: [number, number][], opts?: { depth?: 1, holes?: [number, number][][], bevel?: 0, bevelStyle?: 'round' | 'chamfer', segments?: 12, twist?: 0, taper?: number | [number, number], divisions?: number, axis?: 'x' | 'y' | 'z', center?: true, smooth?: false })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "csg",
-    description: "Sweeps a closed 2D outline into a watertight solid, with optional holes, corner rounding/chamfering, twist, and taper. The way to build any cross-section that is not a box or a cylinder: L-brackets, I-beams, gaskets, washers, star and gear plates, signage, extruded trim.",
-    promptNotes: "The bevel rounds the edges PARALLEL to the sweep axis (the profile corners) — the two flat caps stay sharp. For a box rounded on all twelve edges use roundedBoxGeo instead. Holes are subtracted, so their winding order does not matter. A bevel larger than half the outline's narrowest feature throws rather than silently returning an empty solid. Output is manifold, so it feeds straight into boolUnion / boolDiff / boolIntersect. Async — await it inside an async build().",
-    example: `// L-bracket, inner AND outer corners filleted
-const outline = [[0, 0], [2, 0], [2, 0.4], [0.4, 0.4], [0.4, 2], [0, 2]];
-const geo = await extrudeProfile(outline, { depth: 0.5, bevel: 0.06 });
-createPart('Bracket', geo, steel, { parent: root });`
-  },
-  {
-    name: "revolveProfile",
-    signature: "await revolveProfile(profile: [number, number][], opts?: { segments?: 24, angle?: 360, bevel?: 0, bevelStyle?: 'round' | 'chamfer', bevelSegments?: 12, axis?: 'x' | 'y' | 'z', smooth?: true })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "csg",
-    description: "Revolves a closed 2D outline around an axis into a watertight SOLID, optionally rounding the profile corners first. Bottles, tanks, pressure vessels, wheels, turned wood, domes, buttons, pills.",
-    promptNotes: "Use this instead of lathe/revolveGeo whenever the result must survive a boolean or needs a rounded rim — lathe and revolveGeo build an open surface, this builds a closed solid. Profile convention matches lathe: x is distance from the axis, y is position along it, and only the x >= 0 side is used. Async — await it inside an async build().",
-    example: `// capsule tank with a rounded rim, then carve a port into it
-const profile = [[0, -0.5], [0.4, -0.5], [0.4, 0.5], [0, 0.5]];
-const body = await revolveProfile(profile, { bevel: 0.08, segments: 32 });
-const tank = await boolDiff('Tank', createPart('B', body, steel), portCutter);`
-  },
-  {
-    name: "circleProfile",
-    signature: "circleProfile(radius: number, segments?: 24, center?: [number, number])",
-    returns: "[number, number][]",
-    category: "csg",
-    description: "Builds a closed circular outline for extrudeProfile / revolveProfile, so you never hand-write the trigonometry. Synchronous.",
-    example: `const washer = await extrudeProfile(circleProfile(1), {
-  depth: 0.1,
-  holes: [circleProfile(0.4), circleProfile(0.1, 16, [0.7, 0])],
-});`
-  },
-  {
-    name: "boolIntersect",
-    signature: "await boolIntersect(name: string, a: Object3D, b: Object3D, opts?: { smooth?: false })",
-    returns: "Promise<THREE.Mesh>",
-    category: "csg",
-    description: "Keeps only the volume where both operands overlap. Default flat shading.",
-    example: "const lens = await boolIntersect('Lens', boxMesh, sphereMesh);"
-  },
-  {
-    name: "hull",
-    signature: "await hull(name: string, ...parts: Object3D[], opts?: { smooth?: true })",
-    returns: "Promise<THREE.Mesh>",
-    category: "csg",
-    description: "Tightest convex mesh enclosing all input points. Default smooth shading (rocks, collision volumes). Pass { smooth: false } for a faceted look.",
-    example: `const rockChunks = [...]; // scattered box meshes
-const rock = await hull('Rock', ...rockChunks);`
-  },
-  {
-    name: "arrayLinear",
-    signature: "arrayLinear(namePrefix, source, count, offset: [x,y,z], parent?)",
-    returns: "THREE.Object3D[]",
-    category: "arrays",
-    description: "Places N copies of `source` along a constant offset vector. Copies share geometry + material via createInstance.",
-    example: `const post = createPart('Post0', cylinderGeo(0.05,0.05,1.5,6), wood, { position: [0,0.75,0], parent: root });
-arrayLinear('Post', post, 10, [0.5, 0, 0], root);`
-  },
-  {
-    name: "arrayRadial",
-    signature: "arrayRadial(namePrefix, source, count, axis?: 'x'|'y'|'z', parent?)",
-    returns: "THREE.Object3D[]",
-    category: "arrays",
-    description: "Places N copies of `source` around the given axis. Source's local rotation is oriented outward. Perfect for gear teeth, radial bolts, circle of columns.",
-    example: `const bolt = createPart('Bolt0', cylinderGeo(0.02,0.02,0.1,6), steel, { position: [1,0,0], parent: root });
-arrayRadial('Bolt', bolt, 8, 'y', root);`
-  },
-  {
-    name: "mirror",
-    signature: "mirror(name, source, axis: 'x'|'y'|'z', parent?)",
-    returns: "THREE.Object3D",
-    category: "arrays",
-    description: "Reflects source across the plane whose normal is `axis`. Uses negative scale (winding flip handled by viewers).",
-    example: "mirror('WingR', wingL, 'x', root);"
-  },
-  {
-    name: "subdivide",
-    signature: "subdivide(geometry: BufferGeometry, iterations?: 1, opts?: { preserveUV?: boolean, split?: boolean, uvSmooth?: boolean, preserveEdges?: boolean, flatOnly?: boolean, weld?: boolean })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Loop subdivision returns new geometry; each iteration roughly quadruples triangles and smooths the surface. Use preserveUV:true for textured meshes. Legacy position-only welding discards UVs and reports that loss. This smooths shapes, not selected-edge beveling.",
-    example: "const smoothRock = subdivide(boxGeo(1, 1, 1), 2);"
-  },
-  {
-    name: "mergeVertices",
-    signature: "mergeVertices(geometry: BufferGeometry, opts?: { tolerance?: 1e-4, positionOnly?: boolean } | number)",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Returns indexed geometry. Default welding preserves attribute seams, so a textured cube retains separate face corners. positionOnly:true welds coincident positions and discards other attributes; use it explicitly when changing topology and regenerate shading/UVs afterward.",
-    example: `const welded = mergeVertices(boxGeo(1, 1, 1), { positionOnly: true });
-const rock = displace(subdivide(welded, 2), ([x,y,z]) => [0.08*Math.sin(y*7+z*3), 0.04*Math.sin(x*9), 0]);`
-  },
-  {
-    name: "curveToMesh",
-    signature: "curveToMesh(points: [x,y,z][], radius, tubularSegs?: 32, radialSegs?: 8, closed?: false)",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Sweeps a circular profile along a path. Equivalent to Blender's Curve to Mesh node with a circle profile. Use for pipes, cables, tubular frames.",
-    example: "const pipe = curveToMesh([[0,0,0],[0,1,0],[1,1,0],[1,2,0]], 0.1);"
-  },
-  {
-    name: "pipeAlongPath",
-    signature: "pipeAlongPath(points: [x,y,z][], radius: number, opts?: { bendRadius?: 0, closed?: false, tubularSegments?: 32, radialSegments?: 8 })",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Path-driven swept circle with optional bend smoothing. Generalises beamBetween (point-to-point) and curveToMesh (raw spline) into one helper. bendRadius>0 inserts interpolated waypoints near interior corners so the spline reads as a rounded turn instead of pinching to the control point.",
-    example: "const cable = pipeAlongPath([[0, 0.5, 0], [1, 0.5, 0], [1, 0.5, 2]], 0.02, { bendRadius: 0.1 });"
-  },
-  {
-    name: "lathe",
-    signature: "lathe(profile: [x,y][], segments?: 12)",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Surface of revolution. Spins a 2D profile around the Y axis. For bottles, vases, wheels, turned wood parts.",
-    example: "const vase = lathe([[0.1,0],[0.3,0.5],[0.2,1],[0.1,1.2]], 16);"
-  },
-  {
-    name: "revolveGeo",
-    signature: "revolveGeo(profile: [x,y][], opts?: { angle?: 2π, axis?: [x,y,z]=[0,1,0], segments?: 12 })",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Surface of revolution with explicit axis + sweep angle. Generalises lathe — use it when you need a partial sweep (half-dome, 90° wedge) or revolution around a non-Y axis. Profile convention is identical to lathe: x = radial distance, y = position along the axis.",
-    example: `// Half-dome (180° sweep around +Y):
-const quarter = [...Array(8)].map((_, i) => { const t = (i/7)*Math.PI/2; return [Math.cos(t), Math.sin(t)] as [number, number]; });
-const dome = revolveGeo(quarter, { angle: Math.PI });`
-  },
-  {
-    name: "bezierCurve",
-    signature: "bezierCurve(controlPoints: [x,y,z][], samples?: 32)",
-    returns: "[x,y,z][]",
-    category: "curves",
-    description: "Samples a quadratic (3 ctrl pts) or cubic (4 ctrl pts) Bézier into a point list you can feed into curveToMesh.",
-    example: `const path = bezierCurve([[0,0,0],[1,2,0],[3,2,0],[4,0,0]], 24);
-const geo = curveToMesh(path, 0.1);`
-  },
-  {
-    name: "autoUnwrap",
-    signature: "await autoUnwrap(geometry: BufferGeometry, opts?: { resolution?: 1024, padding?: 2, useNormals?: false })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "uv",
-    description: "xatlas-based UV atlas for ANY geometry (CSG output, subdivided, deformed). Output is a packed atlas with arbitrary per-chart rotation — use for non-tileable baked textures. For directional tileable textures on box/cylinder/plane primitives, prefer the shape-aware unwraps below.",
-    example: `const unwrapped = await autoUnwrap(someCsgResult, { resolution: 1024 });
-const mesh = new THREE.Mesh(unwrapped, bakedPbr);`
-  },
-  {
-    name: "boxUnwrap",
-    signature: "boxUnwrap(geometry: BufferGeometry)",
-    returns: "THREE.BufferGeometry",
-    category: "uv",
-    description: "Preserves BoxGeometry's built-in per-face UVs — every face maps [0,1] with consistent orientation. Use for crates/blocks with a tileable texture. Sync; no WASM cost.",
-    example: `const crate = boxUnwrap(boxGeo(1, 1, 1));
-const mesh = new THREE.Mesh(crate, pbrMaterial({ albedo: planksTex }));`
-  },
-  {
-    name: "cylinderUnwrap",
-    signature: "cylinderUnwrap(geometry: BufferGeometry)",
-    returns: "THREE.BufferGeometry",
-    category: "uv",
-    description: "Preserves CylinderGeometry's built-in UVs: u wraps around the axis (horizontal texture features ring the cylinder), v runs up the height. Caps use circle-in-square. Sync; no WASM cost.",
-    example: `const barrel = cylinderUnwrap(cylinderGeo(0.5, 0.5, 1.2, 24));
-const mesh = new THREE.Mesh(barrel, pbrMaterial({ albedo: bandsTex }));`
-  },
-  {
-    name: "planeUnwrap",
-    signature: "planeUnwrap(geometry: BufferGeometry)",
-    returns: "THREE.BufferGeometry",
-    category: "uv",
-    description: "Projects xy-extent of the bbox to [0,1]. Use for signs/decals/posters where you want ONE readable texture and no edge-face bleeding. Sync.",
-    example: `const sign = planeUnwrap(planeGeo(1, 0.6));
-const mesh = new THREE.Mesh(sign, pbrMaterial({ albedo: kilnTextTex }));`
-  },
-  {
-    name: "panelRemapV",
-    signature: "panelRemapV(geo, vScale=0.30, vOffset=0, uScale=1, uOffset=0)",
-    returns: "THREE.BufferGeometry",
-    category: "uv",
-    description: "Scales an existing UV attribute so a small mesh samples a sub-region of a SHARED texture. Replaces the broken texture.clone() pattern (Three.js Texture.clone() runs JSON.stringify on userData, mangling encoded PNG bytes — panelRemapV avoids that by remapping UVs on the geometry instead). Typical use: multi-zone albedo where v=0..0.30 is plain panel and v=0.30..1 has windows/markings — small parts call panelRemapV(unwrap(geo), 0.30) to sample only the clean strip.",
-    example: `const cowlGeo = panelRemapV(cylinderUnwrap(capsuleXGeo(0.45, 1.0)), 0.30);
-const cowl = new THREE.Mesh(cowlGeo, bodyMat); // SAME bodyMat as fuselage, no clone needed`
-  },
-  {
-    name: "loadApprovedTexture",
-    signature: "await loadApprovedTexture(resourceId)",
-    returns: "Promise<THREE.DataTexture>",
-    category: "textures",
-    description: "Loads one approved kiln.texture.* resource ID through the host-injected closed resolver. The registry fixes bytes, MIME, usage, dimensions, hash, and deadline; paths, URLs, byte arrays, resolver objects, hashes, and options are rejected.",
-    example: "const bark = await loadApprovedTexture('kiln.texture.bark-brown-01-albedo.v1');",
-    promptNotes: "Use only a concrete resource ID listed in material capabilities; never invent one. Prefer materialRecipe when a recipe already binds the family, or proceduralTexture V2 for authored surfaces. NEVER texture.clone() a loaded texture (clone() corrupts encoded bytes and breaks GLB export)."
-  },
-  {
-    name: "proceduralTexture",
-    signature: "proceduralTexture({ schemaVersion: 2, size?: 4..1024 pow2, usage?, name?, layers: [{ op: 'solid'|'checker'|'stripes'|'gradient'|'bricks'|'noise', ...params, blend?: 'normal'|'multiply'|'screen'|'overlay', opacity?: 0..1 }] })",
-    returns: "THREE.DataTexture (tiling, sRGB or linear per usage)",
-    category: "textures",
-    description: "Builds a tiling texture from a bounded layer stack — no image file needed. Layers composite bottom-first. Noise is seeded and tileable, so the same spec always produces the same bytes and a repeating material shows no seam. Baked to PNG and embedded in the GLB automatically.",
-    example: "const bark = proceduralTexture({ schemaVersion: 2, size: 256, usage: 'albedo', name: 'Bark', layers: [{ op: 'solid', color: 0x5a4632 }, { op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4, blend: 'overlay' }] });",
-    promptNotes: "Sync — no await. Strict V2 JSON boundary: unknown/prototype keys, callbacks, paths, URLs, and shader source are rejected. Prefer this over approved resources for describable surfaces. Max 8 layers, power-of-two size up to 1024. Only the six listed ops exist."
-  },
-  {
-    name: "normalMapFromHeight",
-    signature: "normalMapFromHeight(source: THREE.Texture, { strength?: number, name?: string })",
-    returns: "THREE.DataTexture (linear normal map)",
-    category: "textures",
-    description: "Derives a tangent-space normal map from the source texture's brightness, treating it as height. The cheap way to get real PBR surface relief out of a procedural albedo. Wraps at the edges, so a tiling source gives a tiling normal map.",
-    example: `const bark = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4 }] });
-const mat = pbrMaterial({ albedo: bark, normal: normalMapFromHeight(bark, { strength: 4 }) });`,
-    promptNotes: "strength 1 is subtle, 4-8 reads clearly at normal viewing distance. Output is always linear data — never assign it to an albedo/emissive slot."
-  },
-  {
-    name: "pbrMaterial",
-    signature: "pbrMaterial({ albedo?, normal?, roughness?, metalness?, metallicRoughness?, emissive?, aoMap?, alphaMode?, alphaCutoff?, doubleSided? })",
-    returns: "THREE.MeshStandardMaterial",
-    category: "material",
-    description: "Portable glTF PBR material. Use an explicit packed metallicRoughness texture (G=roughness, B=metalness); separate data maps are rejected instead of silently dropping a channel. Supports OPAQUE/MASK/BLEND and double-sided output.",
-    example: `const wood = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x4f301c, colorB: 0x9a6b3e, scale: 8, octaves: 3, seed: 4 }] });
-const crate = pbrMaterial({ albedo: wood, roughness: 0.85, metalness: 0 });`
-  },
-  {
-    name: "foliageMaterial",
-    signature: "foliageMaterial(albedo, { alphaCutoff?, roughness?, doubleSided? })",
-    returns: "THREE.MeshStandardMaterial",
-    category: "material",
-    description: "Portable foliage material that defaults to glTF MASK, cutoff 0.5, rough nonmetal, and double-sided. Use an alpha-bearing albedo texture.",
-    example: "const mat = await materialRecipe('kiln.material.leaf.v1');"
-  },
-  {
-    name: "countTriangles",
-    signature: "countTriangles(root: Object3D)",
-    returns: "number",
-    category: "utility",
-    description: "Sums triangle count across every mesh in the subtree.",
-    example: "meta.tris = countTriangles(root);"
-  },
-  {
-    name: "countMaterials",
-    signature: "countMaterials(root: Object3D)",
-    returns: "number",
-    category: "utility",
-    description: "Unique material count (by reference) across the subtree.",
-    example: "const mats = countMaterials(root);"
-  },
-  {
-    name: "getJointNames",
-    signature: "getJointNames(root: Object3D)",
-    returns: "string[]",
-    category: "utility",
-    description: "All node names beginning with `Joint_`. Use to sanity-check animation targets.",
-    example: "const joints = getJointNames(root);"
-  },
-  {
-    name: "validateAsset",
-    signature: "validateAsset(root: Object3D, category: 'character' | 'prop' | 'vfx' | 'environment' | 'architecture' | 'vegetation' | 'vehicle')",
-    returns: "{ valid, errors, warnings }",
-    category: "utility",
-    description: "Checks geometry and material costs for the selected category. No default triangle limit; choose detail for the intended runtime and inspect measured draw calls.",
-    example: "const v = validateAsset(root, 'prop');"
-  }
-];
-function listPrimitives() {
-  return PRIMITIVES.map((p) => ({ ...p }));
-}
+// src/prompt.ts
+init_list_primitives();
 
 // src/prompt-api.ts
 var CATEGORY_HEADERS = [
@@ -28167,6 +28280,7 @@ import { z as z2 } from "zod";
 var refInput = z2.string().regex(programRefPattern).describe("Returned p_ handle or full sha256 ref.");
 
 // src/tools/discovery.ts
+init_list_primitives();
 import { z as z3 } from "zod";
 init_protocol();
 init_capture_limits();
@@ -28233,10 +28347,12 @@ class MemoryBuildCache {
 
 // src/tools/registry.ts
 init_validation();
+init_protocol();
 init_render();
-import * as THREE35 from "three";
+init_list_primitives();
 init_evaluator();
 init_material_resources();
+import * as THREE35 from "three";
 
 // src/edit-buffer.ts
 class KilnDraftBuffer {
@@ -28827,6 +28943,17 @@ function collectSceneMetrics(root) {
   }
   return { meshes, materials: materialSet.size, bbox, lowestPart };
 }
+function withSyntaxDetail(message, code) {
+  if (!message.startsWith(evaluatorOutcomeMessage("EXECUTION_REJECTED")))
+    return message;
+  let syntax;
+  try {
+    syntax = validate(code).errors.find((error) => error.startsWith("Syntax error:"));
+  } catch {
+    return message;
+  }
+  return syntax ? `${message} ${syntax}` : message;
+}
 async function runRender(input, context) {
   try {
     const { root, rendered } = await loadEvaluatedReviewScene(input.code, context);
@@ -28845,6 +28972,7 @@ async function runRender(input, context) {
       tris: rendered.tris,
       meshes: metrics.meshes,
       materials: metrics.materials,
+      ...rendered.meta.instanceability ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials } : {},
       bbox: metrics.bbox,
       lowestPart: metrics.lowestPart,
       ...instanceability ? {
@@ -28859,7 +28987,7 @@ async function runRender(input, context) {
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: []
     };
   }
@@ -28883,7 +29011,7 @@ async function runScreenshot(input, context) {
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: []
     };
   }
@@ -28916,6 +29044,7 @@ async function runRenderViews(input, context) {
         tris: rendered.tris,
         meshes: metrics.meshes,
         materials: metrics.materials,
+        ...rendered.meta.instanceability ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials } : {},
         bbox: metrics.bbox,
         lowestPart: metrics.lowestPart,
         views: grid2.views,
@@ -29012,6 +29141,7 @@ async function runRenderViews(input, context) {
       tris: rendered.tris,
       meshes: metrics.meshes,
       materials: metrics.materials,
+      ...rendered.meta.instanceability ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials } : {},
       bbox: metrics.bbox,
       lowestPart: metrics.lowestPart,
       ...rendered.meta.instanceability ? {
@@ -29035,7 +29165,7 @@ async function runRenderViews(input, context) {
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: []
     };
   }

--- a/dist/build.json
+++ b/dist/build.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "entries": {
     "mcp": {
-      "identity": "sha256:23ec3588dd0208ab28858afb8ab9f42ab350a416d5743252e6c49535a2a88094",
+      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "74be9350cb13fe199f9bc54bfeba6f9f4482424fb12b6fe5e788a14ed3c097b5",
+      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",
@@ -27,13 +27,13 @@
       },
       "target": "node",
       "file": "mcp-server.mjs",
-      "bundleHash": "sha256:b97a72e1c1c791e9273fe3b9ee276cc6d19b264d2c152c40af6c1871fe5f4770"
+      "bundleHash": "sha256:addada60e499bc4394c047ec3c04065c3c9d068539ecdc9b2007c177baac350f"
     },
     "cli": {
-      "identity": "sha256:23ec3588dd0208ab28858afb8ab9f42ab350a416d5743252e6c49535a2a88094",
+      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "74be9350cb13fe199f9bc54bfeba6f9f4482424fb12b6fe5e788a14ed3c097b5",
+      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",
@@ -55,13 +55,13 @@
       },
       "target": "node",
       "file": "cli.mjs",
-      "bundleHash": "sha256:4d73ef2f0f79a0f74599c560137ecd20d975c2143569b6506d4e89b5eb2a91e3"
+      "bundleHash": "sha256:9b152ea485159e4feee717a3d860f5f962cd108018dc215466f68d506702bbd1"
     },
     "worker": {
-      "identity": "sha256:23ec3588dd0208ab28858afb8ab9f42ab350a416d5743252e6c49535a2a88094",
+      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "74be9350cb13fe199f9bc54bfeba6f9f4482424fb12b6fe5e788a14ed3c097b5",
+      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",
@@ -83,13 +83,13 @@
       },
       "target": "node",
       "file": "evaluator-worker.mjs",
-      "bundleHash": "sha256:d8fa92970ab9f09634a4f5dbfef3b0709998500e0ac4df618eeb0a08ec90c3e0"
+      "bundleHash": "sha256:bb463f3b33b7474ed8f2c0626fa4bde8c64101182b11aac042491f7077e6cbdd"
     },
     "agent-run": {
-      "identity": "sha256:23ec3588dd0208ab28858afb8ab9f42ab350a416d5743252e6c49535a2a88094",
+      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "74be9350cb13fe199f9bc54bfeba6f9f4482424fb12b6fe5e788a14ed3c097b5",
+      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",
@@ -111,13 +111,13 @@
       },
       "target": "node",
       "file": "agent-run.mjs",
-      "bundleHash": "sha256:0d69f758083673b6e2640bb3a45a021ef640fce277dfbe05a0154a51dda82d05"
+      "bundleHash": "sha256:4966a3d3fff0ca42fc8b77e2c0d5bf07af5966adb5fe80a67b3d0285325badf7"
     },
     "agent-providers": {
-      "identity": "sha256:23ec3588dd0208ab28858afb8ab9f42ab350a416d5743252e6c49535a2a88094",
+      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "74be9350cb13fe199f9bc54bfeba6f9f4482424fb12b6fe5e788a14ed3c097b5",
+      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",

--- a/dist/cli.mjs
+++ b/dist/cli.mjs
@@ -31,7 +31,7 @@ function rethrowAuthoringError(error) {
   }
   throw error;
 }
-var UNBOUND_VARIABLE_ADVICE = "Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying.", GEAR_RADII_ORDER_ADVICE = "gearGeo requires boreRadius < rootRadius < tipRadius; specify rootRadius when changing tipRadius. Omitted radii keep their absolute defaults.", ROUNDED_BOX_RADIUS_ADVICE = "roundedBoxGeo: radius must be less than half the smallest dimension. Reduce radius or increase the smallest dimension; equality is invalid.", AuthoringDiagnosticError;
+var UNBOUND_VARIABLE_ADVICE = "Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying. If it was meant to be a Kiln helper, call kiln_list_primitives to confirm the exact name and signature; the sandbox exposes only those globals.", GEAR_RADII_ORDER_ADVICE = "gearGeo requires boreRadius < rootRadius < tipRadius; specify rootRadius when changing tipRadius. Omitted radii keep their absolute defaults.", ROUNDED_BOX_RADIUS_ADVICE = "roundedBoxGeo: radius must be less than half the smallest dimension. Reduce radius or increase the smallest dimension; equality is invalid.", AuthoringDiagnosticError;
 var init_authoring_diagnostic = __esm(() => {
   AuthoringDiagnosticError = class AuthoringDiagnosticError extends Error {
     diagnostic;
@@ -17965,6 +17965,928 @@ var init_texture_resolver = __esm(() => {
   DEFAULT_TEXTURE_RESOLVER = createTextureResolver();
 });
 
+// src/geometry-catalog.ts
+var geometryPrimitives;
+var init_geometry_catalog = __esm(() => {
+  geometryPrimitives = [
+    {
+      name: "copyGeometry",
+      signature: "copyGeometry(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "instancing",
+      description: "Returns an independent geometry with copied vertex buffers. Use before direct mutation of a cached primitive.",
+      example: "const editable = copyGeometry(boxGeo(1, 1, 1)); editable.translate(0, 0.5, 0);"
+    },
+    {
+      name: "copyMaterial",
+      signature: "copyMaterial(material: Material)",
+      returns: "THREE.Material (same subtype)",
+      category: "instancing",
+      description: "Copies material properties so edits do not change other parts. Referenced textures remain shared.",
+      example: "const red = copyMaterial(steel); red.color.set(0xaa2222);"
+    },
+    {
+      name: "meshGeo",
+      signature: "meshGeo({ positions: number[], indices?: number[], normals?: number[], uvs?: number[], tangents?: number[] })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Builds an owned triangle mesh from flat numeric arrays. Validates finite values, attribute lengths and indices; computes normals if absent. Counterclockwise winding.",
+      example: "const triangle = meshGeo({ positions: [0,0,0, 1,0,0, 0,1,0], indices: [0,1,2] });"
+    },
+    {
+      name: "parametricSurface",
+      signature: "parametricSurface(sample: (u,v) => [x,y,z], opts?: { u?: [0,1], v?: [0,1], uSegments?: 24, vSegments?: 24, periodicU?: false, periodicV?: false, orientation?: 'uv'|'vu' })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Samples an equation into an owned surface with UVs. Periodic endpoints must coincide; UV seams retain matching normals. A surface is not automatically a watertight solid.",
+      example: "const canopy = parametricSurface((u,v) => [u, 0.3*Math.sin(u*3)*Math.cos(v*2), v], { u: [-2,2], v: [-1,1] });"
+    },
+    {
+      name: "geometryDiagnostics",
+      signature: "geometryDiagnostics(geometry: BufferGeometry, tolerance?: 1e-6)",
+      returns: "{ vertices, triangles, boundaryEdges, nonManifoldEdges, orientationConflicts, degenerateTriangles, invalidIndices, nonFiniteVertices }",
+      category: "utility",
+      description: "Counts mesh topology problems after position-based seam matching. Open boundaries are valid for sheets; closed edges alone do not prove a self-intersection-free solid.",
+      example: "const topology = geometryDiagnostics(shell);"
+    },
+    {
+      name: "creaseNormals",
+      signature: "creaseNormals(geometry: BufferGeometry, opts?: { angle?: 60, tolerance?: number })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Returns owned geometry with angle-limited smooth normals, preserving UV corners. Angle is degrees. Invalidates tangents; use after shaping for sharp rims and smooth walls.",
+      example: "const shell = creaseNormals(cylinderGeo(1,1,2,32), { angle: 45 });"
+    },
+    {
+      name: "bend",
+      signature: "bend(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Bends local +Y toward +X through angle degrees. Returns owned geometry and updated normals/bounds; preserves UVs, invalidates tangents. Frame rotation is Euler XYZ degrees.",
+      promptNotes: "Deformation interval uses local Y distances; outside vertices stay unchanged. Add enough segments before bending. Falloff returns 0..1; use it to avoid a discontinuity at a selected interval boundary.",
+      example: "const arch = bend(planeGeo(1,4,4,32), { angle: 90 });"
+    },
+    {
+      name: "twist",
+      signature: "twist(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Rotates the cross-section progressively around local +Y, reaching angle degrees at the end. Returns owned geometry; frame rotation uses Euler XYZ degrees.",
+      example: "const spiral = twist(column, { angle: 120 });"
+    },
+    {
+      name: "taper",
+      signature: "taper(geometry, { startScale?: [1,1], endScale: [x,z], frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Scales local X/Z across the local Y interval using positive start/end scale pairs. Returns owned geometry; preserves UVs and invalidates tangents.",
+      example: "const narrowed = taper(column, { endScale: [0.4,0.7] });"
+    },
+    {
+      name: "displace",
+      signature: "displace(geometry, offset: ([x,y,z], t) => [dx,dy,dz], opts?: { frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Adds an authored displacement vector in the chosen local frame. Returns owned geometry; callback coordinates are local and t is normalized along the interval.",
+      example: "const rippled = displace(surface, ([x,y,z]) => [0, 0.1*Math.sin(x*8), 0]);"
+    },
+    {
+      name: "sweepProfile",
+      signature: "sweepProfile(profile: [x,z][], path: [x,y,z][], opts?: { cap?: true, closed?: false, up?: [x,y,z], twist?: 0, scale?: number | [x,z][] })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Sweeps a simple noncircular profile along polyline stations using transported frames. Supports total twist in degrees and per-station scales. Generates UVs and optional caps.",
+      promptNotes: "First version supports one simple profile without holes. Closed paths omit the repeated endpoint and require twist to be a multiple of 360. up sets the initial profile +Z direction and cannot parallel the path. Tight-turn warnings do not replace visual inspection for self-intersections.",
+      example: "const rail = sweepProfile([[-.1,-.2],[.1,-.2],[.1,.2],[-.1,.2]], [[0,0,0],[0,1,0],[1,2,0]]);"
+    },
+    {
+      name: "loftProfiles",
+      signature: "loftProfiles(sections: { profile: [x,z][], frame?: { origin, rotation } }[], opts?: { cap?: true })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Joins corresponding simple profiles in explicit local XZ planes. Each frame uses Euler XYZ degrees and local +Y along the loft. Profiles need equal point counts and corresponding vertices.",
+      promptNotes: "No holes or automatic profile correspondence. Opposite winding is normalized while preserving the first point. Caps close boundaries but do not prove the loft has no self-intersections.",
+      example: "const hull = loftProfiles([{ profile: wide }, { profile: narrow, frame: { origin: [0,2,0] } }]);"
+    },
+    {
+      name: "implicitSurface",
+      signature: "await implicitSurface(sample: ([x,y,z]) => signedValue, { bounds: { min, max }, edgeLength, maxCells?: 1000000, maxEvaluations?: 8000000, level?: 0, tolerance?: -1, smooth?: true })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "geometry",
+      description: "Experimental positive-inside implicit field sampled into a solid mesh. Requires explicit bounds and resolution; checks grid size and actual evaluation count. Output has no UVs.",
+      promptNotes: "Use async build and await. Smaller edgeLength increases cost sharply. This helper cannot stop a callback that never returns; the host evaluator process provides that boundary. Thin features and geometric accuracy require inspection.",
+      example: "const blob = await implicitSurface(([x,y,z]) => 1-Math.hypot(x,y,z), { bounds: { min: [-1.2,-1.2,-1.2], max: [1.2,1.2,1.2] }, edgeLength: 0.15 });"
+    }
+  ];
+});
+
+// src/list-primitives.ts
+function listPrimitives() {
+  return PRIMITIVES.map((p) => ({ ...p }));
+}
+var PRIMITIVES;
+var init_list_primitives = __esm(() => {
+  init_geometry_catalog();
+  PRIMITIVES = [
+    ...geometryPrimitives,
+    {
+      name: "createRoot",
+      signature: "createRoot(name: string)",
+      returns: "THREE.Object3D",
+      category: "structure",
+      description: "Creates the root Object3D for an asset. Call first in build().",
+      example: "const root = createRoot('FuelDrum');"
+    },
+    {
+      name: "createPivot",
+      signature: "createPivot(name: string, position?: [x, y, z], parent?: Object3D)",
+      returns: "THREE.Object3D (prefixed `Joint_`)",
+      category: "structure",
+      description: "Creates an empty pivot node for skeletal animation. Name is auto-prefixed with `Joint_`.",
+      example: "const hip = createPivot('Hip', [0, 1, 0], root);"
+    },
+    {
+      name: "createJointChain",
+      signature: "createJointChain(name, segments: { role, offset, aliases?, side?, localForwardAxis?, localBendAxis?, endEffector?, contact? }[], opts?: { parent?, parentRole? })",
+      returns: "{ root, end, nodes, byRole, descriptors }",
+      category: "structure",
+      description: "Creates one body-plan-neutral deterministic Joint_* chain with explicit parent edges, rest frames, local axes, end effectors, contacts, and semantic metadata.",
+      example: "const leg = createJointChain('LegL', [{ role: 'hip.left', offset: [0, 1, -0.2], side: 'left' }, { role: 'knee.left', offset: [0, -0.5, 0], side: 'left' }, { role: 'ankle.left', offset: [0, -0.5, 0], side: 'left', endEffector: true, contact: true }], { parent: root });",
+      promptNotes: "Use only the resolved body-plan graph. Offsets are local to the previous joint; contact end effectors must land at world Y=0."
+    },
+    {
+      name: "createVehicleFrame",
+      signature: "createVehicleFrame(name, opts?: { chassis?, axles?, seats?, contacts?, steering?, propulsion?, parent? })",
+      returns: "{ root, chassis, axles, seats, contacts, steering, propulsion }",
+      category: "structure",
+      description: "Creates a canonical +X-forward/+Y-up/+Z-right vehicle frame with typed semantic sockets for chassis, support, steering, and propulsion.",
+      example: "const frame = createVehicleFrame('CarFrame', { axles: [{ id: 'front', position: [1.2, 0.45, 0] }, { id: 'rear', position: [-1.2, 0.45, 0] }], parent: root });",
+      promptNotes: "Generated vehicles keep +X as front. Boats and other non-wheeled subtypes use declared support/propulsion sockets, not wheel rules."
+    },
+    {
+      name: "createWheelGeometrySet",
+      signature: "createWheelGeometrySet(radius: number, width: number)",
+      returns: "{ tire, rim, hub } shared THREE.BufferGeometry set",
+      category: "instancing",
+      description: "Creates one reusable +Z-axle tire/rim/hub geometry set for instanced wheel assemblies.",
+      example: "const wheelGeo = createWheelGeometrySet(0.45, 0.22);"
+    },
+    {
+      name: "createWheelAssembly",
+      signature: "createWheelAssembly(name, { tire, rim, hub? }, { radius, width, side, index, position?, rimRadius?, hubRadius?, steering?, loadBearing?, geometries?, parent? })",
+      returns: "{ root, steeringPivot?, spinPivot, tire, rim, hub, contact, radius, width, side, index, spinAxis }",
+      category: "structure",
+      description: "Creates one axle-centered wheel pivot containing concentric tire/rim/hub roles, a contact marker, +Z spin frame, and optional steering pivot.",
+      example: "createWheelAssembly('FrontLeft', { tire: rubber, rim: metal }, { radius: 0.45, width: 0.22, side: 'left', index: 'front', position: [1.2, 0.45, -0.9], steering: true, geometries: wheelGeo, parent: frame.root });",
+      promptNotes: "Keep tire, rim, and hub descendants concentric at the axle pivot. Reuse one geometry set across matching wheels."
+    },
+    {
+      name: "createPart",
+      signature: "createPart(name, geometry, material, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, pivot, parent })",
+      returns: "THREE.Object3D (mesh or wrapping pivot)",
+      category: "structure",
+      description: "Creates a mesh, optionally wrapped in a pivot, and attaches it to `opts.parent`. `rotation` is in DEGREES (like rotationTrack), NOT radians: [0, 0, 90] is a quarter turn; [0, 0, 1.57] is a no-op.",
+      example: "createPart('Barrel', cylinderGeo(0.1, 0.1, 1), gameMaterial(0x556b2f), { position: [0, 0.5, 0], rotation: [0, 0, 90], parent: root });",
+      promptNotes: "AUTO-ADDS to opts.parent. NEVER call parent.add(createPart(...)) — pass { parent } instead. rotation is DEGREES — writing radians (e.g. 0.785 or Math.PI/4) silently produces ~zero rotation."
+    },
+    {
+      name: "beamBetween",
+      signature: "beamBetween(name, start: [x,y,z], end: [x,y,z], radius, material, opts?: { segments, parent })",
+      returns: "THREE.Object3D (prefixed `Mesh_`)",
+      category: "structure",
+      description: "Creates a cylindrical rail/strut exactly between two endpoints. Use for braces, gun barrels, skid struts, cables, and scaffolding.",
+      example: "beamBetween('SkidBraceA', [0.8, 0.3, 0.7], [0.8, 1.0, 0.45], 0.025, black, { parent: root });"
+    },
+    {
+      name: "snapTo",
+      signature: "snapTo(part: Object3D, host: Object3D, opts?: { axis?: 'x'|'y'|'z', overlap?: 0.02 })",
+      returns: "THREE.Object3D (the part, for chaining)",
+      category: "structure",
+      description: 'Translates `part` by the minimal vector that brings its bounding box into contact with `host` (plus a small overlap). The direct cure for a "Floating parts" warning — attach the part instead of eyeballing a corrective offset. No-op if they already touch.',
+      example: `const scope = createPart('Scope', cylinderXGeo(0.04, 0.04, 0.3), steel, { parent: root, position: [0.1, 0.32, 0] });
+snapTo(scope, receiver);`
+    },
+    {
+      name: "createLadder",
+      signature: "createLadder(name, { bottom, top, material, width?, rungCount?, railRadius?, rungRadius?, widthAxis?, parent? })",
+      returns: "{ leftRail: Object3D, rightRail: Object3D, rungs: Object3D[] }",
+      category: "structure",
+      description: "Builds two continuous rails plus evenly-spaced rungs. Use this instead of loose boxes for ladders.",
+      example: "createLadder('TowerLadder', { bottom: [0,0,0], top: [0,2.2,0], width: 0.45, rungCount: 7, material: steel, parent: root });"
+    },
+    {
+      name: "createWingPair",
+      signature: "createWingPair(name, material, { rootZ, span, rootChord, tipChord, sweep?, thickness?, dihedral?, rootX?, rootY?, parent? })",
+      returns: "{ right: Object3D, left: Object3D }",
+      category: "structure",
+      description: "Creates mirrored trapezoid aircraft wings with roots attached at +/-rootZ. Use for aircraft wings and helicopter stub wings.",
+      example: "createWingPair('MainWing', olive, { rootX: 0, rootY: 1.0, rootZ: 0.42, span: 2.4, rootChord: 0.9, tipChord: 0.35, sweep: 0.25, dihedral: 0.08, parent: root });"
+    },
+    {
+      name: "room",
+      signature: "room(name, material, { width?, depth?, height?, wallThickness?, floor?, floorThickness?, openings?: [{ wall: 'front'|'back'|'left'|'right', kind?: 'door'|'window', offset?, width?, height?, sill? }], parent? })",
+      returns: "{ root: Object3D, walls: { front, back, left, right }, floor: Object3D | null }",
+      category: "structure",
+      description: "Builds a HOLLOW, enterable room: four thin walls + a floor, human-scaled (defaults: 2.8m ceiling, a centered 1.1x2.1m front door so it is enterable by default). `front` faces +X; the floor sits on the ground. The keystone of an architecture asset — add a roof with createRoofPlanes and fixtures as separate parts.",
+      example: "const { root: hut } = room('Hut', wood, { width: 5, depth: 4, height: 2.8, openings: [{ wall: 'front', kind: 'door' }, { wall: 'right', kind: 'window' }], parent: root });",
+      promptNotes: "Use for any building the player enters. Do NOT model a building as a solid block — room() guarantees real interior space and a doorway gap. Pass openings to add windows / side doors."
+    },
+    {
+      name: "wallWithOpening",
+      signature: "wallWithOpening(name, material, { length, height, thickness, axis?: 'x'|'z', opening?: { kind?: 'door'|'window', offset?, width?, height?, sill? }, parent? })",
+      returns: "THREE.Object3D (wall container)",
+      category: "structure",
+      description: "A single wall panel with an optional real door/window cut, composed from solid box segments (side panels + lintel + window sill) — no CSG. Base at local Y=0, centered on the run axis. Use to compose custom building layouts or interior dividing walls beyond the default room().",
+      example: "wallWithOpening('Partition', plaster, { length: 4, height: 2.8, thickness: 0.12, axis: 'x', opening: { kind: 'door', offset: 0.5 }, parent: root });"
+    },
+    {
+      name: "createRoofPlanes",
+      signature: "createRoofPlanes(name, material, { width, depth, height, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
+      returns: "{ root: Object3D, slopes: [Object3D, Object3D] }",
+      category: "structure",
+      description: "A pitched roof: two thin slopes meeting at one ridge and falling DOWN-AND-OUTWARD (opposite tilts — never mirrored the same way), footprint-matched with an eave overhang. Eave at local Y=0, ridge at Y=height, so position the group at Y=wallHeight. Returns a named group (e.g. `Roof`) the engine can lift to reveal the interior.",
+      example: `const { root: roof } = createRoofPlanes('Roof', shingle, { width: 5, depth: 4, height: 1.6, overhang: 0.4, ridgeAxis: 'x', parent: root });
+roof.position.y = 2.8;`,
+      promptNotes: "The two slopes must fall AWAY from each other from the ridge — createRoofPlanes does this for you. Drop it onto the walls (position.y = wall height)."
+    },
+    {
+      name: "createGableRoof",
+      signature: "createGableRoof(name, material, { spanX, spanZ, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
+      returns: "{ root, slopes: [Object3D, Object3D], faces: [RoofFaceFrame, RoofFaceFrame], rise, pitchDegrees }",
+      category: "structure",
+      description: "Explicit-axis gable roof using unambiguous footprint spans. Each face owns a rigid frame with ridge tangent, outward normal, downhill direction, ridge/eave endpoints, dimensions, and a live local-to-world transform.",
+      example: "const roof = createGableRoof('Roof', shingles, { spanX: 8, spanZ: 5, pitchDegrees: 35, overhang: 0.35, ridgeAxis: 'x', parent: root });",
+      promptNotes: "Prefer this over width/depth roof math. ridgeAxis is the direction of the ridge; roof panels run along each returned face downhill direction."
+    },
+    {
+      name: "createGableEndPanel",
+      signature: "createGableEndPanel(name, material, { span, rise, thickness?, ridgeAxis?: 'x'|'z', side?: 'positive'|'negative', openings?: [{ id?, offset?, bottom?, width, height }], parent? })",
+      returns: "{ root, geometry, openings }",
+      category: "structure",
+      description: "Exact thick triangular end closure for a gable roof, with optional rectangular openings cut from the geometry and semantic boundary metadata.",
+      example: "createGableEndPanel('FrontGable', siding, { span: 5, rise: 1.8, ridgeAxis: 'x', side: 'positive', parent: root });"
+    },
+    {
+      name: "createGableShell",
+      signature: "createGableShell(name, { wall, roof, floor?, gable? }, { spanX, spanZ, wallHeight?, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, wallThickness?, floorThickness?, closedEnds?, enterable?, openings?, gableOpenings?, parent? })",
+      returns: "{ root, walls, floor, roof, gables, openings }",
+      category: "structure",
+      description: "Closed-by-default, correct-by-construction gable building: hollow room, floor, two opposing roof slopes, two complete gable ends, and a real front doorway when enterable.",
+      example: "const house = createGableShell('House', { wall: plaster, roof: shingles }, { spanX: 8, spanZ: 5, wallHeight: 2.8, pitchDegrees: 35, ridgeAxis: 'x', parent: root });",
+      promptNotes: "Use for complete gable buildings. It stamps wall, floor, slope, gable, opening, adjacency, coverage, and separability semantics for deterministic QA and roof-off views."
+    },
+    {
+      name: "createRoofSurfaceLayout",
+      signature: "createRoofSurfaceLayout(name, material, { face, kind: 'panels'|'shingles'|'seams'|'corrugations', parent?, panelWidth?, rowHeight?, spacing?, thickness? })",
+      returns: "{ root, items: Object3D[] }",
+      category: "structure",
+      description: "Places roof-local panels, shingles, seams, or corrugations from a returned RoofFaceFrame, so repeated elements run ridge-to-eave for either ridge axis without manual Euler rotations.",
+      example: "for (const face of roof.faces) createRoofSurfaceLayout('Panels_' + face.side, metal, { face, kind: 'panels', parent: roof.root });",
+      promptNotes: "Always pass the face object returned by createGableRoof/createGableShell. Never infer the panel rotation from world axes."
+    },
+    {
+      name: "createStairs",
+      signature: "createStairs(name, material, { steps?, totalRise, totalRun, width, axis?: 'x'|'z', treadThickness?, riser?, parent? })",
+      returns: "{ root: Object3D, steps: Object3D[] }",
+      category: "structure",
+      description: "A straight flight of stairs: box treads (with optional risers) climbing totalRise over totalRun from local origin toward +axis. Use for porch/entry steps or to connect storeys in a multi-storey building.",
+      example: "createStairs('Porch', stone, { steps: 4, totalRise: 0.6, totalRun: 1.0, width: 1.4, axis: 'x', parent: root });"
+    },
+    {
+      name: "boxGeo",
+      signature: "boxGeo(width: number, height: number, depth: number)",
+      returns: "THREE.BoxGeometry",
+      category: "geometry",
+      description: "6-face box. 12 tris regardless of size. Cheapest geometry.",
+      example: "const geo = boxGeo(1, 0.5, 2);"
+    },
+    {
+      name: "sphereGeo",
+      signature: "sphereGeo(radius: number, widthSegments?: 8, heightSegments?: 6)",
+      returns: "THREE.SphereGeometry",
+      category: "geometry",
+      description: "UV sphere. Default 8x6 segments = 84 tris. Bump segments for smoother curves.",
+      example: "const geo = sphereGeo(0.5, 12, 8);"
+    },
+    {
+      name: "cylinderGeo",
+      signature: "cylinderGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Y-axis cylinder. Use radiusTop != radiusBottom for cones / tapered pieces.",
+      example: "const geo = cylinderGeo(0.25, 0.25, 1, 12);"
+    },
+    {
+      name: "cylinderYGeo",
+      signature: "cylinderYGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Alias for cylinderGeo — a Y-axis cylinder. Provided because the sandbox exposes cylinderXGeo / cylinderZGeo and the symmetric Y form is commonly reached for.",
+      example: "const geo = cylinderYGeo(0.25, 0.25, 1, 12);"
+    },
+    {
+      name: "cylinderXGeo",
+      signature: "cylinderXGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Cylinder pre-rotated to run along +X/-X. Use for fuselages, cannons, barrels, axles, and forward-facing tubes.",
+      example: "const geo = cylinderXGeo(0.1, 0.1, 1.2, 12);"
+    },
+    {
+      name: "cylinderZGeo",
+      signature: "cylinderZGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Cylinder pre-rotated to run along +Z/-Z. Use for side-mounted weapons, rails, crossbars, and pipes.",
+      example: "const geo = cylinderZGeo(0.08, 0.08, 0.9, 10);"
+    },
+    {
+      name: "cylinderOnAxis",
+      signature: "cylinderOnAxis(center: [x,y,z], normal: [x,y,z], radiusBottom: number, height: number, opts?: { radiusTop?, segments? })",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Frame-first cylinder: position + axis specified directly, no post-hoc rotation. Use when the cylinder needs to point along a non-cardinal direction (struts inside CSG operands, antennas off a tilted surface). For cardinal axes prefer the terser cylinderXGeo / cylinderYGeo / cylinderZGeo helpers.",
+      example: "const strut = cylinderOnAxis([0.5, 0.7, 0], [1, 1, 0.3], 0.05, 0.9);"
+    },
+    {
+      name: "capsuleGeo",
+      signature: "capsuleGeo(radius: number, height: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Stadium shape (cylinder with hemispherical caps). Good for limbs.",
+      example: "const geo = capsuleGeo(0.1, 0.5, 6);"
+    },
+    {
+      name: "capsuleYGeo",
+      signature: "capsuleYGeo(radius: number, height: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Alias for capsuleGeo — a Y-axis capsule. Provided for symmetry with capsuleXGeo / capsuleZGeo.",
+      example: "const geo = capsuleYGeo(0.1, 0.5, 6);"
+    },
+    {
+      name: "capsuleXGeo",
+      signature: "capsuleXGeo(radius: number, length: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Capsule pre-rotated to run along +X/-X. Use for aircraft bodies, rounded vehicle hulls, and missiles.",
+      example: "const geo = capsuleXGeo(0.35, 2.4, 10);"
+    },
+    {
+      name: "capsuleZGeo",
+      signature: "capsuleZGeo(radius: number, length: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Capsule pre-rotated to run along +Z/-Z. Use for lateral pods, floats, and side tanks.",
+      example: "const geo = capsuleZGeo(0.18, 1.1, 8);"
+    },
+    {
+      name: "coneGeo",
+      signature: "coneGeo(radius: number, height: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Y-axis cone (pointed up). Use for spikes, roofs, projectiles.",
+      example: "const geo = coneGeo(0.3, 0.8, 8);"
+    },
+    {
+      name: "coneYGeo",
+      signature: "coneYGeo(radius: number, height: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Alias for coneGeo — a Y-axis cone (point +Y). Provided for symmetry with coneXGeo / coneZGeo.",
+      example: "const geo = coneYGeo(0.3, 0.8, 8);"
+    },
+    {
+      name: "coneXGeo",
+      signature: "coneXGeo(radius: number, length: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Cone pre-rotated so its point faces +X. Use for noses, rockets, shells, and forward-facing tips.",
+      example: "const geo = coneXGeo(0.18, 0.45, 12);"
+    },
+    {
+      name: "coneZGeo",
+      signature: "coneZGeo(radius: number, length: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Cone pre-rotated so its point faces +Z. Use for side-facing projectiles and tips.",
+      example: "const geo = coneZGeo(0.12, 0.35, 10);"
+    },
+    {
+      name: "taperConeGeo",
+      signature: "taperConeGeo(radiusBottom: number, radiusTop: number, height: number, axis?: 'x'|'y'|'z', segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Truncated cone (frustum) — exposes both bottom and top radius. radiusTop=0 matches coneGeo, radiusTop=radiusBottom matches cylinderGeo. Use for pylon caps, soda cans, lampshades, anything tapered that does not come to a point. axis selects orientation (default Y).",
+      example: "const cap = taperConeGeo(0.3, 0.18, 0.4);  // frustum"
+    },
+    {
+      name: "torusGeo",
+      signature: "torusGeo(radius: number, tube: number, radialSegments?: 8, tubularSegments?: 12)",
+      returns: "THREE.TorusGeometry",
+      category: "geometry",
+      description: "Donut shape. For rings, tyres, barrel ribs.",
+      example: "const geo = torusGeo(0.4, 0.04, 8, 16);"
+    },
+    {
+      name: "planeGeo",
+      signature: "planeGeo(width: number, height: number, widthSegments?: 1, heightSegments?: 1)",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Flat quad for TEXTURED surfaces (ground, signs, walls with albedo maps). For solid-color decals like red stars, hull numbers, stamps, or window cutouts on no-texture assets use decalBox — a bare planeGeo without a texture will render as a disconnected 2-tri square and get flagged as a stray plane.",
+      example: "const geo = planeGeo(4, 4);"
+    },
+    {
+      name: "decalBox",
+      signature: "decalBox(width: number, height: number, depth?: 0.01)",
+      returns: "THREE.BoxGeometry",
+      category: "geometry",
+      description: "Thin box for solid-color surface decals: red stars, hull numbers, stamps, no-texture windows. Unlike planeGeo, has real depth so it visibly attaches to its host surface. Must be placed on a surface with position + rotation.",
+      example: `const star = decalBox(0.18, 0.18, 0.01);
+createPart('Mesh_StarPort', star, gameMaterial(0xc61f2a), { position: [0.4, 0.6, 0.41], parent: fuselage });`,
+      promptNotes: "Offset at least 0.01 outside the host surface to avoid z-fighting (a 0.8-wide hull has faces at z=±0.4, so place the decal at z=±0.41)."
+    },
+    {
+      name: "foliageCardGeo",
+      signature: "foliageCardGeo(opts?: { width?, height?, yPivot?: 0..1 })",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Single-quad foliage card with a configurable Y pivot. yPivot=0 plants the quad on the ground. Pair with an alpha-tested material and a leaf/plant sprite.",
+      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
+const quad = foliageCardGeo({ width: 4, height: 6, yPivot: 0 });
+createPart('Mesh_Fern', quad, leaves, { parent: root });`
+    },
+    {
+      name: "crossedQuadsGeo",
+      signature: "crossedQuadsGeo(opts?: { width?, height?, planes?: 2 | 3, yPivot? })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Cross-billboard bush primitive: 2 or 3 planes intersecting along the Y axis. Reads as a dense plant from any angle, cheaper than real geometry.",
+      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
+const bush = crossedQuadsGeo({ width: 2, height: 2, planes: 3 });
+createPart('Mesh_Bush', bush, leaves, { parent: root });`
+    },
+    {
+      name: "octaGridPlane",
+      signature: "octaGridPlane({ tilesX, tilesY, width?, height?, yPivot? })",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Atlas-ready billboard quad. UVs are pre-scaled to cover one tile of a tilesX×tilesY atlas; the consumer shader adds per-instance tile offsets at draw time.",
+      example: "const card = octaGridPlane({ tilesX: 4, tilesY: 4, width: 6, height: 6 });"
+    },
+    {
+      name: "wingGeo",
+      signature: "wingGeo(opts?: { span, rootChord, tipChord, sweep, thickness, dihedral })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Trapezoid wing panel. Local root edge is at Z=0, span extends toward +Z, positive sweep moves the tip aft along -X.",
+      example: "const geo = wingGeo({ span: 2.2, rootChord: 0.8, tipChord: 0.3, sweep: 0.25, dihedral: 0.08 });"
+    },
+    {
+      name: "gearGeo",
+      signature: "gearGeo(opts?: { teeth?: 12, rootRadius?: 0.8, tipRadius?: 1.0, boreRadius?: 0.2, height?: 0.3, toothWidthFrac?: 0.5 })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Stylized gear with flat edges and an optional center bore; no CSG. Use boreRadius < rootRadius < tipRadius. Radii are absolute: an omitted rootRadius stays 0.8 when tipRadius changes. Set all three radii for small gears.",
+      example: `const g = gearGeo({ teeth: 28, rootRadius: 0.063, tipRadius: 0.075, boreRadius: 0.012, height: 0.024 });
+createPart('Gear', g, gameMaterial(0x909090, { metalness: 0.8 }), { parent: root });`
+    },
+    {
+      name: "bladeGeo",
+      signature: "bladeGeo(opts?: { length?: 1.5, baseWidth?: 0.1, thickness?: 0.015, tipLength?: 0.25, edgeBevel?: 0 })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Parametric sword blade: rectangular base tapering to a point over tipLength. edgeBevel > 0 pinches the cross-section toward a diamond ridge.",
+      example: `const b = bladeGeo({ length: 1.6, baseWidth: 0.09, tipLength: 0.3, edgeBevel: 0.5 });
+createPart('Blade', b, steel, { position: [0, 0, 0], parent: root });`
+    },
+    {
+      name: "gameMaterial",
+      signature: "gameMaterial(color, opts?: { metalness, roughness, emissive, emissiveIntensity, flatShading })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Flat-shaded PBR material. Default for game-ready low-poly. Use for 95% of parts.",
+      example: "const mat = gameMaterial(0x8b7355, { roughness: 0.9 });"
+    },
+    {
+      name: "materialRecipe",
+      signature: "await materialRecipe(recipeId, overrides?: { baseColor?, roughness?, metalness?, opacity?, alphaCutoff?, doubleSided?, emissiveColor?, emissiveIntensity?, textureResources? })",
+      returns: "Promise<THREE.MeshStandardMaterial>",
+      category: "material",
+      description: "Resolves a versioned portable bark/leaf/wood/stone/rubber/painted-metal/cloth/skin/glass/emissive recipe to standard glTF PBR.",
+      example: "const bark = await materialRecipe('kiln.material.bark.v1', { baseColor: '#6b4328' });",
+      promptNotes: "Use only listed kiln.material.*.v1 IDs and approved kiln.texture.* resource IDs. Leaf is MASK, glass is BLEND, and host file paths are forbidden."
+    },
+    {
+      name: "compilePortableMaterialSpecV2",
+      signature: "await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', name?, baseColor?, roughness?, metalness?, emissive?, emissiveIntensity?, alphaMode?, alphaCutoff?, doubleSided?, textures?: { baseColor?, normal?, metallicRoughness?, emissive?, occlusion? } })",
+      returns: "Promise<THREE.MeshStandardMaterial>",
+      category: "material",
+      description: "Compiles the strict portable material contract. Texture refs are either typed procedural V2 specs or closed approved kiln.texture.* IDs; paths, URLs, raw textures, callbacks, and shader source are rejected.",
+      example: "const steel = await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', roughness: 0.45, metalness: 0.85, textures: { metallicRoughness: { kind: 'procedural', spec: { schemaVersion: 2, usage: 'metallicRoughness', size: 64, layers: [{ op: 'solid', color: 0x0080cc }] } } } });",
+      promptNotes: "Use metallicRoughness as one packed G=roughness/B=metalness map. Every procedural ref usage must match its slot; resource refs must be approved for that exact slot."
+    },
+    {
+      name: "basicMaterial",
+      signature: "basicMaterial(color, opts?: { transparent, opacity })",
+      returns: "THREE.MeshBasicMaterial",
+      category: "material",
+      description: "Unlit flat material. For UI / effects where lighting is baked in.",
+      example: "const mat = basicMaterial(0xffffff, { transparent: true, opacity: 0.5 });"
+    },
+    {
+      name: "glassMaterial",
+      signature: "glassMaterial(color, opts?: { opacity, roughness, metalness })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Semi-transparent double-sided material. Panels need ~0.05 offset to avoid z-fighting.",
+      example: "const mat = glassMaterial(0x66ccff, { opacity: 0.3 });"
+    },
+    {
+      name: "lambertMaterial",
+      signature: "lambertMaterial(color, opts?: { flatShading, emissive })",
+      returns: "THREE.MeshLambertMaterial",
+      category: "material",
+      description: "Cheaper than gameMaterial. No metalness/roughness. Use when PBR is overkill.",
+      example: "const mat = lambertMaterial(0x2a4d14, { flatShading: true });"
+    },
+    {
+      name: "rotationTrack",
+      signature: "rotationTrack(jointName: string, keyframes: Array<{ time, rotation: [xDeg, yDeg, zDeg] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.QuaternionKeyframeTrack",
+      category: "animation",
+      description: "Rotation track in degrees, auto-converted to quaternions. Joint name must include `Joint_` prefix.",
+      example: "rotationTrack('Joint_Lid', [{ time: 0, rotation: [0, 0, 0] }, { time: 1, rotation: [90, 0, 0] }]);"
+    },
+    {
+      name: "positionTrack",
+      signature: "positionTrack(jointName: string, keyframes: Array<{ time, position: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.VectorKeyframeTrack",
+      category: "animation",
+      description: "Position track in world units. Always use `position:` not `value:` in keyframes.",
+      example: "positionTrack('Joint_Body', [{ time: 0, position: [0, 0, 0] }, { time: 1, position: [0, 0.1, 0] }]);"
+    },
+    {
+      name: "scaleTrack",
+      signature: "scaleTrack(jointName: string, keyframes: Array<{ time, scale: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.VectorKeyframeTrack",
+      category: "animation",
+      description: "Uniform or per-axis scale track.",
+      example: "scaleTrack('Joint_Chest', [{ time: 0, scale: [1, 1, 1] }, { time: 1, scale: [1.1, 1.1, 1.1] }]);"
+    },
+    {
+      name: "createClip",
+      signature: "createClip(name: string, duration: number, tracks: KeyframeTrack[])",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Collects tracks into a named clip. Returned from animate().",
+      example: "return [createClip('Open', 1, [rotationTrack('Joint_Lid', [...])])];"
+    },
+    {
+      name: "idleBreathing",
+      signature: "idleBreathing(bodyJoint: string, duration?: 2, amount?: 0.02)",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Gentle Y-axis bob. For NPC idle states.",
+      example: "return [idleBreathing('Joint_Body')];"
+    },
+    {
+      name: "bobbingAnimation",
+      signature: "bobbingAnimation(rootName: string, duration?: 2, height?: 0.1)",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Floating / bobbing loop for pickups and effects.",
+      example: "return [bobbingAnimation('Joint_Root', 1.5, 0.08)];"
+    },
+    {
+      name: "spinAnimation",
+      signature: "spinAnimation(jointName: string, duration?: 2, axis?: 'x' | 'y' | 'z')",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "360° rotation over `duration` around `axis`.",
+      example: "return [spinAnimation('Joint_Rotor', 0.5, 'y')];"
+    },
+    {
+      name: "cloneGeometry",
+      signature: "cloneGeometry(geo: BufferGeometry)",
+      returns: "THREE.BufferGeometry (same ref)",
+      category: "instancing",
+      description: "Deprecated name: returns the SAME geometry, without copying. Use copyGeometry for independent vertex edits, or pass the original geometry directly for intentional sharing.",
+      example: "const wheelGeo = cylinderGeo(0.4, 0.4, 0.2, 12);"
+    },
+    {
+      name: "cloneMaterial",
+      signature: "cloneMaterial(mat: Material)",
+      returns: "THREE.Material (same ref)",
+      category: "instancing",
+      description: "Deprecated name: returns the SAME material. Use copyMaterial for independent property edits, or pass the original for intentional sharing.",
+      example: "const rubberMat = gameMaterial(0x1a1a1a, { roughness: 0.95 });"
+    },
+    {
+      name: "createInstance",
+      signature: "createInstance(name, source, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, parent })",
+      returns: "THREE.Object3D",
+      category: "instancing",
+      description: "Creates a new mesh reusing an existing part's geometry + material at a new transform. Cheapest way to replicate wheels / bolts / fence posts / windows. `rotation` is in DEGREES, like createPart.",
+      example: `const wheelFL = createPart('WheelFL', wheelGeo, rubberMat, { position: [-0.8, 0.3, 1.2], parent: root });
+createInstance('WheelFR', wheelFL, { position: [0.8, 0.3, 1.2], parent: root });
+createInstance('WheelRL', wheelFL, { position: [-0.8, 0.3, -1.2], parent: root });
+createInstance('WheelRR', wheelFL, { position: [0.8, 0.3, -1.2], parent: root });`
+    },
+    {
+      name: "boolUnion",
+      signature: "await boolUnion(name: string, ...parts: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Merges two or more parts into one watertight manifold mesh. Default flat shading (hard edges) — pass { smooth: true } as last arg for averaged normals on organic merges.",
+      example: `const body = new THREE.Mesh(boxGeo(2, 1, 1), steel);
+const turret = new THREE.Mesh(cylinderGeo(0.3, 0.3, 0.4, 16), steel);
+turret.position.y = 0.5;
+const hull = await boolUnion('Hull', body, turret);`
+    },
+    {
+      name: "boolDiff",
+      signature: "await boolDiff(name: string, body: Object3D, ...cutters: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Subtracts cutters from a body (holes, button recesses, window slots). Default flat shading for sharp mechanical edges.",
+      example: `const body = new THREE.Mesh(cylinderGeo(1, 1, 0.3, 32), steel);
+const teeth = [...]; // 8 radially-arrayed box meshes
+const gear = await boolDiff('Gear', body, ...teeth);  // hard-edged`
+    },
+    {
+      name: "roundedBoxGeo",
+      signature: "await roundedBoxGeo(width: number, height: number, depth: number, radius: number, opts?: { style?: 'round' | 'chamfer', segments?: 12, smooth?: boolean })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "A box with all twelve edges rounded (or chamfered) at the EXACT outer size requested — roundedBoxGeo(1, 1, 1, 0.1) measures 1x1x1, it does not grow. Use it anywhere boxGeo reads too sharp: consoles, crates, appliances, handheld props, machined blocks.",
+      promptNotes: "Real objects almost never have perfectly sharp box edges, and a small radius is the single cheapest upgrade to how manufactured an asset looks. Prefer this over boxGeo for anything moulded, cast, or machined. Keep radius small relative to the box (5-10% of the smallest dimension); radius must be less than half the smallest dimension or the call throws. style: 'chamfer' reads as machined metal, 'round' as moulded plastic. This is async — build() must be async and the call must use await.",
+      example: `const geo = await roundedBoxGeo(1.2, 0.6, 0.8, 0.05);
+createPart('Console', geo, plastic, { position: [0, 0.3, 0], parent: root });`
+    },
+    {
+      name: "extrudeProfile",
+      signature: "await extrudeProfile(profile: [number, number][], opts?: { depth?: 1, holes?: [number, number][][], bevel?: 0, bevelStyle?: 'round' | 'chamfer', segments?: 12, twist?: 0, taper?: number | [number, number], divisions?: number, axis?: 'x' | 'y' | 'z', center?: true, smooth?: false })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "Sweeps a closed 2D outline into a watertight solid, with optional holes, corner rounding/chamfering, twist, and taper. The way to build any cross-section that is not a box or a cylinder: L-brackets, I-beams, gaskets, washers, star and gear plates, signage, extruded trim.",
+      promptNotes: "The bevel rounds the edges PARALLEL to the sweep axis (the profile corners) — the two flat caps stay sharp. For a box rounded on all twelve edges use roundedBoxGeo instead. Holes are subtracted, so their winding order does not matter. A bevel larger than half the outline's narrowest feature throws rather than silently returning an empty solid. Output is manifold, so it feeds straight into boolUnion / boolDiff / boolIntersect. Async — await it inside an async build().",
+      example: `// L-bracket, inner AND outer corners filleted
+const outline = [[0, 0], [2, 0], [2, 0.4], [0.4, 0.4], [0.4, 2], [0, 2]];
+const geo = await extrudeProfile(outline, { depth: 0.5, bevel: 0.06 });
+createPart('Bracket', geo, steel, { parent: root });`
+    },
+    {
+      name: "revolveProfile",
+      signature: "await revolveProfile(profile: [number, number][], opts?: { segments?: 24, angle?: 360, bevel?: 0, bevelStyle?: 'round' | 'chamfer', bevelSegments?: 12, axis?: 'x' | 'y' | 'z', smooth?: true })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "Revolves a closed 2D outline around an axis into a watertight SOLID, optionally rounding the profile corners first. Bottles, tanks, pressure vessels, wheels, turned wood, domes, buttons, pills.",
+      promptNotes: "Use this instead of lathe/revolveGeo whenever the result must survive a boolean or needs a rounded rim — lathe and revolveGeo build an open surface, this builds a closed solid. Profile convention matches lathe: x is distance from the axis, y is position along it, and only the x >= 0 side is used. Async — await it inside an async build().",
+      example: `// capsule tank with a rounded rim, then carve a port into it
+const profile = [[0, -0.5], [0.4, -0.5], [0.4, 0.5], [0, 0.5]];
+const body = await revolveProfile(profile, { bevel: 0.08, segments: 32 });
+const tank = await boolDiff('Tank', createPart('B', body, steel), portCutter);`
+    },
+    {
+      name: "circleProfile",
+      signature: "circleProfile(radius: number, segments?: 24, center?: [number, number])",
+      returns: "[number, number][]",
+      category: "csg",
+      description: "Builds a closed circular outline for extrudeProfile / revolveProfile, so you never hand-write the trigonometry. Synchronous.",
+      example: `const washer = await extrudeProfile(circleProfile(1), {
+  depth: 0.1,
+  holes: [circleProfile(0.4), circleProfile(0.1, 16, [0.7, 0])],
+});`
+    },
+    {
+      name: "boolIntersect",
+      signature: "await boolIntersect(name: string, a: Object3D, b: Object3D, opts?: { smooth?: false })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Keeps only the volume where both operands overlap. Default flat shading.",
+      example: "const lens = await boolIntersect('Lens', boxMesh, sphereMesh);"
+    },
+    {
+      name: "hull",
+      signature: "await hull(name: string, ...parts: Object3D[], opts?: { smooth?: true })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Tightest convex mesh enclosing all input points. Default smooth shading (rocks, collision volumes). Pass { smooth: false } for a faceted look.",
+      example: `const rockChunks = [...]; // scattered box meshes
+const rock = await hull('Rock', ...rockChunks);`
+    },
+    {
+      name: "arrayLinear",
+      signature: "arrayLinear(namePrefix, source, count, offset: [x,y,z], parent?)",
+      returns: "THREE.Object3D[]",
+      category: "arrays",
+      description: "Places N copies of `source` along a constant offset vector. Copies share geometry + material via createInstance.",
+      example: `const post = createPart('Post0', cylinderGeo(0.05,0.05,1.5,6), wood, { position: [0,0.75,0], parent: root });
+arrayLinear('Post', post, 10, [0.5, 0, 0], root);`
+    },
+    {
+      name: "arrayRadial",
+      signature: "arrayRadial(namePrefix, source, count, axis?: 'x'|'y'|'z', parent?)",
+      returns: "THREE.Object3D[]",
+      category: "arrays",
+      description: "Places N copies of `source` around the given axis. Source's local rotation is oriented outward. Perfect for gear teeth, radial bolts, circle of columns.",
+      example: `const bolt = createPart('Bolt0', cylinderGeo(0.02,0.02,0.1,6), steel, { position: [1,0,0], parent: root });
+arrayRadial('Bolt', bolt, 8, 'y', root);`
+    },
+    {
+      name: "mirror",
+      signature: "mirror(name, source, axis: 'x'|'y'|'z', parent?)",
+      returns: "THREE.Object3D",
+      category: "arrays",
+      description: "Reflects source across the plane whose normal is `axis`. Uses negative scale (winding flip handled by viewers).",
+      example: "mirror('WingR', wingL, 'x', root);"
+    },
+    {
+      name: "subdivide",
+      signature: "subdivide(geometry: BufferGeometry, iterations?: 1, opts?: { preserveUV?: boolean, split?: boolean, uvSmooth?: boolean, preserveEdges?: boolean, flatOnly?: boolean, weld?: boolean })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Loop subdivision returns new geometry; each iteration roughly quadruples triangles and smooths the surface. Use preserveUV:true for textured meshes. Legacy position-only welding discards UVs and reports that loss. This smooths shapes, not selected-edge beveling.",
+      example: "const smoothRock = subdivide(boxGeo(1, 1, 1), 2);"
+    },
+    {
+      name: "mergeVertices",
+      signature: "mergeVertices(geometry: BufferGeometry, opts?: { tolerance?: 1e-4, positionOnly?: boolean } | number)",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Returns indexed geometry. Default welding preserves attribute seams, so a textured cube retains separate face corners. positionOnly:true welds coincident positions and discards other attributes; use it explicitly when changing topology and regenerate shading/UVs afterward.",
+      example: `const welded = mergeVertices(boxGeo(1, 1, 1), { positionOnly: true });
+const rock = displace(subdivide(welded, 2), ([x,y,z]) => [0.08*Math.sin(y*7+z*3), 0.04*Math.sin(x*9), 0]);`
+    },
+    {
+      name: "curveToMesh",
+      signature: "curveToMesh(points: [x,y,z][], radius, tubularSegs?: 32, radialSegs?: 8, closed?: false)",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Sweeps a circular profile along a path. Equivalent to Blender's Curve to Mesh node with a circle profile. Use for pipes, cables, tubular frames.",
+      example: "const pipe = curveToMesh([[0,0,0],[0,1,0],[1,1,0],[1,2,0]], 0.1);"
+    },
+    {
+      name: "pipeAlongPath",
+      signature: "pipeAlongPath(points: [x,y,z][], radius: number, opts?: { bendRadius?: 0, closed?: false, tubularSegments?: 32, radialSegments?: 8 })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Path-driven swept circle with optional bend smoothing. Generalises beamBetween (point-to-point) and curveToMesh (raw spline) into one helper. bendRadius>0 inserts interpolated waypoints near interior corners so the spline reads as a rounded turn instead of pinching to the control point.",
+      example: "const cable = pipeAlongPath([[0, 0.5, 0], [1, 0.5, 0], [1, 0.5, 2]], 0.02, { bendRadius: 0.1 });"
+    },
+    {
+      name: "lathe",
+      signature: "lathe(profile: [x,y][], segments?: 12)",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Surface of revolution. Spins a 2D profile around the Y axis. For bottles, vases, wheels, turned wood parts.",
+      example: "const vase = lathe([[0.1,0],[0.3,0.5],[0.2,1],[0.1,1.2]], 16);"
+    },
+    {
+      name: "revolveGeo",
+      signature: "revolveGeo(profile: [x,y][], opts?: { angle?: 2π, axis?: [x,y,z]=[0,1,0], segments?: 12 })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Surface of revolution with explicit axis + sweep angle. Generalises lathe — use it when you need a partial sweep (half-dome, 90° wedge) or revolution around a non-Y axis. Profile convention is identical to lathe: x = radial distance, y = position along the axis.",
+      example: `// Half-dome (180° sweep around +Y):
+const quarter = [...Array(8)].map((_, i) => { const t = (i/7)*Math.PI/2; return [Math.cos(t), Math.sin(t)] as [number, number]; });
+const dome = revolveGeo(quarter, { angle: Math.PI });`
+    },
+    {
+      name: "bezierCurve",
+      signature: "bezierCurve(controlPoints: [x,y,z][], samples?: 32)",
+      returns: "[x,y,z][]",
+      category: "curves",
+      description: "Samples a quadratic (3 ctrl pts) or cubic (4 ctrl pts) Bézier into a point list you can feed into curveToMesh.",
+      example: `const path = bezierCurve([[0,0,0],[1,2,0],[3,2,0],[4,0,0]], 24);
+const geo = curveToMesh(path, 0.1);`
+    },
+    {
+      name: "autoUnwrap",
+      signature: "await autoUnwrap(geometry: BufferGeometry, opts?: { resolution?: 1024, padding?: 2, useNormals?: false })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "uv",
+      description: "xatlas-based UV atlas for ANY geometry (CSG output, subdivided, deformed). Output is a packed atlas with arbitrary per-chart rotation — use for non-tileable baked textures. For directional tileable textures on box/cylinder/plane primitives, prefer the shape-aware unwraps below.",
+      example: `const unwrapped = await autoUnwrap(someCsgResult, { resolution: 1024 });
+const mesh = new THREE.Mesh(unwrapped, bakedPbr);`
+    },
+    {
+      name: "boxUnwrap",
+      signature: "boxUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Preserves BoxGeometry's built-in per-face UVs — every face maps [0,1] with consistent orientation. Use for crates/blocks with a tileable texture. Sync; no WASM cost.",
+      example: `const crate = boxUnwrap(boxGeo(1, 1, 1));
+const mesh = new THREE.Mesh(crate, pbrMaterial({ albedo: planksTex }));`
+    },
+    {
+      name: "cylinderUnwrap",
+      signature: "cylinderUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Preserves CylinderGeometry's built-in UVs: u wraps around the axis (horizontal texture features ring the cylinder), v runs up the height. Caps use circle-in-square. Sync; no WASM cost.",
+      example: `const barrel = cylinderUnwrap(cylinderGeo(0.5, 0.5, 1.2, 24));
+const mesh = new THREE.Mesh(barrel, pbrMaterial({ albedo: bandsTex }));`
+    },
+    {
+      name: "planeUnwrap",
+      signature: "planeUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Projects xy-extent of the bbox to [0,1]. Use for signs/decals/posters where you want ONE readable texture and no edge-face bleeding. Sync.",
+      example: `const sign = planeUnwrap(planeGeo(1, 0.6));
+const mesh = new THREE.Mesh(sign, pbrMaterial({ albedo: kilnTextTex }));`
+    },
+    {
+      name: "panelRemapV",
+      signature: "panelRemapV(geo, vScale=0.30, vOffset=0, uScale=1, uOffset=0)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Scales an existing UV attribute so a small mesh samples a sub-region of a SHARED texture. Replaces the broken texture.clone() pattern (Three.js Texture.clone() runs JSON.stringify on userData, mangling encoded PNG bytes — panelRemapV avoids that by remapping UVs on the geometry instead). Typical use: multi-zone albedo where v=0..0.30 is plain panel and v=0.30..1 has windows/markings — small parts call panelRemapV(unwrap(geo), 0.30) to sample only the clean strip.",
+      example: `const cowlGeo = panelRemapV(cylinderUnwrap(capsuleXGeo(0.45, 1.0)), 0.30);
+const cowl = new THREE.Mesh(cowlGeo, bodyMat); // SAME bodyMat as fuselage, no clone needed`
+    },
+    {
+      name: "loadApprovedTexture",
+      signature: "await loadApprovedTexture(resourceId)",
+      returns: "Promise<THREE.DataTexture>",
+      category: "textures",
+      description: "Loads one approved kiln.texture.* resource ID through the host-injected closed resolver. The registry fixes bytes, MIME, usage, dimensions, hash, and deadline; paths, URLs, byte arrays, resolver objects, hashes, and options are rejected.",
+      example: "const bark = await loadApprovedTexture('kiln.texture.bark-brown-01-albedo.v1');",
+      promptNotes: "Use only a concrete resource ID listed in material capabilities; never invent one. Prefer materialRecipe when a recipe already binds the family, or proceduralTexture V2 for authored surfaces. NEVER texture.clone() a loaded texture (clone() corrupts encoded bytes and breaks GLB export)."
+    },
+    {
+      name: "proceduralTexture",
+      signature: "proceduralTexture({ schemaVersion: 2, size?: 4..1024 pow2, usage?, name?, layers: [{ op: 'solid'|'checker'|'stripes'|'gradient'|'bricks'|'noise', ...params, blend?: 'normal'|'multiply'|'screen'|'overlay', opacity?: 0..1 }] })",
+      returns: "THREE.DataTexture (tiling, sRGB or linear per usage)",
+      category: "textures",
+      description: "Builds a tiling texture from a bounded layer stack — no image file needed. Layers composite bottom-first. Noise is seeded and tileable, so the same spec always produces the same bytes and a repeating material shows no seam. Baked to PNG and embedded in the GLB automatically.",
+      example: "const bark = proceduralTexture({ schemaVersion: 2, size: 256, usage: 'albedo', name: 'Bark', layers: [{ op: 'solid', color: 0x5a4632 }, { op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4, blend: 'overlay' }] });",
+      promptNotes: "Sync — no await. Strict V2 JSON boundary: unknown/prototype keys, callbacks, paths, URLs, and shader source are rejected. Prefer this over approved resources for describable surfaces. Max 8 layers, power-of-two size up to 1024. Only the six listed ops exist."
+    },
+    {
+      name: "normalMapFromHeight",
+      signature: "normalMapFromHeight(source: THREE.Texture, { strength?: number, name?: string })",
+      returns: "THREE.DataTexture (linear normal map)",
+      category: "textures",
+      description: "Derives a tangent-space normal map from the source texture's brightness, treating it as height. The cheap way to get real PBR surface relief out of a procedural albedo. Wraps at the edges, so a tiling source gives a tiling normal map.",
+      example: `const bark = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4 }] });
+const mat = pbrMaterial({ albedo: bark, normal: normalMapFromHeight(bark, { strength: 4 }) });`,
+      promptNotes: "strength 1 is subtle, 4-8 reads clearly at normal viewing distance. Output is always linear data — never assign it to an albedo/emissive slot."
+    },
+    {
+      name: "pbrMaterial",
+      signature: "pbrMaterial({ albedo?, normal?, roughness?, metalness?, metallicRoughness?, emissive?, aoMap?, alphaMode?, alphaCutoff?, doubleSided? })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Portable glTF PBR material. Use an explicit packed metallicRoughness texture (G=roughness, B=metalness); separate data maps are rejected instead of silently dropping a channel. Supports OPAQUE/MASK/BLEND and double-sided output.",
+      example: `const wood = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x4f301c, colorB: 0x9a6b3e, scale: 8, octaves: 3, seed: 4 }] });
+const crate = pbrMaterial({ albedo: wood, roughness: 0.85, metalness: 0 });`
+    },
+    {
+      name: "foliageMaterial",
+      signature: "foliageMaterial(albedo, { alphaCutoff?, roughness?, doubleSided? })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Portable foliage material that defaults to glTF MASK, cutoff 0.5, rough nonmetal, and double-sided. Use an alpha-bearing albedo texture.",
+      example: "const mat = await materialRecipe('kiln.material.leaf.v1');"
+    },
+    {
+      name: "countTriangles",
+      signature: "countTriangles(root: Object3D)",
+      returns: "number",
+      category: "utility",
+      description: "Sums triangle count across every mesh in the subtree.",
+      example: "meta.tris = countTriangles(root);"
+    },
+    {
+      name: "countMaterials",
+      signature: "countMaterials(root: Object3D)",
+      returns: "number",
+      category: "utility",
+      description: "Unique material count (by reference) across the subtree.",
+      example: "const mats = countMaterials(root);"
+    },
+    {
+      name: "getJointNames",
+      signature: "getJointNames(root: Object3D)",
+      returns: "string[]",
+      category: "utility",
+      description: "All node names beginning with `Joint_`. Use to sanity-check animation targets.",
+      example: "const joints = getJointNames(root);"
+    },
+    {
+      name: "validateAsset",
+      signature: "validateAsset(root: Object3D, category: 'character' | 'prop' | 'vfx' | 'environment' | 'architecture' | 'vegetation' | 'vehicle')",
+      returns: "{ valid, errors, warnings }",
+      category: "utility",
+      description: "Checks geometry and material costs for the selected category. No default triangle limit; choose detail for the intended runtime and inspect measured draw calls.",
+      example: "const v = validateAsset(root, 'prop');"
+    }
+  ];
+});
+
 // src/validation.ts
 import * as acorn from "acorn";
 import * as walk from "acorn-walk";
@@ -18152,7 +19074,73 @@ function validate(code, _opts = {}) {
       line: smell.line
     });
   }
+  warnings.push(...unknownHelperWarnings(ast));
   return toResult(issues, warnings, analysis.estimatedTris);
+}
+function unknownHelperWarnings(ast) {
+  const declared = new Set;
+  const bind = (node) => {
+    const target = node;
+    if (!target?.type)
+      return;
+    if (target.type === "Identifier")
+      declared.add(target["name"]);
+    else if (target.type === "ObjectPattern")
+      for (const prop of target["properties"])
+        bind(prop.value ?? prop.argument);
+    else if (target.type === "ArrayPattern")
+      for (const el of target["elements"])
+        bind(el);
+    else if (target.type === "AssignmentPattern")
+      bind(target["left"]);
+    else if (target.type === "RestElement")
+      bind(target["argument"]);
+  };
+  const params = (node) => {
+    const fn = node;
+    if (fn.id?.name)
+      declared.add(fn.id.name);
+    for (const param of fn.params ?? [])
+      bind(param);
+  };
+  walk.simple(ast, {
+    VariableDeclarator(node) {
+      bind(node.id);
+    },
+    FunctionDeclaration(node) {
+      params(node);
+    },
+    FunctionExpression(node) {
+      params(node);
+    },
+    ArrowFunctionExpression(node) {
+      params(node);
+    },
+    ClassDeclaration(node) {
+      params(node);
+    },
+    CatchClause(node) {
+      bind(node.param);
+    }
+  });
+  const seen = new Map;
+  walk.simple(ast, {
+    CallExpression(node) {
+      const callee = node.callee;
+      if (callee?.type !== "Identifier" || !callee.name)
+        return;
+      const name = callee.name;
+      if (declared.has(name) || SANDBOX_CALLABLES.has(name) || seen.has(name))
+        return;
+      seen.set(name, node.loc?.start?.line);
+    }
+  });
+  return [...seen].map(([name, line]) => ({
+    code: "UNKNOWN_HELPER",
+    message: `${name}() is not declared in this program and is not a Kiln sandbox global; the build will fail when it runs.`,
+    fixHint: "Call kiln_list_primitives to confirm the helper name and signature, or declare the function in this program.",
+    ...line === undefined ? {} : { line }
+  }));
 }
 function assertGeneratedSourceSafe(code) {
   let ast;
@@ -18668,8 +19656,45 @@ function hasBreak(body) {
   });
   return found;
 }
-var GeneratedSourcePolicyError, FORBIDDEN_AMBIENT_IDENTIFIERS, FORBIDDEN_THREE_CONSTRUCTORS, ROTATION_OPTION_FNS;
+var SANDBOX_CALLABLES, GeneratedSourcePolicyError, FORBIDDEN_AMBIENT_IDENTIFIERS, FORBIDDEN_THREE_CONSTRUCTORS, ROTATION_OPTION_FNS;
 var init_validation = __esm(() => {
+  init_list_primitives();
+  SANDBOX_CALLABLES = new Set([
+    ...listPrimitives().map((primitive) => primitive.name),
+    "Array",
+    "BigInt",
+    "Boolean",
+    "Error",
+    "Float32Array",
+    "Float64Array",
+    "Int16Array",
+    "Int32Array",
+    "Int8Array",
+    "Map",
+    "Number",
+    "Object",
+    "Promise",
+    "Proxy",
+    "RangeError",
+    "Reflect",
+    "RegExp",
+    "Set",
+    "String",
+    "Symbol",
+    "TypeError",
+    "Uint16Array",
+    "Uint32Array",
+    "Uint8Array",
+    "WeakMap",
+    "WeakSet",
+    "decodeURIComponent",
+    "encodeURIComponent",
+    "isFinite",
+    "isNaN",
+    "parseFloat",
+    "parseInt",
+    "structuredClone"
+  ]);
   GeneratedSourcePolicyError = class GeneratedSourcePolicyError extends Error {
     code;
     line;
@@ -26553,928 +27578,6 @@ var init_programs = __esm(() => {
   refInput = z2.string().regex(programRefPattern).describe("Returned p_ handle or full sha256 ref.");
 });
 
-// src/geometry-catalog.ts
-var geometryPrimitives;
-var init_geometry_catalog = __esm(() => {
-  geometryPrimitives = [
-    {
-      name: "copyGeometry",
-      signature: "copyGeometry(geometry: BufferGeometry)",
-      returns: "THREE.BufferGeometry",
-      category: "instancing",
-      description: "Returns an independent geometry with copied vertex buffers. Use before direct mutation of a cached primitive.",
-      example: "const editable = copyGeometry(boxGeo(1, 1, 1)); editable.translate(0, 0.5, 0);"
-    },
-    {
-      name: "copyMaterial",
-      signature: "copyMaterial(material: Material)",
-      returns: "THREE.Material (same subtype)",
-      category: "instancing",
-      description: "Copies material properties so edits do not change other parts. Referenced textures remain shared.",
-      example: "const red = copyMaterial(steel); red.color.set(0xaa2222);"
-    },
-    {
-      name: "meshGeo",
-      signature: "meshGeo({ positions: number[], indices?: number[], normals?: number[], uvs?: number[], tangents?: number[] })",
-      returns: "THREE.BufferGeometry",
-      category: "geometry",
-      description: "Builds an owned triangle mesh from flat numeric arrays. Validates finite values, attribute lengths and indices; computes normals if absent. Counterclockwise winding.",
-      example: "const triangle = meshGeo({ positions: [0,0,0, 1,0,0, 0,1,0], indices: [0,1,2] });"
-    },
-    {
-      name: "parametricSurface",
-      signature: "parametricSurface(sample: (u,v) => [x,y,z], opts?: { u?: [0,1], v?: [0,1], uSegments?: 24, vSegments?: 24, periodicU?: false, periodicV?: false, orientation?: 'uv'|'vu' })",
-      returns: "THREE.BufferGeometry",
-      category: "geometry",
-      description: "Samples an equation into an owned surface with UVs. Periodic endpoints must coincide; UV seams retain matching normals. A surface is not automatically a watertight solid.",
-      example: "const canopy = parametricSurface((u,v) => [u, 0.3*Math.sin(u*3)*Math.cos(v*2), v], { u: [-2,2], v: [-1,1] });"
-    },
-    {
-      name: "geometryDiagnostics",
-      signature: "geometryDiagnostics(geometry: BufferGeometry, tolerance?: 1e-6)",
-      returns: "{ vertices, triangles, boundaryEdges, nonManifoldEdges, orientationConflicts, degenerateTriangles, invalidIndices, nonFiniteVertices }",
-      category: "utility",
-      description: "Counts mesh topology problems after position-based seam matching. Open boundaries are valid for sheets; closed edges alone do not prove a self-intersection-free solid.",
-      example: "const topology = geometryDiagnostics(shell);"
-    },
-    {
-      name: "creaseNormals",
-      signature: "creaseNormals(geometry: BufferGeometry, opts?: { angle?: 60, tolerance?: number })",
-      returns: "THREE.BufferGeometry",
-      category: "mesh-ops",
-      description: "Returns owned geometry with angle-limited smooth normals, preserving UV corners. Angle is degrees. Invalidates tangents; use after shaping for sharp rims and smooth walls.",
-      example: "const shell = creaseNormals(cylinderGeo(1,1,2,32), { angle: 45 });"
-    },
-    {
-      name: "bend",
-      signature: "bend(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-      returns: "THREE.BufferGeometry",
-      category: "mesh-ops",
-      description: "Bends local +Y toward +X through angle degrees. Returns owned geometry and updated normals/bounds; preserves UVs, invalidates tangents. Frame rotation is Euler XYZ degrees.",
-      promptNotes: "Deformation interval uses local Y distances; outside vertices stay unchanged. Add enough segments before bending. Falloff returns 0..1; use it to avoid a discontinuity at a selected interval boundary.",
-      example: "const arch = bend(planeGeo(1,4,4,32), { angle: 90 });"
-    },
-    {
-      name: "twist",
-      signature: "twist(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-      returns: "THREE.BufferGeometry",
-      category: "mesh-ops",
-      description: "Rotates the cross-section progressively around local +Y, reaching angle degrees at the end. Returns owned geometry; frame rotation uses Euler XYZ degrees.",
-      example: "const spiral = twist(column, { angle: 120 });"
-    },
-    {
-      name: "taper",
-      signature: "taper(geometry, { startScale?: [1,1], endScale: [x,z], frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-      returns: "THREE.BufferGeometry",
-      category: "mesh-ops",
-      description: "Scales local X/Z across the local Y interval using positive start/end scale pairs. Returns owned geometry; preserves UVs and invalidates tangents.",
-      example: "const narrowed = taper(column, { endScale: [0.4,0.7] });"
-    },
-    {
-      name: "displace",
-      signature: "displace(geometry, offset: ([x,y,z], t) => [dx,dy,dz], opts?: { frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-      returns: "THREE.BufferGeometry",
-      category: "mesh-ops",
-      description: "Adds an authored displacement vector in the chosen local frame. Returns owned geometry; callback coordinates are local and t is normalized along the interval.",
-      example: "const rippled = displace(surface, ([x,y,z]) => [0, 0.1*Math.sin(x*8), 0]);"
-    },
-    {
-      name: "sweepProfile",
-      signature: "sweepProfile(profile: [x,z][], path: [x,y,z][], opts?: { cap?: true, closed?: false, up?: [x,y,z], twist?: 0, scale?: number | [x,z][] })",
-      returns: "THREE.BufferGeometry",
-      category: "curves",
-      description: "Sweeps a simple noncircular profile along polyline stations using transported frames. Supports total twist in degrees and per-station scales. Generates UVs and optional caps.",
-      promptNotes: "First version supports one simple profile without holes. Closed paths omit the repeated endpoint and require twist to be a multiple of 360. up sets the initial profile +Z direction and cannot parallel the path. Tight-turn warnings do not replace visual inspection for self-intersections.",
-      example: "const rail = sweepProfile([[-.1,-.2],[.1,-.2],[.1,.2],[-.1,.2]], [[0,0,0],[0,1,0],[1,2,0]]);"
-    },
-    {
-      name: "loftProfiles",
-      signature: "loftProfiles(sections: { profile: [x,z][], frame?: { origin, rotation } }[], opts?: { cap?: true })",
-      returns: "THREE.BufferGeometry",
-      category: "curves",
-      description: "Joins corresponding simple profiles in explicit local XZ planes. Each frame uses Euler XYZ degrees and local +Y along the loft. Profiles need equal point counts and corresponding vertices.",
-      promptNotes: "No holes or automatic profile correspondence. Opposite winding is normalized while preserving the first point. Caps close boundaries but do not prove the loft has no self-intersections.",
-      example: "const hull = loftProfiles([{ profile: wide }, { profile: narrow, frame: { origin: [0,2,0] } }]);"
-    },
-    {
-      name: "implicitSurface",
-      signature: "await implicitSurface(sample: ([x,y,z]) => signedValue, { bounds: { min, max }, edgeLength, maxCells?: 1000000, maxEvaluations?: 8000000, level?: 0, tolerance?: -1, smooth?: true })",
-      returns: "Promise<THREE.BufferGeometry>",
-      category: "geometry",
-      description: "Experimental positive-inside implicit field sampled into a solid mesh. Requires explicit bounds and resolution; checks grid size and actual evaluation count. Output has no UVs.",
-      promptNotes: "Use async build and await. Smaller edgeLength increases cost sharply. This helper cannot stop a callback that never returns; the host evaluator process provides that boundary. Thin features and geometric accuracy require inspection.",
-      example: "const blob = await implicitSurface(([x,y,z]) => 1-Math.hypot(x,y,z), { bounds: { min: [-1.2,-1.2,-1.2], max: [1.2,1.2,1.2] }, edgeLength: 0.15 });"
-    }
-  ];
-});
-
-// src/list-primitives.ts
-function listPrimitives() {
-  return PRIMITIVES.map((p) => ({ ...p }));
-}
-var PRIMITIVES;
-var init_list_primitives = __esm(() => {
-  init_geometry_catalog();
-  PRIMITIVES = [
-    ...geometryPrimitives,
-    {
-      name: "createRoot",
-      signature: "createRoot(name: string)",
-      returns: "THREE.Object3D",
-      category: "structure",
-      description: "Creates the root Object3D for an asset. Call first in build().",
-      example: "const root = createRoot('FuelDrum');"
-    },
-    {
-      name: "createPivot",
-      signature: "createPivot(name: string, position?: [x, y, z], parent?: Object3D)",
-      returns: "THREE.Object3D (prefixed `Joint_`)",
-      category: "structure",
-      description: "Creates an empty pivot node for skeletal animation. Name is auto-prefixed with `Joint_`.",
-      example: "const hip = createPivot('Hip', [0, 1, 0], root);"
-    },
-    {
-      name: "createJointChain",
-      signature: "createJointChain(name, segments: { role, offset, aliases?, side?, localForwardAxis?, localBendAxis?, endEffector?, contact? }[], opts?: { parent?, parentRole? })",
-      returns: "{ root, end, nodes, byRole, descriptors }",
-      category: "structure",
-      description: "Creates one body-plan-neutral deterministic Joint_* chain with explicit parent edges, rest frames, local axes, end effectors, contacts, and semantic metadata.",
-      example: "const leg = createJointChain('LegL', [{ role: 'hip.left', offset: [0, 1, -0.2], side: 'left' }, { role: 'knee.left', offset: [0, -0.5, 0], side: 'left' }, { role: 'ankle.left', offset: [0, -0.5, 0], side: 'left', endEffector: true, contact: true }], { parent: root });",
-      promptNotes: "Use only the resolved body-plan graph. Offsets are local to the previous joint; contact end effectors must land at world Y=0."
-    },
-    {
-      name: "createVehicleFrame",
-      signature: "createVehicleFrame(name, opts?: { chassis?, axles?, seats?, contacts?, steering?, propulsion?, parent? })",
-      returns: "{ root, chassis, axles, seats, contacts, steering, propulsion }",
-      category: "structure",
-      description: "Creates a canonical +X-forward/+Y-up/+Z-right vehicle frame with typed semantic sockets for chassis, support, steering, and propulsion.",
-      example: "const frame = createVehicleFrame('CarFrame', { axles: [{ id: 'front', position: [1.2, 0.45, 0] }, { id: 'rear', position: [-1.2, 0.45, 0] }], parent: root });",
-      promptNotes: "Generated vehicles keep +X as front. Boats and other non-wheeled subtypes use declared support/propulsion sockets, not wheel rules."
-    },
-    {
-      name: "createWheelGeometrySet",
-      signature: "createWheelGeometrySet(radius: number, width: number)",
-      returns: "{ tire, rim, hub } shared THREE.BufferGeometry set",
-      category: "instancing",
-      description: "Creates one reusable +Z-axle tire/rim/hub geometry set for instanced wheel assemblies.",
-      example: "const wheelGeo = createWheelGeometrySet(0.45, 0.22);"
-    },
-    {
-      name: "createWheelAssembly",
-      signature: "createWheelAssembly(name, { tire, rim, hub? }, { radius, width, side, index, position?, rimRadius?, hubRadius?, steering?, loadBearing?, geometries?, parent? })",
-      returns: "{ root, steeringPivot?, spinPivot, tire, rim, hub, contact, radius, width, side, index, spinAxis }",
-      category: "structure",
-      description: "Creates one axle-centered wheel pivot containing concentric tire/rim/hub roles, a contact marker, +Z spin frame, and optional steering pivot.",
-      example: "createWheelAssembly('FrontLeft', { tire: rubber, rim: metal }, { radius: 0.45, width: 0.22, side: 'left', index: 'front', position: [1.2, 0.45, -0.9], steering: true, geometries: wheelGeo, parent: frame.root });",
-      promptNotes: "Keep tire, rim, and hub descendants concentric at the axle pivot. Reuse one geometry set across matching wheels."
-    },
-    {
-      name: "createPart",
-      signature: "createPart(name, geometry, material, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, pivot, parent })",
-      returns: "THREE.Object3D (mesh or wrapping pivot)",
-      category: "structure",
-      description: "Creates a mesh, optionally wrapped in a pivot, and attaches it to `opts.parent`. `rotation` is in DEGREES (like rotationTrack), NOT radians: [0, 0, 90] is a quarter turn; [0, 0, 1.57] is a no-op.",
-      example: "createPart('Barrel', cylinderGeo(0.1, 0.1, 1), gameMaterial(0x556b2f), { position: [0, 0.5, 0], rotation: [0, 0, 90], parent: root });",
-      promptNotes: "AUTO-ADDS to opts.parent. NEVER call parent.add(createPart(...)) — pass { parent } instead. rotation is DEGREES — writing radians (e.g. 0.785 or Math.PI/4) silently produces ~zero rotation."
-    },
-    {
-      name: "beamBetween",
-      signature: "beamBetween(name, start: [x,y,z], end: [x,y,z], radius, material, opts?: { segments, parent })",
-      returns: "THREE.Object3D (prefixed `Mesh_`)",
-      category: "structure",
-      description: "Creates a cylindrical rail/strut exactly between two endpoints. Use for braces, gun barrels, skid struts, cables, and scaffolding.",
-      example: "beamBetween('SkidBraceA', [0.8, 0.3, 0.7], [0.8, 1.0, 0.45], 0.025, black, { parent: root });"
-    },
-    {
-      name: "snapTo",
-      signature: "snapTo(part: Object3D, host: Object3D, opts?: { axis?: 'x'|'y'|'z', overlap?: 0.02 })",
-      returns: "THREE.Object3D (the part, for chaining)",
-      category: "structure",
-      description: 'Translates `part` by the minimal vector that brings its bounding box into contact with `host` (plus a small overlap). The direct cure for a "Floating parts" warning — attach the part instead of eyeballing a corrective offset. No-op if they already touch.',
-      example: `const scope = createPart('Scope', cylinderXGeo(0.04, 0.04, 0.3), steel, { parent: root, position: [0.1, 0.32, 0] });
-snapTo(scope, receiver);`
-    },
-    {
-      name: "createLadder",
-      signature: "createLadder(name, { bottom, top, material, width?, rungCount?, railRadius?, rungRadius?, widthAxis?, parent? })",
-      returns: "{ leftRail: Object3D, rightRail: Object3D, rungs: Object3D[] }",
-      category: "structure",
-      description: "Builds two continuous rails plus evenly-spaced rungs. Use this instead of loose boxes for ladders.",
-      example: "createLadder('TowerLadder', { bottom: [0,0,0], top: [0,2.2,0], width: 0.45, rungCount: 7, material: steel, parent: root });"
-    },
-    {
-      name: "createWingPair",
-      signature: "createWingPair(name, material, { rootZ, span, rootChord, tipChord, sweep?, thickness?, dihedral?, rootX?, rootY?, parent? })",
-      returns: "{ right: Object3D, left: Object3D }",
-      category: "structure",
-      description: "Creates mirrored trapezoid aircraft wings with roots attached at +/-rootZ. Use for aircraft wings and helicopter stub wings.",
-      example: "createWingPair('MainWing', olive, { rootX: 0, rootY: 1.0, rootZ: 0.42, span: 2.4, rootChord: 0.9, tipChord: 0.35, sweep: 0.25, dihedral: 0.08, parent: root });"
-    },
-    {
-      name: "room",
-      signature: "room(name, material, { width?, depth?, height?, wallThickness?, floor?, floorThickness?, openings?: [{ wall: 'front'|'back'|'left'|'right', kind?: 'door'|'window', offset?, width?, height?, sill? }], parent? })",
-      returns: "{ root: Object3D, walls: { front, back, left, right }, floor: Object3D | null }",
-      category: "structure",
-      description: "Builds a HOLLOW, enterable room: four thin walls + a floor, human-scaled (defaults: 2.8m ceiling, a centered 1.1x2.1m front door so it is enterable by default). `front` faces +X; the floor sits on the ground. The keystone of an architecture asset — add a roof with createRoofPlanes and fixtures as separate parts.",
-      example: "const { root: hut } = room('Hut', wood, { width: 5, depth: 4, height: 2.8, openings: [{ wall: 'front', kind: 'door' }, { wall: 'right', kind: 'window' }], parent: root });",
-      promptNotes: "Use for any building the player enters. Do NOT model a building as a solid block — room() guarantees real interior space and a doorway gap. Pass openings to add windows / side doors."
-    },
-    {
-      name: "wallWithOpening",
-      signature: "wallWithOpening(name, material, { length, height, thickness, axis?: 'x'|'z', opening?: { kind?: 'door'|'window', offset?, width?, height?, sill? }, parent? })",
-      returns: "THREE.Object3D (wall container)",
-      category: "structure",
-      description: "A single wall panel with an optional real door/window cut, composed from solid box segments (side panels + lintel + window sill) — no CSG. Base at local Y=0, centered on the run axis. Use to compose custom building layouts or interior dividing walls beyond the default room().",
-      example: "wallWithOpening('Partition', plaster, { length: 4, height: 2.8, thickness: 0.12, axis: 'x', opening: { kind: 'door', offset: 0.5 }, parent: root });"
-    },
-    {
-      name: "createRoofPlanes",
-      signature: "createRoofPlanes(name, material, { width, depth, height, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
-      returns: "{ root: Object3D, slopes: [Object3D, Object3D] }",
-      category: "structure",
-      description: "A pitched roof: two thin slopes meeting at one ridge and falling DOWN-AND-OUTWARD (opposite tilts — never mirrored the same way), footprint-matched with an eave overhang. Eave at local Y=0, ridge at Y=height, so position the group at Y=wallHeight. Returns a named group (e.g. `Roof`) the engine can lift to reveal the interior.",
-      example: `const { root: roof } = createRoofPlanes('Roof', shingle, { width: 5, depth: 4, height: 1.6, overhang: 0.4, ridgeAxis: 'x', parent: root });
-roof.position.y = 2.8;`,
-      promptNotes: "The two slopes must fall AWAY from each other from the ridge — createRoofPlanes does this for you. Drop it onto the walls (position.y = wall height)."
-    },
-    {
-      name: "createGableRoof",
-      signature: "createGableRoof(name, material, { spanX, spanZ, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
-      returns: "{ root, slopes: [Object3D, Object3D], faces: [RoofFaceFrame, RoofFaceFrame], rise, pitchDegrees }",
-      category: "structure",
-      description: "Explicit-axis gable roof using unambiguous footprint spans. Each face owns a rigid frame with ridge tangent, outward normal, downhill direction, ridge/eave endpoints, dimensions, and a live local-to-world transform.",
-      example: "const roof = createGableRoof('Roof', shingles, { spanX: 8, spanZ: 5, pitchDegrees: 35, overhang: 0.35, ridgeAxis: 'x', parent: root });",
-      promptNotes: "Prefer this over width/depth roof math. ridgeAxis is the direction of the ridge; roof panels run along each returned face downhill direction."
-    },
-    {
-      name: "createGableEndPanel",
-      signature: "createGableEndPanel(name, material, { span, rise, thickness?, ridgeAxis?: 'x'|'z', side?: 'positive'|'negative', openings?: [{ id?, offset?, bottom?, width, height }], parent? })",
-      returns: "{ root, geometry, openings }",
-      category: "structure",
-      description: "Exact thick triangular end closure for a gable roof, with optional rectangular openings cut from the geometry and semantic boundary metadata.",
-      example: "createGableEndPanel('FrontGable', siding, { span: 5, rise: 1.8, ridgeAxis: 'x', side: 'positive', parent: root });"
-    },
-    {
-      name: "createGableShell",
-      signature: "createGableShell(name, { wall, roof, floor?, gable? }, { spanX, spanZ, wallHeight?, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, wallThickness?, floorThickness?, closedEnds?, enterable?, openings?, gableOpenings?, parent? })",
-      returns: "{ root, walls, floor, roof, gables, openings }",
-      category: "structure",
-      description: "Closed-by-default, correct-by-construction gable building: hollow room, floor, two opposing roof slopes, two complete gable ends, and a real front doorway when enterable.",
-      example: "const house = createGableShell('House', { wall: plaster, roof: shingles }, { spanX: 8, spanZ: 5, wallHeight: 2.8, pitchDegrees: 35, ridgeAxis: 'x', parent: root });",
-      promptNotes: "Use for complete gable buildings. It stamps wall, floor, slope, gable, opening, adjacency, coverage, and separability semantics for deterministic QA and roof-off views."
-    },
-    {
-      name: "createRoofSurfaceLayout",
-      signature: "createRoofSurfaceLayout(name, material, { face, kind: 'panels'|'shingles'|'seams'|'corrugations', parent?, panelWidth?, rowHeight?, spacing?, thickness? })",
-      returns: "{ root, items: Object3D[] }",
-      category: "structure",
-      description: "Places roof-local panels, shingles, seams, or corrugations from a returned RoofFaceFrame, so repeated elements run ridge-to-eave for either ridge axis without manual Euler rotations.",
-      example: "for (const face of roof.faces) createRoofSurfaceLayout('Panels_' + face.side, metal, { face, kind: 'panels', parent: roof.root });",
-      promptNotes: "Always pass the face object returned by createGableRoof/createGableShell. Never infer the panel rotation from world axes."
-    },
-    {
-      name: "createStairs",
-      signature: "createStairs(name, material, { steps?, totalRise, totalRun, width, axis?: 'x'|'z', treadThickness?, riser?, parent? })",
-      returns: "{ root: Object3D, steps: Object3D[] }",
-      category: "structure",
-      description: "A straight flight of stairs: box treads (with optional risers) climbing totalRise over totalRun from local origin toward +axis. Use for porch/entry steps or to connect storeys in a multi-storey building.",
-      example: "createStairs('Porch', stone, { steps: 4, totalRise: 0.6, totalRun: 1.0, width: 1.4, axis: 'x', parent: root });"
-    },
-    {
-      name: "boxGeo",
-      signature: "boxGeo(width: number, height: number, depth: number)",
-      returns: "THREE.BoxGeometry",
-      category: "geometry",
-      description: "6-face box. 12 tris regardless of size. Cheapest geometry.",
-      example: "const geo = boxGeo(1, 0.5, 2);"
-    },
-    {
-      name: "sphereGeo",
-      signature: "sphereGeo(radius: number, widthSegments?: 8, heightSegments?: 6)",
-      returns: "THREE.SphereGeometry",
-      category: "geometry",
-      description: "UV sphere. Default 8x6 segments = 84 tris. Bump segments for smoother curves.",
-      example: "const geo = sphereGeo(0.5, 12, 8);"
-    },
-    {
-      name: "cylinderGeo",
-      signature: "cylinderGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
-      returns: "THREE.CylinderGeometry",
-      category: "geometry",
-      description: "Y-axis cylinder. Use radiusTop != radiusBottom for cones / tapered pieces.",
-      example: "const geo = cylinderGeo(0.25, 0.25, 1, 12);"
-    },
-    {
-      name: "cylinderYGeo",
-      signature: "cylinderYGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
-      returns: "THREE.CylinderGeometry",
-      category: "geometry",
-      description: "Alias for cylinderGeo — a Y-axis cylinder. Provided because the sandbox exposes cylinderXGeo / cylinderZGeo and the symmetric Y form is commonly reached for.",
-      example: "const geo = cylinderYGeo(0.25, 0.25, 1, 12);"
-    },
-    {
-      name: "cylinderXGeo",
-      signature: "cylinderXGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
-      returns: "THREE.CylinderGeometry",
-      category: "geometry",
-      description: "Cylinder pre-rotated to run along +X/-X. Use for fuselages, cannons, barrels, axles, and forward-facing tubes.",
-      example: "const geo = cylinderXGeo(0.1, 0.1, 1.2, 12);"
-    },
-    {
-      name: "cylinderZGeo",
-      signature: "cylinderZGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
-      returns: "THREE.CylinderGeometry",
-      category: "geometry",
-      description: "Cylinder pre-rotated to run along +Z/-Z. Use for side-mounted weapons, rails, crossbars, and pipes.",
-      example: "const geo = cylinderZGeo(0.08, 0.08, 0.9, 10);"
-    },
-    {
-      name: "cylinderOnAxis",
-      signature: "cylinderOnAxis(center: [x,y,z], normal: [x,y,z], radiusBottom: number, height: number, opts?: { radiusTop?, segments? })",
-      returns: "THREE.CylinderGeometry",
-      category: "geometry",
-      description: "Frame-first cylinder: position + axis specified directly, no post-hoc rotation. Use when the cylinder needs to point along a non-cardinal direction (struts inside CSG operands, antennas off a tilted surface). For cardinal axes prefer the terser cylinderXGeo / cylinderYGeo / cylinderZGeo helpers.",
-      example: "const strut = cylinderOnAxis([0.5, 0.7, 0], [1, 1, 0.3], 0.05, 0.9);"
-    },
-    {
-      name: "capsuleGeo",
-      signature: "capsuleGeo(radius: number, height: number, segments?: 6)",
-      returns: "THREE.CapsuleGeometry",
-      category: "geometry",
-      description: "Stadium shape (cylinder with hemispherical caps). Good for limbs.",
-      example: "const geo = capsuleGeo(0.1, 0.5, 6);"
-    },
-    {
-      name: "capsuleYGeo",
-      signature: "capsuleYGeo(radius: number, height: number, segments?: 6)",
-      returns: "THREE.CapsuleGeometry",
-      category: "geometry",
-      description: "Alias for capsuleGeo — a Y-axis capsule. Provided for symmetry with capsuleXGeo / capsuleZGeo.",
-      example: "const geo = capsuleYGeo(0.1, 0.5, 6);"
-    },
-    {
-      name: "capsuleXGeo",
-      signature: "capsuleXGeo(radius: number, length: number, segments?: 6)",
-      returns: "THREE.CapsuleGeometry",
-      category: "geometry",
-      description: "Capsule pre-rotated to run along +X/-X. Use for aircraft bodies, rounded vehicle hulls, and missiles.",
-      example: "const geo = capsuleXGeo(0.35, 2.4, 10);"
-    },
-    {
-      name: "capsuleZGeo",
-      signature: "capsuleZGeo(radius: number, length: number, segments?: 6)",
-      returns: "THREE.CapsuleGeometry",
-      category: "geometry",
-      description: "Capsule pre-rotated to run along +Z/-Z. Use for lateral pods, floats, and side tanks.",
-      example: "const geo = capsuleZGeo(0.18, 1.1, 8);"
-    },
-    {
-      name: "coneGeo",
-      signature: "coneGeo(radius: number, height: number, segments?: 8)",
-      returns: "THREE.ConeGeometry",
-      category: "geometry",
-      description: "Y-axis cone (pointed up). Use for spikes, roofs, projectiles.",
-      example: "const geo = coneGeo(0.3, 0.8, 8);"
-    },
-    {
-      name: "coneYGeo",
-      signature: "coneYGeo(radius: number, height: number, segments?: 8)",
-      returns: "THREE.ConeGeometry",
-      category: "geometry",
-      description: "Alias for coneGeo — a Y-axis cone (point +Y). Provided for symmetry with coneXGeo / coneZGeo.",
-      example: "const geo = coneYGeo(0.3, 0.8, 8);"
-    },
-    {
-      name: "coneXGeo",
-      signature: "coneXGeo(radius: number, length: number, segments?: 8)",
-      returns: "THREE.ConeGeometry",
-      category: "geometry",
-      description: "Cone pre-rotated so its point faces +X. Use for noses, rockets, shells, and forward-facing tips.",
-      example: "const geo = coneXGeo(0.18, 0.45, 12);"
-    },
-    {
-      name: "coneZGeo",
-      signature: "coneZGeo(radius: number, length: number, segments?: 8)",
-      returns: "THREE.ConeGeometry",
-      category: "geometry",
-      description: "Cone pre-rotated so its point faces +Z. Use for side-facing projectiles and tips.",
-      example: "const geo = coneZGeo(0.12, 0.35, 10);"
-    },
-    {
-      name: "taperConeGeo",
-      signature: "taperConeGeo(radiusBottom: number, radiusTop: number, height: number, axis?: 'x'|'y'|'z', segments?: 8)",
-      returns: "THREE.CylinderGeometry",
-      category: "geometry",
-      description: "Truncated cone (frustum) — exposes both bottom and top radius. radiusTop=0 matches coneGeo, radiusTop=radiusBottom matches cylinderGeo. Use for pylon caps, soda cans, lampshades, anything tapered that does not come to a point. axis selects orientation (default Y).",
-      example: "const cap = taperConeGeo(0.3, 0.18, 0.4);  // frustum"
-    },
-    {
-      name: "torusGeo",
-      signature: "torusGeo(radius: number, tube: number, radialSegments?: 8, tubularSegments?: 12)",
-      returns: "THREE.TorusGeometry",
-      category: "geometry",
-      description: "Donut shape. For rings, tyres, barrel ribs.",
-      example: "const geo = torusGeo(0.4, 0.04, 8, 16);"
-    },
-    {
-      name: "planeGeo",
-      signature: "planeGeo(width: number, height: number, widthSegments?: 1, heightSegments?: 1)",
-      returns: "THREE.PlaneGeometry",
-      category: "geometry",
-      description: "Flat quad for TEXTURED surfaces (ground, signs, walls with albedo maps). For solid-color decals like red stars, hull numbers, stamps, or window cutouts on no-texture assets use decalBox — a bare planeGeo without a texture will render as a disconnected 2-tri square and get flagged as a stray plane.",
-      example: "const geo = planeGeo(4, 4);"
-    },
-    {
-      name: "decalBox",
-      signature: "decalBox(width: number, height: number, depth?: 0.01)",
-      returns: "THREE.BoxGeometry",
-      category: "geometry",
-      description: "Thin box for solid-color surface decals: red stars, hull numbers, stamps, no-texture windows. Unlike planeGeo, has real depth so it visibly attaches to its host surface. Must be placed on a surface with position + rotation.",
-      example: `const star = decalBox(0.18, 0.18, 0.01);
-createPart('Mesh_StarPort', star, gameMaterial(0xc61f2a), { position: [0.4, 0.6, 0.41], parent: fuselage });`,
-      promptNotes: "Offset at least 0.01 outside the host surface to avoid z-fighting (a 0.8-wide hull has faces at z=±0.4, so place the decal at z=±0.41)."
-    },
-    {
-      name: "foliageCardGeo",
-      signature: "foliageCardGeo(opts?: { width?, height?, yPivot?: 0..1 })",
-      returns: "THREE.PlaneGeometry",
-      category: "geometry",
-      description: "Single-quad foliage card with a configurable Y pivot. yPivot=0 plants the quad on the ground. Pair with an alpha-tested material and a leaf/plant sprite.",
-      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
-const quad = foliageCardGeo({ width: 4, height: 6, yPivot: 0 });
-createPart('Mesh_Fern', quad, leaves, { parent: root });`
-    },
-    {
-      name: "crossedQuadsGeo",
-      signature: "crossedQuadsGeo(opts?: { width?, height?, planes?: 2 | 3, yPivot? })",
-      returns: "THREE.BufferGeometry",
-      category: "geometry",
-      description: "Cross-billboard bush primitive: 2 or 3 planes intersecting along the Y axis. Reads as a dense plant from any angle, cheaper than real geometry.",
-      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
-const bush = crossedQuadsGeo({ width: 2, height: 2, planes: 3 });
-createPart('Mesh_Bush', bush, leaves, { parent: root });`
-    },
-    {
-      name: "octaGridPlane",
-      signature: "octaGridPlane({ tilesX, tilesY, width?, height?, yPivot? })",
-      returns: "THREE.PlaneGeometry",
-      category: "geometry",
-      description: "Atlas-ready billboard quad. UVs are pre-scaled to cover one tile of a tilesX×tilesY atlas; the consumer shader adds per-instance tile offsets at draw time.",
-      example: "const card = octaGridPlane({ tilesX: 4, tilesY: 4, width: 6, height: 6 });"
-    },
-    {
-      name: "wingGeo",
-      signature: "wingGeo(opts?: { span, rootChord, tipChord, sweep, thickness, dihedral })",
-      returns: "THREE.BufferGeometry",
-      category: "geometry",
-      description: "Trapezoid wing panel. Local root edge is at Z=0, span extends toward +Z, positive sweep moves the tip aft along -X.",
-      example: "const geo = wingGeo({ span: 2.2, rootChord: 0.8, tipChord: 0.3, sweep: 0.25, dihedral: 0.08 });"
-    },
-    {
-      name: "gearGeo",
-      signature: "gearGeo(opts?: { teeth?: 12, rootRadius?: 0.8, tipRadius?: 1.0, boreRadius?: 0.2, height?: 0.3, toothWidthFrac?: 0.5 })",
-      returns: "THREE.BufferGeometry",
-      category: "geometry",
-      description: "Stylized gear with flat edges and an optional center bore; no CSG. Use boreRadius < rootRadius < tipRadius. Radii are absolute: an omitted rootRadius stays 0.8 when tipRadius changes. Set all three radii for small gears.",
-      example: `const g = gearGeo({ teeth: 28, rootRadius: 0.063, tipRadius: 0.075, boreRadius: 0.012, height: 0.024 });
-createPart('Gear', g, gameMaterial(0x909090, { metalness: 0.8 }), { parent: root });`
-    },
-    {
-      name: "bladeGeo",
-      signature: "bladeGeo(opts?: { length?: 1.5, baseWidth?: 0.1, thickness?: 0.015, tipLength?: 0.25, edgeBevel?: 0 })",
-      returns: "THREE.BufferGeometry",
-      category: "geometry",
-      description: "Parametric sword blade: rectangular base tapering to a point over tipLength. edgeBevel > 0 pinches the cross-section toward a diamond ridge.",
-      example: `const b = bladeGeo({ length: 1.6, baseWidth: 0.09, tipLength: 0.3, edgeBevel: 0.5 });
-createPart('Blade', b, steel, { position: [0, 0, 0], parent: root });`
-    },
-    {
-      name: "gameMaterial",
-      signature: "gameMaterial(color, opts?: { metalness, roughness, emissive, emissiveIntensity, flatShading })",
-      returns: "THREE.MeshStandardMaterial",
-      category: "material",
-      description: "Flat-shaded PBR material. Default for game-ready low-poly. Use for 95% of parts.",
-      example: "const mat = gameMaterial(0x8b7355, { roughness: 0.9 });"
-    },
-    {
-      name: "materialRecipe",
-      signature: "await materialRecipe(recipeId, overrides?: { baseColor?, roughness?, metalness?, opacity?, alphaCutoff?, doubleSided?, emissiveColor?, emissiveIntensity?, textureResources? })",
-      returns: "Promise<THREE.MeshStandardMaterial>",
-      category: "material",
-      description: "Resolves a versioned portable bark/leaf/wood/stone/rubber/painted-metal/cloth/skin/glass/emissive recipe to standard glTF PBR.",
-      example: "const bark = await materialRecipe('kiln.material.bark.v1', { baseColor: '#6b4328' });",
-      promptNotes: "Use only listed kiln.material.*.v1 IDs and approved kiln.texture.* resource IDs. Leaf is MASK, glass is BLEND, and host file paths are forbidden."
-    },
-    {
-      name: "compilePortableMaterialSpecV2",
-      signature: "await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', name?, baseColor?, roughness?, metalness?, emissive?, emissiveIntensity?, alphaMode?, alphaCutoff?, doubleSided?, textures?: { baseColor?, normal?, metallicRoughness?, emissive?, occlusion? } })",
-      returns: "Promise<THREE.MeshStandardMaterial>",
-      category: "material",
-      description: "Compiles the strict portable material contract. Texture refs are either typed procedural V2 specs or closed approved kiln.texture.* IDs; paths, URLs, raw textures, callbacks, and shader source are rejected.",
-      example: "const steel = await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', roughness: 0.45, metalness: 0.85, textures: { metallicRoughness: { kind: 'procedural', spec: { schemaVersion: 2, usage: 'metallicRoughness', size: 64, layers: [{ op: 'solid', color: 0x0080cc }] } } } });",
-      promptNotes: "Use metallicRoughness as one packed G=roughness/B=metalness map. Every procedural ref usage must match its slot; resource refs must be approved for that exact slot."
-    },
-    {
-      name: "basicMaterial",
-      signature: "basicMaterial(color, opts?: { transparent, opacity })",
-      returns: "THREE.MeshBasicMaterial",
-      category: "material",
-      description: "Unlit flat material. For UI / effects where lighting is baked in.",
-      example: "const mat = basicMaterial(0xffffff, { transparent: true, opacity: 0.5 });"
-    },
-    {
-      name: "glassMaterial",
-      signature: "glassMaterial(color, opts?: { opacity, roughness, metalness })",
-      returns: "THREE.MeshStandardMaterial",
-      category: "material",
-      description: "Semi-transparent double-sided material. Panels need ~0.05 offset to avoid z-fighting.",
-      example: "const mat = glassMaterial(0x66ccff, { opacity: 0.3 });"
-    },
-    {
-      name: "lambertMaterial",
-      signature: "lambertMaterial(color, opts?: { flatShading, emissive })",
-      returns: "THREE.MeshLambertMaterial",
-      category: "material",
-      description: "Cheaper than gameMaterial. No metalness/roughness. Use when PBR is overkill.",
-      example: "const mat = lambertMaterial(0x2a4d14, { flatShading: true });"
-    },
-    {
-      name: "rotationTrack",
-      signature: "rotationTrack(jointName: string, keyframes: Array<{ time, rotation: [xDeg, yDeg, zDeg] }>, interp?: 'LINEAR' | 'STEP')",
-      returns: "THREE.QuaternionKeyframeTrack",
-      category: "animation",
-      description: "Rotation track in degrees, auto-converted to quaternions. Joint name must include `Joint_` prefix.",
-      example: "rotationTrack('Joint_Lid', [{ time: 0, rotation: [0, 0, 0] }, { time: 1, rotation: [90, 0, 0] }]);"
-    },
-    {
-      name: "positionTrack",
-      signature: "positionTrack(jointName: string, keyframes: Array<{ time, position: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
-      returns: "THREE.VectorKeyframeTrack",
-      category: "animation",
-      description: "Position track in world units. Always use `position:` not `value:` in keyframes.",
-      example: "positionTrack('Joint_Body', [{ time: 0, position: [0, 0, 0] }, { time: 1, position: [0, 0.1, 0] }]);"
-    },
-    {
-      name: "scaleTrack",
-      signature: "scaleTrack(jointName: string, keyframes: Array<{ time, scale: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
-      returns: "THREE.VectorKeyframeTrack",
-      category: "animation",
-      description: "Uniform or per-axis scale track.",
-      example: "scaleTrack('Joint_Chest', [{ time: 0, scale: [1, 1, 1] }, { time: 1, scale: [1.1, 1.1, 1.1] }]);"
-    },
-    {
-      name: "createClip",
-      signature: "createClip(name: string, duration: number, tracks: KeyframeTrack[])",
-      returns: "THREE.AnimationClip",
-      category: "animation",
-      description: "Collects tracks into a named clip. Returned from animate().",
-      example: "return [createClip('Open', 1, [rotationTrack('Joint_Lid', [...])])];"
-    },
-    {
-      name: "idleBreathing",
-      signature: "idleBreathing(bodyJoint: string, duration?: 2, amount?: 0.02)",
-      returns: "THREE.AnimationClip",
-      category: "animation",
-      description: "Gentle Y-axis bob. For NPC idle states.",
-      example: "return [idleBreathing('Joint_Body')];"
-    },
-    {
-      name: "bobbingAnimation",
-      signature: "bobbingAnimation(rootName: string, duration?: 2, height?: 0.1)",
-      returns: "THREE.AnimationClip",
-      category: "animation",
-      description: "Floating / bobbing loop for pickups and effects.",
-      example: "return [bobbingAnimation('Joint_Root', 1.5, 0.08)];"
-    },
-    {
-      name: "spinAnimation",
-      signature: "spinAnimation(jointName: string, duration?: 2, axis?: 'x' | 'y' | 'z')",
-      returns: "THREE.AnimationClip",
-      category: "animation",
-      description: "360° rotation over `duration` around `axis`.",
-      example: "return [spinAnimation('Joint_Rotor', 0.5, 'y')];"
-    },
-    {
-      name: "cloneGeometry",
-      signature: "cloneGeometry(geo: BufferGeometry)",
-      returns: "THREE.BufferGeometry (same ref)",
-      category: "instancing",
-      description: "Deprecated name: returns the SAME geometry, without copying. Use copyGeometry for independent vertex edits, or pass the original geometry directly for intentional sharing.",
-      example: "const wheelGeo = cylinderGeo(0.4, 0.4, 0.2, 12);"
-    },
-    {
-      name: "cloneMaterial",
-      signature: "cloneMaterial(mat: Material)",
-      returns: "THREE.Material (same ref)",
-      category: "instancing",
-      description: "Deprecated name: returns the SAME material. Use copyMaterial for independent property edits, or pass the original for intentional sharing.",
-      example: "const rubberMat = gameMaterial(0x1a1a1a, { roughness: 0.95 });"
-    },
-    {
-      name: "createInstance",
-      signature: "createInstance(name, source, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, parent })",
-      returns: "THREE.Object3D",
-      category: "instancing",
-      description: "Creates a new mesh reusing an existing part's geometry + material at a new transform. Cheapest way to replicate wheels / bolts / fence posts / windows. `rotation` is in DEGREES, like createPart.",
-      example: `const wheelFL = createPart('WheelFL', wheelGeo, rubberMat, { position: [-0.8, 0.3, 1.2], parent: root });
-createInstance('WheelFR', wheelFL, { position: [0.8, 0.3, 1.2], parent: root });
-createInstance('WheelRL', wheelFL, { position: [-0.8, 0.3, -1.2], parent: root });
-createInstance('WheelRR', wheelFL, { position: [0.8, 0.3, -1.2], parent: root });`
-    },
-    {
-      name: "boolUnion",
-      signature: "await boolUnion(name: string, ...parts: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
-      returns: "Promise<THREE.Mesh>",
-      category: "csg",
-      description: "Merges two or more parts into one watertight manifold mesh. Default flat shading (hard edges) — pass { smooth: true } as last arg for averaged normals on organic merges.",
-      example: `const body = new THREE.Mesh(boxGeo(2, 1, 1), steel);
-const turret = new THREE.Mesh(cylinderGeo(0.3, 0.3, 0.4, 16), steel);
-turret.position.y = 0.5;
-const hull = await boolUnion('Hull', body, turret);`
-    },
-    {
-      name: "boolDiff",
-      signature: "await boolDiff(name: string, body: Object3D, ...cutters: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
-      returns: "Promise<THREE.Mesh>",
-      category: "csg",
-      description: "Subtracts cutters from a body (holes, button recesses, window slots). Default flat shading for sharp mechanical edges.",
-      example: `const body = new THREE.Mesh(cylinderGeo(1, 1, 0.3, 32), steel);
-const teeth = [...]; // 8 radially-arrayed box meshes
-const gear = await boolDiff('Gear', body, ...teeth);  // hard-edged`
-    },
-    {
-      name: "roundedBoxGeo",
-      signature: "await roundedBoxGeo(width: number, height: number, depth: number, radius: number, opts?: { style?: 'round' | 'chamfer', segments?: 12, smooth?: boolean })",
-      returns: "Promise<THREE.BufferGeometry>",
-      category: "csg",
-      description: "A box with all twelve edges rounded (or chamfered) at the EXACT outer size requested — roundedBoxGeo(1, 1, 1, 0.1) measures 1x1x1, it does not grow. Use it anywhere boxGeo reads too sharp: consoles, crates, appliances, handheld props, machined blocks.",
-      promptNotes: "Real objects almost never have perfectly sharp box edges, and a small radius is the single cheapest upgrade to how manufactured an asset looks. Prefer this over boxGeo for anything moulded, cast, or machined. Keep radius small relative to the box (5-10% of the smallest dimension); radius must be less than half the smallest dimension or the call throws. style: 'chamfer' reads as machined metal, 'round' as moulded plastic. This is async — build() must be async and the call must use await.",
-      example: `const geo = await roundedBoxGeo(1.2, 0.6, 0.8, 0.05);
-createPart('Console', geo, plastic, { position: [0, 0.3, 0], parent: root });`
-    },
-    {
-      name: "extrudeProfile",
-      signature: "await extrudeProfile(profile: [number, number][], opts?: { depth?: 1, holes?: [number, number][][], bevel?: 0, bevelStyle?: 'round' | 'chamfer', segments?: 12, twist?: 0, taper?: number | [number, number], divisions?: number, axis?: 'x' | 'y' | 'z', center?: true, smooth?: false })",
-      returns: "Promise<THREE.BufferGeometry>",
-      category: "csg",
-      description: "Sweeps a closed 2D outline into a watertight solid, with optional holes, corner rounding/chamfering, twist, and taper. The way to build any cross-section that is not a box or a cylinder: L-brackets, I-beams, gaskets, washers, star and gear plates, signage, extruded trim.",
-      promptNotes: "The bevel rounds the edges PARALLEL to the sweep axis (the profile corners) — the two flat caps stay sharp. For a box rounded on all twelve edges use roundedBoxGeo instead. Holes are subtracted, so their winding order does not matter. A bevel larger than half the outline's narrowest feature throws rather than silently returning an empty solid. Output is manifold, so it feeds straight into boolUnion / boolDiff / boolIntersect. Async — await it inside an async build().",
-      example: `// L-bracket, inner AND outer corners filleted
-const outline = [[0, 0], [2, 0], [2, 0.4], [0.4, 0.4], [0.4, 2], [0, 2]];
-const geo = await extrudeProfile(outline, { depth: 0.5, bevel: 0.06 });
-createPart('Bracket', geo, steel, { parent: root });`
-    },
-    {
-      name: "revolveProfile",
-      signature: "await revolveProfile(profile: [number, number][], opts?: { segments?: 24, angle?: 360, bevel?: 0, bevelStyle?: 'round' | 'chamfer', bevelSegments?: 12, axis?: 'x' | 'y' | 'z', smooth?: true })",
-      returns: "Promise<THREE.BufferGeometry>",
-      category: "csg",
-      description: "Revolves a closed 2D outline around an axis into a watertight SOLID, optionally rounding the profile corners first. Bottles, tanks, pressure vessels, wheels, turned wood, domes, buttons, pills.",
-      promptNotes: "Use this instead of lathe/revolveGeo whenever the result must survive a boolean or needs a rounded rim — lathe and revolveGeo build an open surface, this builds a closed solid. Profile convention matches lathe: x is distance from the axis, y is position along it, and only the x >= 0 side is used. Async — await it inside an async build().",
-      example: `// capsule tank with a rounded rim, then carve a port into it
-const profile = [[0, -0.5], [0.4, -0.5], [0.4, 0.5], [0, 0.5]];
-const body = await revolveProfile(profile, { bevel: 0.08, segments: 32 });
-const tank = await boolDiff('Tank', createPart('B', body, steel), portCutter);`
-    },
-    {
-      name: "circleProfile",
-      signature: "circleProfile(radius: number, segments?: 24, center?: [number, number])",
-      returns: "[number, number][]",
-      category: "csg",
-      description: "Builds a closed circular outline for extrudeProfile / revolveProfile, so you never hand-write the trigonometry. Synchronous.",
-      example: `const washer = await extrudeProfile(circleProfile(1), {
-  depth: 0.1,
-  holes: [circleProfile(0.4), circleProfile(0.1, 16, [0.7, 0])],
-});`
-    },
-    {
-      name: "boolIntersect",
-      signature: "await boolIntersect(name: string, a: Object3D, b: Object3D, opts?: { smooth?: false })",
-      returns: "Promise<THREE.Mesh>",
-      category: "csg",
-      description: "Keeps only the volume where both operands overlap. Default flat shading.",
-      example: "const lens = await boolIntersect('Lens', boxMesh, sphereMesh);"
-    },
-    {
-      name: "hull",
-      signature: "await hull(name: string, ...parts: Object3D[], opts?: { smooth?: true })",
-      returns: "Promise<THREE.Mesh>",
-      category: "csg",
-      description: "Tightest convex mesh enclosing all input points. Default smooth shading (rocks, collision volumes). Pass { smooth: false } for a faceted look.",
-      example: `const rockChunks = [...]; // scattered box meshes
-const rock = await hull('Rock', ...rockChunks);`
-    },
-    {
-      name: "arrayLinear",
-      signature: "arrayLinear(namePrefix, source, count, offset: [x,y,z], parent?)",
-      returns: "THREE.Object3D[]",
-      category: "arrays",
-      description: "Places N copies of `source` along a constant offset vector. Copies share geometry + material via createInstance.",
-      example: `const post = createPart('Post0', cylinderGeo(0.05,0.05,1.5,6), wood, { position: [0,0.75,0], parent: root });
-arrayLinear('Post', post, 10, [0.5, 0, 0], root);`
-    },
-    {
-      name: "arrayRadial",
-      signature: "arrayRadial(namePrefix, source, count, axis?: 'x'|'y'|'z', parent?)",
-      returns: "THREE.Object3D[]",
-      category: "arrays",
-      description: "Places N copies of `source` around the given axis. Source's local rotation is oriented outward. Perfect for gear teeth, radial bolts, circle of columns.",
-      example: `const bolt = createPart('Bolt0', cylinderGeo(0.02,0.02,0.1,6), steel, { position: [1,0,0], parent: root });
-arrayRadial('Bolt', bolt, 8, 'y', root);`
-    },
-    {
-      name: "mirror",
-      signature: "mirror(name, source, axis: 'x'|'y'|'z', parent?)",
-      returns: "THREE.Object3D",
-      category: "arrays",
-      description: "Reflects source across the plane whose normal is `axis`. Uses negative scale (winding flip handled by viewers).",
-      example: "mirror('WingR', wingL, 'x', root);"
-    },
-    {
-      name: "subdivide",
-      signature: "subdivide(geometry: BufferGeometry, iterations?: 1, opts?: { preserveUV?: boolean, split?: boolean, uvSmooth?: boolean, preserveEdges?: boolean, flatOnly?: boolean, weld?: boolean })",
-      returns: "THREE.BufferGeometry",
-      category: "mesh-ops",
-      description: "Loop subdivision returns new geometry; each iteration roughly quadruples triangles and smooths the surface. Use preserveUV:true for textured meshes. Legacy position-only welding discards UVs and reports that loss. This smooths shapes, not selected-edge beveling.",
-      example: "const smoothRock = subdivide(boxGeo(1, 1, 1), 2);"
-    },
-    {
-      name: "mergeVertices",
-      signature: "mergeVertices(geometry: BufferGeometry, opts?: { tolerance?: 1e-4, positionOnly?: boolean } | number)",
-      returns: "THREE.BufferGeometry",
-      category: "mesh-ops",
-      description: "Returns indexed geometry. Default welding preserves attribute seams, so a textured cube retains separate face corners. positionOnly:true welds coincident positions and discards other attributes; use it explicitly when changing topology and regenerate shading/UVs afterward.",
-      example: `const welded = mergeVertices(boxGeo(1, 1, 1), { positionOnly: true });
-const rock = displace(subdivide(welded, 2), ([x,y,z]) => [0.08*Math.sin(y*7+z*3), 0.04*Math.sin(x*9), 0]);`
-    },
-    {
-      name: "curveToMesh",
-      signature: "curveToMesh(points: [x,y,z][], radius, tubularSegs?: 32, radialSegs?: 8, closed?: false)",
-      returns: "THREE.BufferGeometry",
-      category: "curves",
-      description: "Sweeps a circular profile along a path. Equivalent to Blender's Curve to Mesh node with a circle profile. Use for pipes, cables, tubular frames.",
-      example: "const pipe = curveToMesh([[0,0,0],[0,1,0],[1,1,0],[1,2,0]], 0.1);"
-    },
-    {
-      name: "pipeAlongPath",
-      signature: "pipeAlongPath(points: [x,y,z][], radius: number, opts?: { bendRadius?: 0, closed?: false, tubularSegments?: 32, radialSegments?: 8 })",
-      returns: "THREE.BufferGeometry",
-      category: "curves",
-      description: "Path-driven swept circle with optional bend smoothing. Generalises beamBetween (point-to-point) and curveToMesh (raw spline) into one helper. bendRadius>0 inserts interpolated waypoints near interior corners so the spline reads as a rounded turn instead of pinching to the control point.",
-      example: "const cable = pipeAlongPath([[0, 0.5, 0], [1, 0.5, 0], [1, 0.5, 2]], 0.02, { bendRadius: 0.1 });"
-    },
-    {
-      name: "lathe",
-      signature: "lathe(profile: [x,y][], segments?: 12)",
-      returns: "THREE.BufferGeometry",
-      category: "curves",
-      description: "Surface of revolution. Spins a 2D profile around the Y axis. For bottles, vases, wheels, turned wood parts.",
-      example: "const vase = lathe([[0.1,0],[0.3,0.5],[0.2,1],[0.1,1.2]], 16);"
-    },
-    {
-      name: "revolveGeo",
-      signature: "revolveGeo(profile: [x,y][], opts?: { angle?: 2π, axis?: [x,y,z]=[0,1,0], segments?: 12 })",
-      returns: "THREE.BufferGeometry",
-      category: "curves",
-      description: "Surface of revolution with explicit axis + sweep angle. Generalises lathe — use it when you need a partial sweep (half-dome, 90° wedge) or revolution around a non-Y axis. Profile convention is identical to lathe: x = radial distance, y = position along the axis.",
-      example: `// Half-dome (180° sweep around +Y):
-const quarter = [...Array(8)].map((_, i) => { const t = (i/7)*Math.PI/2; return [Math.cos(t), Math.sin(t)] as [number, number]; });
-const dome = revolveGeo(quarter, { angle: Math.PI });`
-    },
-    {
-      name: "bezierCurve",
-      signature: "bezierCurve(controlPoints: [x,y,z][], samples?: 32)",
-      returns: "[x,y,z][]",
-      category: "curves",
-      description: "Samples a quadratic (3 ctrl pts) or cubic (4 ctrl pts) Bézier into a point list you can feed into curveToMesh.",
-      example: `const path = bezierCurve([[0,0,0],[1,2,0],[3,2,0],[4,0,0]], 24);
-const geo = curveToMesh(path, 0.1);`
-    },
-    {
-      name: "autoUnwrap",
-      signature: "await autoUnwrap(geometry: BufferGeometry, opts?: { resolution?: 1024, padding?: 2, useNormals?: false })",
-      returns: "Promise<THREE.BufferGeometry>",
-      category: "uv",
-      description: "xatlas-based UV atlas for ANY geometry (CSG output, subdivided, deformed). Output is a packed atlas with arbitrary per-chart rotation — use for non-tileable baked textures. For directional tileable textures on box/cylinder/plane primitives, prefer the shape-aware unwraps below.",
-      example: `const unwrapped = await autoUnwrap(someCsgResult, { resolution: 1024 });
-const mesh = new THREE.Mesh(unwrapped, bakedPbr);`
-    },
-    {
-      name: "boxUnwrap",
-      signature: "boxUnwrap(geometry: BufferGeometry)",
-      returns: "THREE.BufferGeometry",
-      category: "uv",
-      description: "Preserves BoxGeometry's built-in per-face UVs — every face maps [0,1] with consistent orientation. Use for crates/blocks with a tileable texture. Sync; no WASM cost.",
-      example: `const crate = boxUnwrap(boxGeo(1, 1, 1));
-const mesh = new THREE.Mesh(crate, pbrMaterial({ albedo: planksTex }));`
-    },
-    {
-      name: "cylinderUnwrap",
-      signature: "cylinderUnwrap(geometry: BufferGeometry)",
-      returns: "THREE.BufferGeometry",
-      category: "uv",
-      description: "Preserves CylinderGeometry's built-in UVs: u wraps around the axis (horizontal texture features ring the cylinder), v runs up the height. Caps use circle-in-square. Sync; no WASM cost.",
-      example: `const barrel = cylinderUnwrap(cylinderGeo(0.5, 0.5, 1.2, 24));
-const mesh = new THREE.Mesh(barrel, pbrMaterial({ albedo: bandsTex }));`
-    },
-    {
-      name: "planeUnwrap",
-      signature: "planeUnwrap(geometry: BufferGeometry)",
-      returns: "THREE.BufferGeometry",
-      category: "uv",
-      description: "Projects xy-extent of the bbox to [0,1]. Use for signs/decals/posters where you want ONE readable texture and no edge-face bleeding. Sync.",
-      example: `const sign = planeUnwrap(planeGeo(1, 0.6));
-const mesh = new THREE.Mesh(sign, pbrMaterial({ albedo: kilnTextTex }));`
-    },
-    {
-      name: "panelRemapV",
-      signature: "panelRemapV(geo, vScale=0.30, vOffset=0, uScale=1, uOffset=0)",
-      returns: "THREE.BufferGeometry",
-      category: "uv",
-      description: "Scales an existing UV attribute so a small mesh samples a sub-region of a SHARED texture. Replaces the broken texture.clone() pattern (Three.js Texture.clone() runs JSON.stringify on userData, mangling encoded PNG bytes — panelRemapV avoids that by remapping UVs on the geometry instead). Typical use: multi-zone albedo where v=0..0.30 is plain panel and v=0.30..1 has windows/markings — small parts call panelRemapV(unwrap(geo), 0.30) to sample only the clean strip.",
-      example: `const cowlGeo = panelRemapV(cylinderUnwrap(capsuleXGeo(0.45, 1.0)), 0.30);
-const cowl = new THREE.Mesh(cowlGeo, bodyMat); // SAME bodyMat as fuselage, no clone needed`
-    },
-    {
-      name: "loadApprovedTexture",
-      signature: "await loadApprovedTexture(resourceId)",
-      returns: "Promise<THREE.DataTexture>",
-      category: "textures",
-      description: "Loads one approved kiln.texture.* resource ID through the host-injected closed resolver. The registry fixes bytes, MIME, usage, dimensions, hash, and deadline; paths, URLs, byte arrays, resolver objects, hashes, and options are rejected.",
-      example: "const bark = await loadApprovedTexture('kiln.texture.bark-brown-01-albedo.v1');",
-      promptNotes: "Use only a concrete resource ID listed in material capabilities; never invent one. Prefer materialRecipe when a recipe already binds the family, or proceduralTexture V2 for authored surfaces. NEVER texture.clone() a loaded texture (clone() corrupts encoded bytes and breaks GLB export)."
-    },
-    {
-      name: "proceduralTexture",
-      signature: "proceduralTexture({ schemaVersion: 2, size?: 4..1024 pow2, usage?, name?, layers: [{ op: 'solid'|'checker'|'stripes'|'gradient'|'bricks'|'noise', ...params, blend?: 'normal'|'multiply'|'screen'|'overlay', opacity?: 0..1 }] })",
-      returns: "THREE.DataTexture (tiling, sRGB or linear per usage)",
-      category: "textures",
-      description: "Builds a tiling texture from a bounded layer stack — no image file needed. Layers composite bottom-first. Noise is seeded and tileable, so the same spec always produces the same bytes and a repeating material shows no seam. Baked to PNG and embedded in the GLB automatically.",
-      example: "const bark = proceduralTexture({ schemaVersion: 2, size: 256, usage: 'albedo', name: 'Bark', layers: [{ op: 'solid', color: 0x5a4632 }, { op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4, blend: 'overlay' }] });",
-      promptNotes: "Sync — no await. Strict V2 JSON boundary: unknown/prototype keys, callbacks, paths, URLs, and shader source are rejected. Prefer this over approved resources for describable surfaces. Max 8 layers, power-of-two size up to 1024. Only the six listed ops exist."
-    },
-    {
-      name: "normalMapFromHeight",
-      signature: "normalMapFromHeight(source: THREE.Texture, { strength?: number, name?: string })",
-      returns: "THREE.DataTexture (linear normal map)",
-      category: "textures",
-      description: "Derives a tangent-space normal map from the source texture's brightness, treating it as height. The cheap way to get real PBR surface relief out of a procedural albedo. Wraps at the edges, so a tiling source gives a tiling normal map.",
-      example: `const bark = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4 }] });
-const mat = pbrMaterial({ albedo: bark, normal: normalMapFromHeight(bark, { strength: 4 }) });`,
-      promptNotes: "strength 1 is subtle, 4-8 reads clearly at normal viewing distance. Output is always linear data — never assign it to an albedo/emissive slot."
-    },
-    {
-      name: "pbrMaterial",
-      signature: "pbrMaterial({ albedo?, normal?, roughness?, metalness?, metallicRoughness?, emissive?, aoMap?, alphaMode?, alphaCutoff?, doubleSided? })",
-      returns: "THREE.MeshStandardMaterial",
-      category: "material",
-      description: "Portable glTF PBR material. Use an explicit packed metallicRoughness texture (G=roughness, B=metalness); separate data maps are rejected instead of silently dropping a channel. Supports OPAQUE/MASK/BLEND and double-sided output.",
-      example: `const wood = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x4f301c, colorB: 0x9a6b3e, scale: 8, octaves: 3, seed: 4 }] });
-const crate = pbrMaterial({ albedo: wood, roughness: 0.85, metalness: 0 });`
-    },
-    {
-      name: "foliageMaterial",
-      signature: "foliageMaterial(albedo, { alphaCutoff?, roughness?, doubleSided? })",
-      returns: "THREE.MeshStandardMaterial",
-      category: "material",
-      description: "Portable foliage material that defaults to glTF MASK, cutoff 0.5, rough nonmetal, and double-sided. Use an alpha-bearing albedo texture.",
-      example: "const mat = await materialRecipe('kiln.material.leaf.v1');"
-    },
-    {
-      name: "countTriangles",
-      signature: "countTriangles(root: Object3D)",
-      returns: "number",
-      category: "utility",
-      description: "Sums triangle count across every mesh in the subtree.",
-      example: "meta.tris = countTriangles(root);"
-    },
-    {
-      name: "countMaterials",
-      signature: "countMaterials(root: Object3D)",
-      returns: "number",
-      category: "utility",
-      description: "Unique material count (by reference) across the subtree.",
-      example: "const mats = countMaterials(root);"
-    },
-    {
-      name: "getJointNames",
-      signature: "getJointNames(root: Object3D)",
-      returns: "string[]",
-      category: "utility",
-      description: "All node names beginning with `Joint_`. Use to sanity-check animation targets.",
-      example: "const joints = getJointNames(root);"
-    },
-    {
-      name: "validateAsset",
-      signature: "validateAsset(root: Object3D, category: 'character' | 'prop' | 'vfx' | 'environment' | 'architecture' | 'vegetation' | 'vehicle')",
-      returns: "{ valid, errors, warnings }",
-      category: "utility",
-      description: "Checks geometry and material costs for the selected category. No default triangle limit; choose detail for the intended runtime and inspect measured draw calls.",
-      example: "const v = validateAsset(root, 'prop');"
-    }
-  ];
-});
-
 // src/tools/discovery.ts
 import { z as z3 } from "zod";
 function createKilnDiscoveryDef(context) {
@@ -28653,6 +28756,17 @@ function collectSceneMetrics(root) {
   }
   return { meshes, materials: materialSet.size, bbox, lowestPart };
 }
+function withSyntaxDetail(message, code) {
+  if (!message.startsWith(evaluatorOutcomeMessage("EXECUTION_REJECTED")))
+    return message;
+  let syntax;
+  try {
+    syntax = validate(code).errors.find((error) => error.startsWith("Syntax error:"));
+  } catch {
+    return message;
+  }
+  return syntax ? `${message} ${syntax}` : message;
+}
 async function runRender(input, context) {
   try {
     const { root, rendered } = await loadEvaluatedReviewScene(input.code, context);
@@ -28671,6 +28785,7 @@ async function runRender(input, context) {
       tris: rendered.tris,
       meshes: metrics.meshes,
       materials: metrics.materials,
+      ...rendered.meta.instanceability ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials } : {},
       bbox: metrics.bbox,
       lowestPart: metrics.lowestPart,
       ...instanceability ? {
@@ -28685,7 +28800,7 @@ async function runRender(input, context) {
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: []
     };
   }
@@ -28709,7 +28824,7 @@ async function runScreenshot(input, context) {
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: []
     };
   }
@@ -28742,6 +28857,7 @@ async function runRenderViews(input, context) {
         tris: rendered.tris,
         meshes: metrics.meshes,
         materials: metrics.materials,
+        ...rendered.meta.instanceability ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials } : {},
         bbox: metrics.bbox,
         lowestPart: metrics.lowestPart,
         views: grid2.views,
@@ -28838,6 +28954,7 @@ async function runRenderViews(input, context) {
       tris: rendered.tris,
       meshes: metrics.meshes,
       materials: metrics.materials,
+      ...rendered.meta.instanceability ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials } : {},
       bbox: metrics.bbox,
       lowestPart: metrics.lowestPart,
       ...rendered.meta.instanceability ? {
@@ -28861,7 +28978,7 @@ async function runRenderViews(input, context) {
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: []
     };
   }
@@ -29520,6 +29637,7 @@ var init_registry2 = __esm(() => {
   init_discovery();
   init_build_cache();
   init_validation();
+  init_protocol();
   init_render();
   init_list_primitives();
   init_evaluator();

--- a/dist/evaluator-worker.mjs
+++ b/dist/evaluator-worker.mjs
@@ -16,7 +16,7 @@ function rethrowAuthoringError(error) {
   }
   throw error;
 }
-var UNBOUND_VARIABLE_ADVICE = "Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying.", GEAR_RADII_ORDER_ADVICE = "gearGeo requires boreRadius < rootRadius < tipRadius; specify rootRadius when changing tipRadius. Omitted radii keep their absolute defaults.", ROUNDED_BOX_RADIUS_ADVICE = "roundedBoxGeo: radius must be less than half the smallest dimension. Reduce radius or increase the smallest dimension; equality is invalid.", AuthoringDiagnosticError;
+var UNBOUND_VARIABLE_ADVICE = "Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying. If it was meant to be a Kiln helper, call kiln_list_primitives to confirm the exact name and signature; the sandbox exposes only those globals.", GEAR_RADII_ORDER_ADVICE = "gearGeo requires boreRadius < rootRadius < tipRadius; specify rootRadius when changing tipRadius. Omitted radii keep their absolute defaults.", ROUNDED_BOX_RADIUS_ADVICE = "roundedBoxGeo: radius must be less than half the smallest dimension. Reduce radius or increase the smallest dimension; equality is invalid.", AuthoringDiagnosticError;
 var init_authoring_diagnostic = __esm(() => {
   AuthoringDiagnosticError = class AuthoringDiagnosticError extends Error {
     diagnostic;
@@ -17769,6 +17769,928 @@ var init_texture_resolver = __esm(() => {
   DEFAULT_TEXTURE_RESOLVER = createTextureResolver();
 });
 
+// src/geometry-catalog.ts
+var geometryPrimitives;
+var init_geometry_catalog = __esm(() => {
+  geometryPrimitives = [
+    {
+      name: "copyGeometry",
+      signature: "copyGeometry(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "instancing",
+      description: "Returns an independent geometry with copied vertex buffers. Use before direct mutation of a cached primitive.",
+      example: "const editable = copyGeometry(boxGeo(1, 1, 1)); editable.translate(0, 0.5, 0);"
+    },
+    {
+      name: "copyMaterial",
+      signature: "copyMaterial(material: Material)",
+      returns: "THREE.Material (same subtype)",
+      category: "instancing",
+      description: "Copies material properties so edits do not change other parts. Referenced textures remain shared.",
+      example: "const red = copyMaterial(steel); red.color.set(0xaa2222);"
+    },
+    {
+      name: "meshGeo",
+      signature: "meshGeo({ positions: number[], indices?: number[], normals?: number[], uvs?: number[], tangents?: number[] })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Builds an owned triangle mesh from flat numeric arrays. Validates finite values, attribute lengths and indices; computes normals if absent. Counterclockwise winding.",
+      example: "const triangle = meshGeo({ positions: [0,0,0, 1,0,0, 0,1,0], indices: [0,1,2] });"
+    },
+    {
+      name: "parametricSurface",
+      signature: "parametricSurface(sample: (u,v) => [x,y,z], opts?: { u?: [0,1], v?: [0,1], uSegments?: 24, vSegments?: 24, periodicU?: false, periodicV?: false, orientation?: 'uv'|'vu' })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Samples an equation into an owned surface with UVs. Periodic endpoints must coincide; UV seams retain matching normals. A surface is not automatically a watertight solid.",
+      example: "const canopy = parametricSurface((u,v) => [u, 0.3*Math.sin(u*3)*Math.cos(v*2), v], { u: [-2,2], v: [-1,1] });"
+    },
+    {
+      name: "geometryDiagnostics",
+      signature: "geometryDiagnostics(geometry: BufferGeometry, tolerance?: 1e-6)",
+      returns: "{ vertices, triangles, boundaryEdges, nonManifoldEdges, orientationConflicts, degenerateTriangles, invalidIndices, nonFiniteVertices }",
+      category: "utility",
+      description: "Counts mesh topology problems after position-based seam matching. Open boundaries are valid for sheets; closed edges alone do not prove a self-intersection-free solid.",
+      example: "const topology = geometryDiagnostics(shell);"
+    },
+    {
+      name: "creaseNormals",
+      signature: "creaseNormals(geometry: BufferGeometry, opts?: { angle?: 60, tolerance?: number })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Returns owned geometry with angle-limited smooth normals, preserving UV corners. Angle is degrees. Invalidates tangents; use after shaping for sharp rims and smooth walls.",
+      example: "const shell = creaseNormals(cylinderGeo(1,1,2,32), { angle: 45 });"
+    },
+    {
+      name: "bend",
+      signature: "bend(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Bends local +Y toward +X through angle degrees. Returns owned geometry and updated normals/bounds; preserves UVs, invalidates tangents. Frame rotation is Euler XYZ degrees.",
+      promptNotes: "Deformation interval uses local Y distances; outside vertices stay unchanged. Add enough segments before bending. Falloff returns 0..1; use it to avoid a discontinuity at a selected interval boundary.",
+      example: "const arch = bend(planeGeo(1,4,4,32), { angle: 90 });"
+    },
+    {
+      name: "twist",
+      signature: "twist(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Rotates the cross-section progressively around local +Y, reaching angle degrees at the end. Returns owned geometry; frame rotation uses Euler XYZ degrees.",
+      example: "const spiral = twist(column, { angle: 120 });"
+    },
+    {
+      name: "taper",
+      signature: "taper(geometry, { startScale?: [1,1], endScale: [x,z], frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Scales local X/Z across the local Y interval using positive start/end scale pairs. Returns owned geometry; preserves UVs and invalidates tangents.",
+      example: "const narrowed = taper(column, { endScale: [0.4,0.7] });"
+    },
+    {
+      name: "displace",
+      signature: "displace(geometry, offset: ([x,y,z], t) => [dx,dy,dz], opts?: { frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Adds an authored displacement vector in the chosen local frame. Returns owned geometry; callback coordinates are local and t is normalized along the interval.",
+      example: "const rippled = displace(surface, ([x,y,z]) => [0, 0.1*Math.sin(x*8), 0]);"
+    },
+    {
+      name: "sweepProfile",
+      signature: "sweepProfile(profile: [x,z][], path: [x,y,z][], opts?: { cap?: true, closed?: false, up?: [x,y,z], twist?: 0, scale?: number | [x,z][] })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Sweeps a simple noncircular profile along polyline stations using transported frames. Supports total twist in degrees and per-station scales. Generates UVs and optional caps.",
+      promptNotes: "First version supports one simple profile without holes. Closed paths omit the repeated endpoint and require twist to be a multiple of 360. up sets the initial profile +Z direction and cannot parallel the path. Tight-turn warnings do not replace visual inspection for self-intersections.",
+      example: "const rail = sweepProfile([[-.1,-.2],[.1,-.2],[.1,.2],[-.1,.2]], [[0,0,0],[0,1,0],[1,2,0]]);"
+    },
+    {
+      name: "loftProfiles",
+      signature: "loftProfiles(sections: { profile: [x,z][], frame?: { origin, rotation } }[], opts?: { cap?: true })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Joins corresponding simple profiles in explicit local XZ planes. Each frame uses Euler XYZ degrees and local +Y along the loft. Profiles need equal point counts and corresponding vertices.",
+      promptNotes: "No holes or automatic profile correspondence. Opposite winding is normalized while preserving the first point. Caps close boundaries but do not prove the loft has no self-intersections.",
+      example: "const hull = loftProfiles([{ profile: wide }, { profile: narrow, frame: { origin: [0,2,0] } }]);"
+    },
+    {
+      name: "implicitSurface",
+      signature: "await implicitSurface(sample: ([x,y,z]) => signedValue, { bounds: { min, max }, edgeLength, maxCells?: 1000000, maxEvaluations?: 8000000, level?: 0, tolerance?: -1, smooth?: true })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "geometry",
+      description: "Experimental positive-inside implicit field sampled into a solid mesh. Requires explicit bounds and resolution; checks grid size and actual evaluation count. Output has no UVs.",
+      promptNotes: "Use async build and await. Smaller edgeLength increases cost sharply. This helper cannot stop a callback that never returns; the host evaluator process provides that boundary. Thin features and geometric accuracy require inspection.",
+      example: "const blob = await implicitSurface(([x,y,z]) => 1-Math.hypot(x,y,z), { bounds: { min: [-1.2,-1.2,-1.2], max: [1.2,1.2,1.2] }, edgeLength: 0.15 });"
+    }
+  ];
+});
+
+// src/list-primitives.ts
+function listPrimitives() {
+  return PRIMITIVES.map((p) => ({ ...p }));
+}
+var PRIMITIVES;
+var init_list_primitives = __esm(() => {
+  init_geometry_catalog();
+  PRIMITIVES = [
+    ...geometryPrimitives,
+    {
+      name: "createRoot",
+      signature: "createRoot(name: string)",
+      returns: "THREE.Object3D",
+      category: "structure",
+      description: "Creates the root Object3D for an asset. Call first in build().",
+      example: "const root = createRoot('FuelDrum');"
+    },
+    {
+      name: "createPivot",
+      signature: "createPivot(name: string, position?: [x, y, z], parent?: Object3D)",
+      returns: "THREE.Object3D (prefixed `Joint_`)",
+      category: "structure",
+      description: "Creates an empty pivot node for skeletal animation. Name is auto-prefixed with `Joint_`.",
+      example: "const hip = createPivot('Hip', [0, 1, 0], root);"
+    },
+    {
+      name: "createJointChain",
+      signature: "createJointChain(name, segments: { role, offset, aliases?, side?, localForwardAxis?, localBendAxis?, endEffector?, contact? }[], opts?: { parent?, parentRole? })",
+      returns: "{ root, end, nodes, byRole, descriptors }",
+      category: "structure",
+      description: "Creates one body-plan-neutral deterministic Joint_* chain with explicit parent edges, rest frames, local axes, end effectors, contacts, and semantic metadata.",
+      example: "const leg = createJointChain('LegL', [{ role: 'hip.left', offset: [0, 1, -0.2], side: 'left' }, { role: 'knee.left', offset: [0, -0.5, 0], side: 'left' }, { role: 'ankle.left', offset: [0, -0.5, 0], side: 'left', endEffector: true, contact: true }], { parent: root });",
+      promptNotes: "Use only the resolved body-plan graph. Offsets are local to the previous joint; contact end effectors must land at world Y=0."
+    },
+    {
+      name: "createVehicleFrame",
+      signature: "createVehicleFrame(name, opts?: { chassis?, axles?, seats?, contacts?, steering?, propulsion?, parent? })",
+      returns: "{ root, chassis, axles, seats, contacts, steering, propulsion }",
+      category: "structure",
+      description: "Creates a canonical +X-forward/+Y-up/+Z-right vehicle frame with typed semantic sockets for chassis, support, steering, and propulsion.",
+      example: "const frame = createVehicleFrame('CarFrame', { axles: [{ id: 'front', position: [1.2, 0.45, 0] }, { id: 'rear', position: [-1.2, 0.45, 0] }], parent: root });",
+      promptNotes: "Generated vehicles keep +X as front. Boats and other non-wheeled subtypes use declared support/propulsion sockets, not wheel rules."
+    },
+    {
+      name: "createWheelGeometrySet",
+      signature: "createWheelGeometrySet(radius: number, width: number)",
+      returns: "{ tire, rim, hub } shared THREE.BufferGeometry set",
+      category: "instancing",
+      description: "Creates one reusable +Z-axle tire/rim/hub geometry set for instanced wheel assemblies.",
+      example: "const wheelGeo = createWheelGeometrySet(0.45, 0.22);"
+    },
+    {
+      name: "createWheelAssembly",
+      signature: "createWheelAssembly(name, { tire, rim, hub? }, { radius, width, side, index, position?, rimRadius?, hubRadius?, steering?, loadBearing?, geometries?, parent? })",
+      returns: "{ root, steeringPivot?, spinPivot, tire, rim, hub, contact, radius, width, side, index, spinAxis }",
+      category: "structure",
+      description: "Creates one axle-centered wheel pivot containing concentric tire/rim/hub roles, a contact marker, +Z spin frame, and optional steering pivot.",
+      example: "createWheelAssembly('FrontLeft', { tire: rubber, rim: metal }, { radius: 0.45, width: 0.22, side: 'left', index: 'front', position: [1.2, 0.45, -0.9], steering: true, geometries: wheelGeo, parent: frame.root });",
+      promptNotes: "Keep tire, rim, and hub descendants concentric at the axle pivot. Reuse one geometry set across matching wheels."
+    },
+    {
+      name: "createPart",
+      signature: "createPart(name, geometry, material, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, pivot, parent })",
+      returns: "THREE.Object3D (mesh or wrapping pivot)",
+      category: "structure",
+      description: "Creates a mesh, optionally wrapped in a pivot, and attaches it to `opts.parent`. `rotation` is in DEGREES (like rotationTrack), NOT radians: [0, 0, 90] is a quarter turn; [0, 0, 1.57] is a no-op.",
+      example: "createPart('Barrel', cylinderGeo(0.1, 0.1, 1), gameMaterial(0x556b2f), { position: [0, 0.5, 0], rotation: [0, 0, 90], parent: root });",
+      promptNotes: "AUTO-ADDS to opts.parent. NEVER call parent.add(createPart(...)) — pass { parent } instead. rotation is DEGREES — writing radians (e.g. 0.785 or Math.PI/4) silently produces ~zero rotation."
+    },
+    {
+      name: "beamBetween",
+      signature: "beamBetween(name, start: [x,y,z], end: [x,y,z], radius, material, opts?: { segments, parent })",
+      returns: "THREE.Object3D (prefixed `Mesh_`)",
+      category: "structure",
+      description: "Creates a cylindrical rail/strut exactly between two endpoints. Use for braces, gun barrels, skid struts, cables, and scaffolding.",
+      example: "beamBetween('SkidBraceA', [0.8, 0.3, 0.7], [0.8, 1.0, 0.45], 0.025, black, { parent: root });"
+    },
+    {
+      name: "snapTo",
+      signature: "snapTo(part: Object3D, host: Object3D, opts?: { axis?: 'x'|'y'|'z', overlap?: 0.02 })",
+      returns: "THREE.Object3D (the part, for chaining)",
+      category: "structure",
+      description: 'Translates `part` by the minimal vector that brings its bounding box into contact with `host` (plus a small overlap). The direct cure for a "Floating parts" warning — attach the part instead of eyeballing a corrective offset. No-op if they already touch.',
+      example: `const scope = createPart('Scope', cylinderXGeo(0.04, 0.04, 0.3), steel, { parent: root, position: [0.1, 0.32, 0] });
+snapTo(scope, receiver);`
+    },
+    {
+      name: "createLadder",
+      signature: "createLadder(name, { bottom, top, material, width?, rungCount?, railRadius?, rungRadius?, widthAxis?, parent? })",
+      returns: "{ leftRail: Object3D, rightRail: Object3D, rungs: Object3D[] }",
+      category: "structure",
+      description: "Builds two continuous rails plus evenly-spaced rungs. Use this instead of loose boxes for ladders.",
+      example: "createLadder('TowerLadder', { bottom: [0,0,0], top: [0,2.2,0], width: 0.45, rungCount: 7, material: steel, parent: root });"
+    },
+    {
+      name: "createWingPair",
+      signature: "createWingPair(name, material, { rootZ, span, rootChord, tipChord, sweep?, thickness?, dihedral?, rootX?, rootY?, parent? })",
+      returns: "{ right: Object3D, left: Object3D }",
+      category: "structure",
+      description: "Creates mirrored trapezoid aircraft wings with roots attached at +/-rootZ. Use for aircraft wings and helicopter stub wings.",
+      example: "createWingPair('MainWing', olive, { rootX: 0, rootY: 1.0, rootZ: 0.42, span: 2.4, rootChord: 0.9, tipChord: 0.35, sweep: 0.25, dihedral: 0.08, parent: root });"
+    },
+    {
+      name: "room",
+      signature: "room(name, material, { width?, depth?, height?, wallThickness?, floor?, floorThickness?, openings?: [{ wall: 'front'|'back'|'left'|'right', kind?: 'door'|'window', offset?, width?, height?, sill? }], parent? })",
+      returns: "{ root: Object3D, walls: { front, back, left, right }, floor: Object3D | null }",
+      category: "structure",
+      description: "Builds a HOLLOW, enterable room: four thin walls + a floor, human-scaled (defaults: 2.8m ceiling, a centered 1.1x2.1m front door so it is enterable by default). `front` faces +X; the floor sits on the ground. The keystone of an architecture asset — add a roof with createRoofPlanes and fixtures as separate parts.",
+      example: "const { root: hut } = room('Hut', wood, { width: 5, depth: 4, height: 2.8, openings: [{ wall: 'front', kind: 'door' }, { wall: 'right', kind: 'window' }], parent: root });",
+      promptNotes: "Use for any building the player enters. Do NOT model a building as a solid block — room() guarantees real interior space and a doorway gap. Pass openings to add windows / side doors."
+    },
+    {
+      name: "wallWithOpening",
+      signature: "wallWithOpening(name, material, { length, height, thickness, axis?: 'x'|'z', opening?: { kind?: 'door'|'window', offset?, width?, height?, sill? }, parent? })",
+      returns: "THREE.Object3D (wall container)",
+      category: "structure",
+      description: "A single wall panel with an optional real door/window cut, composed from solid box segments (side panels + lintel + window sill) — no CSG. Base at local Y=0, centered on the run axis. Use to compose custom building layouts or interior dividing walls beyond the default room().",
+      example: "wallWithOpening('Partition', plaster, { length: 4, height: 2.8, thickness: 0.12, axis: 'x', opening: { kind: 'door', offset: 0.5 }, parent: root });"
+    },
+    {
+      name: "createRoofPlanes",
+      signature: "createRoofPlanes(name, material, { width, depth, height, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
+      returns: "{ root: Object3D, slopes: [Object3D, Object3D] }",
+      category: "structure",
+      description: "A pitched roof: two thin slopes meeting at one ridge and falling DOWN-AND-OUTWARD (opposite tilts — never mirrored the same way), footprint-matched with an eave overhang. Eave at local Y=0, ridge at Y=height, so position the group at Y=wallHeight. Returns a named group (e.g. `Roof`) the engine can lift to reveal the interior.",
+      example: `const { root: roof } = createRoofPlanes('Roof', shingle, { width: 5, depth: 4, height: 1.6, overhang: 0.4, ridgeAxis: 'x', parent: root });
+roof.position.y = 2.8;`,
+      promptNotes: "The two slopes must fall AWAY from each other from the ridge — createRoofPlanes does this for you. Drop it onto the walls (position.y = wall height)."
+    },
+    {
+      name: "createGableRoof",
+      signature: "createGableRoof(name, material, { spanX, spanZ, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
+      returns: "{ root, slopes: [Object3D, Object3D], faces: [RoofFaceFrame, RoofFaceFrame], rise, pitchDegrees }",
+      category: "structure",
+      description: "Explicit-axis gable roof using unambiguous footprint spans. Each face owns a rigid frame with ridge tangent, outward normal, downhill direction, ridge/eave endpoints, dimensions, and a live local-to-world transform.",
+      example: "const roof = createGableRoof('Roof', shingles, { spanX: 8, spanZ: 5, pitchDegrees: 35, overhang: 0.35, ridgeAxis: 'x', parent: root });",
+      promptNotes: "Prefer this over width/depth roof math. ridgeAxis is the direction of the ridge; roof panels run along each returned face downhill direction."
+    },
+    {
+      name: "createGableEndPanel",
+      signature: "createGableEndPanel(name, material, { span, rise, thickness?, ridgeAxis?: 'x'|'z', side?: 'positive'|'negative', openings?: [{ id?, offset?, bottom?, width, height }], parent? })",
+      returns: "{ root, geometry, openings }",
+      category: "structure",
+      description: "Exact thick triangular end closure for a gable roof, with optional rectangular openings cut from the geometry and semantic boundary metadata.",
+      example: "createGableEndPanel('FrontGable', siding, { span: 5, rise: 1.8, ridgeAxis: 'x', side: 'positive', parent: root });"
+    },
+    {
+      name: "createGableShell",
+      signature: "createGableShell(name, { wall, roof, floor?, gable? }, { spanX, spanZ, wallHeight?, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, wallThickness?, floorThickness?, closedEnds?, enterable?, openings?, gableOpenings?, parent? })",
+      returns: "{ root, walls, floor, roof, gables, openings }",
+      category: "structure",
+      description: "Closed-by-default, correct-by-construction gable building: hollow room, floor, two opposing roof slopes, two complete gable ends, and a real front doorway when enterable.",
+      example: "const house = createGableShell('House', { wall: plaster, roof: shingles }, { spanX: 8, spanZ: 5, wallHeight: 2.8, pitchDegrees: 35, ridgeAxis: 'x', parent: root });",
+      promptNotes: "Use for complete gable buildings. It stamps wall, floor, slope, gable, opening, adjacency, coverage, and separability semantics for deterministic QA and roof-off views."
+    },
+    {
+      name: "createRoofSurfaceLayout",
+      signature: "createRoofSurfaceLayout(name, material, { face, kind: 'panels'|'shingles'|'seams'|'corrugations', parent?, panelWidth?, rowHeight?, spacing?, thickness? })",
+      returns: "{ root, items: Object3D[] }",
+      category: "structure",
+      description: "Places roof-local panels, shingles, seams, or corrugations from a returned RoofFaceFrame, so repeated elements run ridge-to-eave for either ridge axis without manual Euler rotations.",
+      example: "for (const face of roof.faces) createRoofSurfaceLayout('Panels_' + face.side, metal, { face, kind: 'panels', parent: roof.root });",
+      promptNotes: "Always pass the face object returned by createGableRoof/createGableShell. Never infer the panel rotation from world axes."
+    },
+    {
+      name: "createStairs",
+      signature: "createStairs(name, material, { steps?, totalRise, totalRun, width, axis?: 'x'|'z', treadThickness?, riser?, parent? })",
+      returns: "{ root: Object3D, steps: Object3D[] }",
+      category: "structure",
+      description: "A straight flight of stairs: box treads (with optional risers) climbing totalRise over totalRun from local origin toward +axis. Use for porch/entry steps or to connect storeys in a multi-storey building.",
+      example: "createStairs('Porch', stone, { steps: 4, totalRise: 0.6, totalRun: 1.0, width: 1.4, axis: 'x', parent: root });"
+    },
+    {
+      name: "boxGeo",
+      signature: "boxGeo(width: number, height: number, depth: number)",
+      returns: "THREE.BoxGeometry",
+      category: "geometry",
+      description: "6-face box. 12 tris regardless of size. Cheapest geometry.",
+      example: "const geo = boxGeo(1, 0.5, 2);"
+    },
+    {
+      name: "sphereGeo",
+      signature: "sphereGeo(radius: number, widthSegments?: 8, heightSegments?: 6)",
+      returns: "THREE.SphereGeometry",
+      category: "geometry",
+      description: "UV sphere. Default 8x6 segments = 84 tris. Bump segments for smoother curves.",
+      example: "const geo = sphereGeo(0.5, 12, 8);"
+    },
+    {
+      name: "cylinderGeo",
+      signature: "cylinderGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Y-axis cylinder. Use radiusTop != radiusBottom for cones / tapered pieces.",
+      example: "const geo = cylinderGeo(0.25, 0.25, 1, 12);"
+    },
+    {
+      name: "cylinderYGeo",
+      signature: "cylinderYGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Alias for cylinderGeo — a Y-axis cylinder. Provided because the sandbox exposes cylinderXGeo / cylinderZGeo and the symmetric Y form is commonly reached for.",
+      example: "const geo = cylinderYGeo(0.25, 0.25, 1, 12);"
+    },
+    {
+      name: "cylinderXGeo",
+      signature: "cylinderXGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Cylinder pre-rotated to run along +X/-X. Use for fuselages, cannons, barrels, axles, and forward-facing tubes.",
+      example: "const geo = cylinderXGeo(0.1, 0.1, 1.2, 12);"
+    },
+    {
+      name: "cylinderZGeo",
+      signature: "cylinderZGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Cylinder pre-rotated to run along +Z/-Z. Use for side-mounted weapons, rails, crossbars, and pipes.",
+      example: "const geo = cylinderZGeo(0.08, 0.08, 0.9, 10);"
+    },
+    {
+      name: "cylinderOnAxis",
+      signature: "cylinderOnAxis(center: [x,y,z], normal: [x,y,z], radiusBottom: number, height: number, opts?: { radiusTop?, segments? })",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Frame-first cylinder: position + axis specified directly, no post-hoc rotation. Use when the cylinder needs to point along a non-cardinal direction (struts inside CSG operands, antennas off a tilted surface). For cardinal axes prefer the terser cylinderXGeo / cylinderYGeo / cylinderZGeo helpers.",
+      example: "const strut = cylinderOnAxis([0.5, 0.7, 0], [1, 1, 0.3], 0.05, 0.9);"
+    },
+    {
+      name: "capsuleGeo",
+      signature: "capsuleGeo(radius: number, height: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Stadium shape (cylinder with hemispherical caps). Good for limbs.",
+      example: "const geo = capsuleGeo(0.1, 0.5, 6);"
+    },
+    {
+      name: "capsuleYGeo",
+      signature: "capsuleYGeo(radius: number, height: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Alias for capsuleGeo — a Y-axis capsule. Provided for symmetry with capsuleXGeo / capsuleZGeo.",
+      example: "const geo = capsuleYGeo(0.1, 0.5, 6);"
+    },
+    {
+      name: "capsuleXGeo",
+      signature: "capsuleXGeo(radius: number, length: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Capsule pre-rotated to run along +X/-X. Use for aircraft bodies, rounded vehicle hulls, and missiles.",
+      example: "const geo = capsuleXGeo(0.35, 2.4, 10);"
+    },
+    {
+      name: "capsuleZGeo",
+      signature: "capsuleZGeo(radius: number, length: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Capsule pre-rotated to run along +Z/-Z. Use for lateral pods, floats, and side tanks.",
+      example: "const geo = capsuleZGeo(0.18, 1.1, 8);"
+    },
+    {
+      name: "coneGeo",
+      signature: "coneGeo(radius: number, height: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Y-axis cone (pointed up). Use for spikes, roofs, projectiles.",
+      example: "const geo = coneGeo(0.3, 0.8, 8);"
+    },
+    {
+      name: "coneYGeo",
+      signature: "coneYGeo(radius: number, height: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Alias for coneGeo — a Y-axis cone (point +Y). Provided for symmetry with coneXGeo / coneZGeo.",
+      example: "const geo = coneYGeo(0.3, 0.8, 8);"
+    },
+    {
+      name: "coneXGeo",
+      signature: "coneXGeo(radius: number, length: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Cone pre-rotated so its point faces +X. Use for noses, rockets, shells, and forward-facing tips.",
+      example: "const geo = coneXGeo(0.18, 0.45, 12);"
+    },
+    {
+      name: "coneZGeo",
+      signature: "coneZGeo(radius: number, length: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Cone pre-rotated so its point faces +Z. Use for side-facing projectiles and tips.",
+      example: "const geo = coneZGeo(0.12, 0.35, 10);"
+    },
+    {
+      name: "taperConeGeo",
+      signature: "taperConeGeo(radiusBottom: number, radiusTop: number, height: number, axis?: 'x'|'y'|'z', segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Truncated cone (frustum) — exposes both bottom and top radius. radiusTop=0 matches coneGeo, radiusTop=radiusBottom matches cylinderGeo. Use for pylon caps, soda cans, lampshades, anything tapered that does not come to a point. axis selects orientation (default Y).",
+      example: "const cap = taperConeGeo(0.3, 0.18, 0.4);  // frustum"
+    },
+    {
+      name: "torusGeo",
+      signature: "torusGeo(radius: number, tube: number, radialSegments?: 8, tubularSegments?: 12)",
+      returns: "THREE.TorusGeometry",
+      category: "geometry",
+      description: "Donut shape. For rings, tyres, barrel ribs.",
+      example: "const geo = torusGeo(0.4, 0.04, 8, 16);"
+    },
+    {
+      name: "planeGeo",
+      signature: "planeGeo(width: number, height: number, widthSegments?: 1, heightSegments?: 1)",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Flat quad for TEXTURED surfaces (ground, signs, walls with albedo maps). For solid-color decals like red stars, hull numbers, stamps, or window cutouts on no-texture assets use decalBox — a bare planeGeo without a texture will render as a disconnected 2-tri square and get flagged as a stray plane.",
+      example: "const geo = planeGeo(4, 4);"
+    },
+    {
+      name: "decalBox",
+      signature: "decalBox(width: number, height: number, depth?: 0.01)",
+      returns: "THREE.BoxGeometry",
+      category: "geometry",
+      description: "Thin box for solid-color surface decals: red stars, hull numbers, stamps, no-texture windows. Unlike planeGeo, has real depth so it visibly attaches to its host surface. Must be placed on a surface with position + rotation.",
+      example: `const star = decalBox(0.18, 0.18, 0.01);
+createPart('Mesh_StarPort', star, gameMaterial(0xc61f2a), { position: [0.4, 0.6, 0.41], parent: fuselage });`,
+      promptNotes: "Offset at least 0.01 outside the host surface to avoid z-fighting (a 0.8-wide hull has faces at z=±0.4, so place the decal at z=±0.41)."
+    },
+    {
+      name: "foliageCardGeo",
+      signature: "foliageCardGeo(opts?: { width?, height?, yPivot?: 0..1 })",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Single-quad foliage card with a configurable Y pivot. yPivot=0 plants the quad on the ground. Pair with an alpha-tested material and a leaf/plant sprite.",
+      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
+const quad = foliageCardGeo({ width: 4, height: 6, yPivot: 0 });
+createPart('Mesh_Fern', quad, leaves, { parent: root });`
+    },
+    {
+      name: "crossedQuadsGeo",
+      signature: "crossedQuadsGeo(opts?: { width?, height?, planes?: 2 | 3, yPivot? })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Cross-billboard bush primitive: 2 or 3 planes intersecting along the Y axis. Reads as a dense plant from any angle, cheaper than real geometry.",
+      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
+const bush = crossedQuadsGeo({ width: 2, height: 2, planes: 3 });
+createPart('Mesh_Bush', bush, leaves, { parent: root });`
+    },
+    {
+      name: "octaGridPlane",
+      signature: "octaGridPlane({ tilesX, tilesY, width?, height?, yPivot? })",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Atlas-ready billboard quad. UVs are pre-scaled to cover one tile of a tilesX×tilesY atlas; the consumer shader adds per-instance tile offsets at draw time.",
+      example: "const card = octaGridPlane({ tilesX: 4, tilesY: 4, width: 6, height: 6 });"
+    },
+    {
+      name: "wingGeo",
+      signature: "wingGeo(opts?: { span, rootChord, tipChord, sweep, thickness, dihedral })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Trapezoid wing panel. Local root edge is at Z=0, span extends toward +Z, positive sweep moves the tip aft along -X.",
+      example: "const geo = wingGeo({ span: 2.2, rootChord: 0.8, tipChord: 0.3, sweep: 0.25, dihedral: 0.08 });"
+    },
+    {
+      name: "gearGeo",
+      signature: "gearGeo(opts?: { teeth?: 12, rootRadius?: 0.8, tipRadius?: 1.0, boreRadius?: 0.2, height?: 0.3, toothWidthFrac?: 0.5 })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Stylized gear with flat edges and an optional center bore; no CSG. Use boreRadius < rootRadius < tipRadius. Radii are absolute: an omitted rootRadius stays 0.8 when tipRadius changes. Set all three radii for small gears.",
+      example: `const g = gearGeo({ teeth: 28, rootRadius: 0.063, tipRadius: 0.075, boreRadius: 0.012, height: 0.024 });
+createPart('Gear', g, gameMaterial(0x909090, { metalness: 0.8 }), { parent: root });`
+    },
+    {
+      name: "bladeGeo",
+      signature: "bladeGeo(opts?: { length?: 1.5, baseWidth?: 0.1, thickness?: 0.015, tipLength?: 0.25, edgeBevel?: 0 })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Parametric sword blade: rectangular base tapering to a point over tipLength. edgeBevel > 0 pinches the cross-section toward a diamond ridge.",
+      example: `const b = bladeGeo({ length: 1.6, baseWidth: 0.09, tipLength: 0.3, edgeBevel: 0.5 });
+createPart('Blade', b, steel, { position: [0, 0, 0], parent: root });`
+    },
+    {
+      name: "gameMaterial",
+      signature: "gameMaterial(color, opts?: { metalness, roughness, emissive, emissiveIntensity, flatShading })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Flat-shaded PBR material. Default for game-ready low-poly. Use for 95% of parts.",
+      example: "const mat = gameMaterial(0x8b7355, { roughness: 0.9 });"
+    },
+    {
+      name: "materialRecipe",
+      signature: "await materialRecipe(recipeId, overrides?: { baseColor?, roughness?, metalness?, opacity?, alphaCutoff?, doubleSided?, emissiveColor?, emissiveIntensity?, textureResources? })",
+      returns: "Promise<THREE.MeshStandardMaterial>",
+      category: "material",
+      description: "Resolves a versioned portable bark/leaf/wood/stone/rubber/painted-metal/cloth/skin/glass/emissive recipe to standard glTF PBR.",
+      example: "const bark = await materialRecipe('kiln.material.bark.v1', { baseColor: '#6b4328' });",
+      promptNotes: "Use only listed kiln.material.*.v1 IDs and approved kiln.texture.* resource IDs. Leaf is MASK, glass is BLEND, and host file paths are forbidden."
+    },
+    {
+      name: "compilePortableMaterialSpecV2",
+      signature: "await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', name?, baseColor?, roughness?, metalness?, emissive?, emissiveIntensity?, alphaMode?, alphaCutoff?, doubleSided?, textures?: { baseColor?, normal?, metallicRoughness?, emissive?, occlusion? } })",
+      returns: "Promise<THREE.MeshStandardMaterial>",
+      category: "material",
+      description: "Compiles the strict portable material contract. Texture refs are either typed procedural V2 specs or closed approved kiln.texture.* IDs; paths, URLs, raw textures, callbacks, and shader source are rejected.",
+      example: "const steel = await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', roughness: 0.45, metalness: 0.85, textures: { metallicRoughness: { kind: 'procedural', spec: { schemaVersion: 2, usage: 'metallicRoughness', size: 64, layers: [{ op: 'solid', color: 0x0080cc }] } } } });",
+      promptNotes: "Use metallicRoughness as one packed G=roughness/B=metalness map. Every procedural ref usage must match its slot; resource refs must be approved for that exact slot."
+    },
+    {
+      name: "basicMaterial",
+      signature: "basicMaterial(color, opts?: { transparent, opacity })",
+      returns: "THREE.MeshBasicMaterial",
+      category: "material",
+      description: "Unlit flat material. For UI / effects where lighting is baked in.",
+      example: "const mat = basicMaterial(0xffffff, { transparent: true, opacity: 0.5 });"
+    },
+    {
+      name: "glassMaterial",
+      signature: "glassMaterial(color, opts?: { opacity, roughness, metalness })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Semi-transparent double-sided material. Panels need ~0.05 offset to avoid z-fighting.",
+      example: "const mat = glassMaterial(0x66ccff, { opacity: 0.3 });"
+    },
+    {
+      name: "lambertMaterial",
+      signature: "lambertMaterial(color, opts?: { flatShading, emissive })",
+      returns: "THREE.MeshLambertMaterial",
+      category: "material",
+      description: "Cheaper than gameMaterial. No metalness/roughness. Use when PBR is overkill.",
+      example: "const mat = lambertMaterial(0x2a4d14, { flatShading: true });"
+    },
+    {
+      name: "rotationTrack",
+      signature: "rotationTrack(jointName: string, keyframes: Array<{ time, rotation: [xDeg, yDeg, zDeg] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.QuaternionKeyframeTrack",
+      category: "animation",
+      description: "Rotation track in degrees, auto-converted to quaternions. Joint name must include `Joint_` prefix.",
+      example: "rotationTrack('Joint_Lid', [{ time: 0, rotation: [0, 0, 0] }, { time: 1, rotation: [90, 0, 0] }]);"
+    },
+    {
+      name: "positionTrack",
+      signature: "positionTrack(jointName: string, keyframes: Array<{ time, position: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.VectorKeyframeTrack",
+      category: "animation",
+      description: "Position track in world units. Always use `position:` not `value:` in keyframes.",
+      example: "positionTrack('Joint_Body', [{ time: 0, position: [0, 0, 0] }, { time: 1, position: [0, 0.1, 0] }]);"
+    },
+    {
+      name: "scaleTrack",
+      signature: "scaleTrack(jointName: string, keyframes: Array<{ time, scale: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.VectorKeyframeTrack",
+      category: "animation",
+      description: "Uniform or per-axis scale track.",
+      example: "scaleTrack('Joint_Chest', [{ time: 0, scale: [1, 1, 1] }, { time: 1, scale: [1.1, 1.1, 1.1] }]);"
+    },
+    {
+      name: "createClip",
+      signature: "createClip(name: string, duration: number, tracks: KeyframeTrack[])",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Collects tracks into a named clip. Returned from animate().",
+      example: "return [createClip('Open', 1, [rotationTrack('Joint_Lid', [...])])];"
+    },
+    {
+      name: "idleBreathing",
+      signature: "idleBreathing(bodyJoint: string, duration?: 2, amount?: 0.02)",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Gentle Y-axis bob. For NPC idle states.",
+      example: "return [idleBreathing('Joint_Body')];"
+    },
+    {
+      name: "bobbingAnimation",
+      signature: "bobbingAnimation(rootName: string, duration?: 2, height?: 0.1)",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Floating / bobbing loop for pickups and effects.",
+      example: "return [bobbingAnimation('Joint_Root', 1.5, 0.08)];"
+    },
+    {
+      name: "spinAnimation",
+      signature: "spinAnimation(jointName: string, duration?: 2, axis?: 'x' | 'y' | 'z')",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "360° rotation over `duration` around `axis`.",
+      example: "return [spinAnimation('Joint_Rotor', 0.5, 'y')];"
+    },
+    {
+      name: "cloneGeometry",
+      signature: "cloneGeometry(geo: BufferGeometry)",
+      returns: "THREE.BufferGeometry (same ref)",
+      category: "instancing",
+      description: "Deprecated name: returns the SAME geometry, without copying. Use copyGeometry for independent vertex edits, or pass the original geometry directly for intentional sharing.",
+      example: "const wheelGeo = cylinderGeo(0.4, 0.4, 0.2, 12);"
+    },
+    {
+      name: "cloneMaterial",
+      signature: "cloneMaterial(mat: Material)",
+      returns: "THREE.Material (same ref)",
+      category: "instancing",
+      description: "Deprecated name: returns the SAME material. Use copyMaterial for independent property edits, or pass the original for intentional sharing.",
+      example: "const rubberMat = gameMaterial(0x1a1a1a, { roughness: 0.95 });"
+    },
+    {
+      name: "createInstance",
+      signature: "createInstance(name, source, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, parent })",
+      returns: "THREE.Object3D",
+      category: "instancing",
+      description: "Creates a new mesh reusing an existing part's geometry + material at a new transform. Cheapest way to replicate wheels / bolts / fence posts / windows. `rotation` is in DEGREES, like createPart.",
+      example: `const wheelFL = createPart('WheelFL', wheelGeo, rubberMat, { position: [-0.8, 0.3, 1.2], parent: root });
+createInstance('WheelFR', wheelFL, { position: [0.8, 0.3, 1.2], parent: root });
+createInstance('WheelRL', wheelFL, { position: [-0.8, 0.3, -1.2], parent: root });
+createInstance('WheelRR', wheelFL, { position: [0.8, 0.3, -1.2], parent: root });`
+    },
+    {
+      name: "boolUnion",
+      signature: "await boolUnion(name: string, ...parts: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Merges two or more parts into one watertight manifold mesh. Default flat shading (hard edges) — pass { smooth: true } as last arg for averaged normals on organic merges.",
+      example: `const body = new THREE.Mesh(boxGeo(2, 1, 1), steel);
+const turret = new THREE.Mesh(cylinderGeo(0.3, 0.3, 0.4, 16), steel);
+turret.position.y = 0.5;
+const hull = await boolUnion('Hull', body, turret);`
+    },
+    {
+      name: "boolDiff",
+      signature: "await boolDiff(name: string, body: Object3D, ...cutters: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Subtracts cutters from a body (holes, button recesses, window slots). Default flat shading for sharp mechanical edges.",
+      example: `const body = new THREE.Mesh(cylinderGeo(1, 1, 0.3, 32), steel);
+const teeth = [...]; // 8 radially-arrayed box meshes
+const gear = await boolDiff('Gear', body, ...teeth);  // hard-edged`
+    },
+    {
+      name: "roundedBoxGeo",
+      signature: "await roundedBoxGeo(width: number, height: number, depth: number, radius: number, opts?: { style?: 'round' | 'chamfer', segments?: 12, smooth?: boolean })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "A box with all twelve edges rounded (or chamfered) at the EXACT outer size requested — roundedBoxGeo(1, 1, 1, 0.1) measures 1x1x1, it does not grow. Use it anywhere boxGeo reads too sharp: consoles, crates, appliances, handheld props, machined blocks.",
+      promptNotes: "Real objects almost never have perfectly sharp box edges, and a small radius is the single cheapest upgrade to how manufactured an asset looks. Prefer this over boxGeo for anything moulded, cast, or machined. Keep radius small relative to the box (5-10% of the smallest dimension); radius must be less than half the smallest dimension or the call throws. style: 'chamfer' reads as machined metal, 'round' as moulded plastic. This is async — build() must be async and the call must use await.",
+      example: `const geo = await roundedBoxGeo(1.2, 0.6, 0.8, 0.05);
+createPart('Console', geo, plastic, { position: [0, 0.3, 0], parent: root });`
+    },
+    {
+      name: "extrudeProfile",
+      signature: "await extrudeProfile(profile: [number, number][], opts?: { depth?: 1, holes?: [number, number][][], bevel?: 0, bevelStyle?: 'round' | 'chamfer', segments?: 12, twist?: 0, taper?: number | [number, number], divisions?: number, axis?: 'x' | 'y' | 'z', center?: true, smooth?: false })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "Sweeps a closed 2D outline into a watertight solid, with optional holes, corner rounding/chamfering, twist, and taper. The way to build any cross-section that is not a box or a cylinder: L-brackets, I-beams, gaskets, washers, star and gear plates, signage, extruded trim.",
+      promptNotes: "The bevel rounds the edges PARALLEL to the sweep axis (the profile corners) — the two flat caps stay sharp. For a box rounded on all twelve edges use roundedBoxGeo instead. Holes are subtracted, so their winding order does not matter. A bevel larger than half the outline's narrowest feature throws rather than silently returning an empty solid. Output is manifold, so it feeds straight into boolUnion / boolDiff / boolIntersect. Async — await it inside an async build().",
+      example: `// L-bracket, inner AND outer corners filleted
+const outline = [[0, 0], [2, 0], [2, 0.4], [0.4, 0.4], [0.4, 2], [0, 2]];
+const geo = await extrudeProfile(outline, { depth: 0.5, bevel: 0.06 });
+createPart('Bracket', geo, steel, { parent: root });`
+    },
+    {
+      name: "revolveProfile",
+      signature: "await revolveProfile(profile: [number, number][], opts?: { segments?: 24, angle?: 360, bevel?: 0, bevelStyle?: 'round' | 'chamfer', bevelSegments?: 12, axis?: 'x' | 'y' | 'z', smooth?: true })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "Revolves a closed 2D outline around an axis into a watertight SOLID, optionally rounding the profile corners first. Bottles, tanks, pressure vessels, wheels, turned wood, domes, buttons, pills.",
+      promptNotes: "Use this instead of lathe/revolveGeo whenever the result must survive a boolean or needs a rounded rim — lathe and revolveGeo build an open surface, this builds a closed solid. Profile convention matches lathe: x is distance from the axis, y is position along it, and only the x >= 0 side is used. Async — await it inside an async build().",
+      example: `// capsule tank with a rounded rim, then carve a port into it
+const profile = [[0, -0.5], [0.4, -0.5], [0.4, 0.5], [0, 0.5]];
+const body = await revolveProfile(profile, { bevel: 0.08, segments: 32 });
+const tank = await boolDiff('Tank', createPart('B', body, steel), portCutter);`
+    },
+    {
+      name: "circleProfile",
+      signature: "circleProfile(radius: number, segments?: 24, center?: [number, number])",
+      returns: "[number, number][]",
+      category: "csg",
+      description: "Builds a closed circular outline for extrudeProfile / revolveProfile, so you never hand-write the trigonometry. Synchronous.",
+      example: `const washer = await extrudeProfile(circleProfile(1), {
+  depth: 0.1,
+  holes: [circleProfile(0.4), circleProfile(0.1, 16, [0.7, 0])],
+});`
+    },
+    {
+      name: "boolIntersect",
+      signature: "await boolIntersect(name: string, a: Object3D, b: Object3D, opts?: { smooth?: false })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Keeps only the volume where both operands overlap. Default flat shading.",
+      example: "const lens = await boolIntersect('Lens', boxMesh, sphereMesh);"
+    },
+    {
+      name: "hull",
+      signature: "await hull(name: string, ...parts: Object3D[], opts?: { smooth?: true })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Tightest convex mesh enclosing all input points. Default smooth shading (rocks, collision volumes). Pass { smooth: false } for a faceted look.",
+      example: `const rockChunks = [...]; // scattered box meshes
+const rock = await hull('Rock', ...rockChunks);`
+    },
+    {
+      name: "arrayLinear",
+      signature: "arrayLinear(namePrefix, source, count, offset: [x,y,z], parent?)",
+      returns: "THREE.Object3D[]",
+      category: "arrays",
+      description: "Places N copies of `source` along a constant offset vector. Copies share geometry + material via createInstance.",
+      example: `const post = createPart('Post0', cylinderGeo(0.05,0.05,1.5,6), wood, { position: [0,0.75,0], parent: root });
+arrayLinear('Post', post, 10, [0.5, 0, 0], root);`
+    },
+    {
+      name: "arrayRadial",
+      signature: "arrayRadial(namePrefix, source, count, axis?: 'x'|'y'|'z', parent?)",
+      returns: "THREE.Object3D[]",
+      category: "arrays",
+      description: "Places N copies of `source` around the given axis. Source's local rotation is oriented outward. Perfect for gear teeth, radial bolts, circle of columns.",
+      example: `const bolt = createPart('Bolt0', cylinderGeo(0.02,0.02,0.1,6), steel, { position: [1,0,0], parent: root });
+arrayRadial('Bolt', bolt, 8, 'y', root);`
+    },
+    {
+      name: "mirror",
+      signature: "mirror(name, source, axis: 'x'|'y'|'z', parent?)",
+      returns: "THREE.Object3D",
+      category: "arrays",
+      description: "Reflects source across the plane whose normal is `axis`. Uses negative scale (winding flip handled by viewers).",
+      example: "mirror('WingR', wingL, 'x', root);"
+    },
+    {
+      name: "subdivide",
+      signature: "subdivide(geometry: BufferGeometry, iterations?: 1, opts?: { preserveUV?: boolean, split?: boolean, uvSmooth?: boolean, preserveEdges?: boolean, flatOnly?: boolean, weld?: boolean })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Loop subdivision returns new geometry; each iteration roughly quadruples triangles and smooths the surface. Use preserveUV:true for textured meshes. Legacy position-only welding discards UVs and reports that loss. This smooths shapes, not selected-edge beveling.",
+      example: "const smoothRock = subdivide(boxGeo(1, 1, 1), 2);"
+    },
+    {
+      name: "mergeVertices",
+      signature: "mergeVertices(geometry: BufferGeometry, opts?: { tolerance?: 1e-4, positionOnly?: boolean } | number)",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Returns indexed geometry. Default welding preserves attribute seams, so a textured cube retains separate face corners. positionOnly:true welds coincident positions and discards other attributes; use it explicitly when changing topology and regenerate shading/UVs afterward.",
+      example: `const welded = mergeVertices(boxGeo(1, 1, 1), { positionOnly: true });
+const rock = displace(subdivide(welded, 2), ([x,y,z]) => [0.08*Math.sin(y*7+z*3), 0.04*Math.sin(x*9), 0]);`
+    },
+    {
+      name: "curveToMesh",
+      signature: "curveToMesh(points: [x,y,z][], radius, tubularSegs?: 32, radialSegs?: 8, closed?: false)",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Sweeps a circular profile along a path. Equivalent to Blender's Curve to Mesh node with a circle profile. Use for pipes, cables, tubular frames.",
+      example: "const pipe = curveToMesh([[0,0,0],[0,1,0],[1,1,0],[1,2,0]], 0.1);"
+    },
+    {
+      name: "pipeAlongPath",
+      signature: "pipeAlongPath(points: [x,y,z][], radius: number, opts?: { bendRadius?: 0, closed?: false, tubularSegments?: 32, radialSegments?: 8 })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Path-driven swept circle with optional bend smoothing. Generalises beamBetween (point-to-point) and curveToMesh (raw spline) into one helper. bendRadius>0 inserts interpolated waypoints near interior corners so the spline reads as a rounded turn instead of pinching to the control point.",
+      example: "const cable = pipeAlongPath([[0, 0.5, 0], [1, 0.5, 0], [1, 0.5, 2]], 0.02, { bendRadius: 0.1 });"
+    },
+    {
+      name: "lathe",
+      signature: "lathe(profile: [x,y][], segments?: 12)",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Surface of revolution. Spins a 2D profile around the Y axis. For bottles, vases, wheels, turned wood parts.",
+      example: "const vase = lathe([[0.1,0],[0.3,0.5],[0.2,1],[0.1,1.2]], 16);"
+    },
+    {
+      name: "revolveGeo",
+      signature: "revolveGeo(profile: [x,y][], opts?: { angle?: 2π, axis?: [x,y,z]=[0,1,0], segments?: 12 })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Surface of revolution with explicit axis + sweep angle. Generalises lathe — use it when you need a partial sweep (half-dome, 90° wedge) or revolution around a non-Y axis. Profile convention is identical to lathe: x = radial distance, y = position along the axis.",
+      example: `// Half-dome (180° sweep around +Y):
+const quarter = [...Array(8)].map((_, i) => { const t = (i/7)*Math.PI/2; return [Math.cos(t), Math.sin(t)] as [number, number]; });
+const dome = revolveGeo(quarter, { angle: Math.PI });`
+    },
+    {
+      name: "bezierCurve",
+      signature: "bezierCurve(controlPoints: [x,y,z][], samples?: 32)",
+      returns: "[x,y,z][]",
+      category: "curves",
+      description: "Samples a quadratic (3 ctrl pts) or cubic (4 ctrl pts) Bézier into a point list you can feed into curveToMesh.",
+      example: `const path = bezierCurve([[0,0,0],[1,2,0],[3,2,0],[4,0,0]], 24);
+const geo = curveToMesh(path, 0.1);`
+    },
+    {
+      name: "autoUnwrap",
+      signature: "await autoUnwrap(geometry: BufferGeometry, opts?: { resolution?: 1024, padding?: 2, useNormals?: false })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "uv",
+      description: "xatlas-based UV atlas for ANY geometry (CSG output, subdivided, deformed). Output is a packed atlas with arbitrary per-chart rotation — use for non-tileable baked textures. For directional tileable textures on box/cylinder/plane primitives, prefer the shape-aware unwraps below.",
+      example: `const unwrapped = await autoUnwrap(someCsgResult, { resolution: 1024 });
+const mesh = new THREE.Mesh(unwrapped, bakedPbr);`
+    },
+    {
+      name: "boxUnwrap",
+      signature: "boxUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Preserves BoxGeometry's built-in per-face UVs — every face maps [0,1] with consistent orientation. Use for crates/blocks with a tileable texture. Sync; no WASM cost.",
+      example: `const crate = boxUnwrap(boxGeo(1, 1, 1));
+const mesh = new THREE.Mesh(crate, pbrMaterial({ albedo: planksTex }));`
+    },
+    {
+      name: "cylinderUnwrap",
+      signature: "cylinderUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Preserves CylinderGeometry's built-in UVs: u wraps around the axis (horizontal texture features ring the cylinder), v runs up the height. Caps use circle-in-square. Sync; no WASM cost.",
+      example: `const barrel = cylinderUnwrap(cylinderGeo(0.5, 0.5, 1.2, 24));
+const mesh = new THREE.Mesh(barrel, pbrMaterial({ albedo: bandsTex }));`
+    },
+    {
+      name: "planeUnwrap",
+      signature: "planeUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Projects xy-extent of the bbox to [0,1]. Use for signs/decals/posters where you want ONE readable texture and no edge-face bleeding. Sync.",
+      example: `const sign = planeUnwrap(planeGeo(1, 0.6));
+const mesh = new THREE.Mesh(sign, pbrMaterial({ albedo: kilnTextTex }));`
+    },
+    {
+      name: "panelRemapV",
+      signature: "panelRemapV(geo, vScale=0.30, vOffset=0, uScale=1, uOffset=0)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Scales an existing UV attribute so a small mesh samples a sub-region of a SHARED texture. Replaces the broken texture.clone() pattern (Three.js Texture.clone() runs JSON.stringify on userData, mangling encoded PNG bytes — panelRemapV avoids that by remapping UVs on the geometry instead). Typical use: multi-zone albedo where v=0..0.30 is plain panel and v=0.30..1 has windows/markings — small parts call panelRemapV(unwrap(geo), 0.30) to sample only the clean strip.",
+      example: `const cowlGeo = panelRemapV(cylinderUnwrap(capsuleXGeo(0.45, 1.0)), 0.30);
+const cowl = new THREE.Mesh(cowlGeo, bodyMat); // SAME bodyMat as fuselage, no clone needed`
+    },
+    {
+      name: "loadApprovedTexture",
+      signature: "await loadApprovedTexture(resourceId)",
+      returns: "Promise<THREE.DataTexture>",
+      category: "textures",
+      description: "Loads one approved kiln.texture.* resource ID through the host-injected closed resolver. The registry fixes bytes, MIME, usage, dimensions, hash, and deadline; paths, URLs, byte arrays, resolver objects, hashes, and options are rejected.",
+      example: "const bark = await loadApprovedTexture('kiln.texture.bark-brown-01-albedo.v1');",
+      promptNotes: "Use only a concrete resource ID listed in material capabilities; never invent one. Prefer materialRecipe when a recipe already binds the family, or proceduralTexture V2 for authored surfaces. NEVER texture.clone() a loaded texture (clone() corrupts encoded bytes and breaks GLB export)."
+    },
+    {
+      name: "proceduralTexture",
+      signature: "proceduralTexture({ schemaVersion: 2, size?: 4..1024 pow2, usage?, name?, layers: [{ op: 'solid'|'checker'|'stripes'|'gradient'|'bricks'|'noise', ...params, blend?: 'normal'|'multiply'|'screen'|'overlay', opacity?: 0..1 }] })",
+      returns: "THREE.DataTexture (tiling, sRGB or linear per usage)",
+      category: "textures",
+      description: "Builds a tiling texture from a bounded layer stack — no image file needed. Layers composite bottom-first. Noise is seeded and tileable, so the same spec always produces the same bytes and a repeating material shows no seam. Baked to PNG and embedded in the GLB automatically.",
+      example: "const bark = proceduralTexture({ schemaVersion: 2, size: 256, usage: 'albedo', name: 'Bark', layers: [{ op: 'solid', color: 0x5a4632 }, { op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4, blend: 'overlay' }] });",
+      promptNotes: "Sync — no await. Strict V2 JSON boundary: unknown/prototype keys, callbacks, paths, URLs, and shader source are rejected. Prefer this over approved resources for describable surfaces. Max 8 layers, power-of-two size up to 1024. Only the six listed ops exist."
+    },
+    {
+      name: "normalMapFromHeight",
+      signature: "normalMapFromHeight(source: THREE.Texture, { strength?: number, name?: string })",
+      returns: "THREE.DataTexture (linear normal map)",
+      category: "textures",
+      description: "Derives a tangent-space normal map from the source texture's brightness, treating it as height. The cheap way to get real PBR surface relief out of a procedural albedo. Wraps at the edges, so a tiling source gives a tiling normal map.",
+      example: `const bark = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4 }] });
+const mat = pbrMaterial({ albedo: bark, normal: normalMapFromHeight(bark, { strength: 4 }) });`,
+      promptNotes: "strength 1 is subtle, 4-8 reads clearly at normal viewing distance. Output is always linear data — never assign it to an albedo/emissive slot."
+    },
+    {
+      name: "pbrMaterial",
+      signature: "pbrMaterial({ albedo?, normal?, roughness?, metalness?, metallicRoughness?, emissive?, aoMap?, alphaMode?, alphaCutoff?, doubleSided? })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Portable glTF PBR material. Use an explicit packed metallicRoughness texture (G=roughness, B=metalness); separate data maps are rejected instead of silently dropping a channel. Supports OPAQUE/MASK/BLEND and double-sided output.",
+      example: `const wood = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x4f301c, colorB: 0x9a6b3e, scale: 8, octaves: 3, seed: 4 }] });
+const crate = pbrMaterial({ albedo: wood, roughness: 0.85, metalness: 0 });`
+    },
+    {
+      name: "foliageMaterial",
+      signature: "foliageMaterial(albedo, { alphaCutoff?, roughness?, doubleSided? })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Portable foliage material that defaults to glTF MASK, cutoff 0.5, rough nonmetal, and double-sided. Use an alpha-bearing albedo texture.",
+      example: "const mat = await materialRecipe('kiln.material.leaf.v1');"
+    },
+    {
+      name: "countTriangles",
+      signature: "countTriangles(root: Object3D)",
+      returns: "number",
+      category: "utility",
+      description: "Sums triangle count across every mesh in the subtree.",
+      example: "meta.tris = countTriangles(root);"
+    },
+    {
+      name: "countMaterials",
+      signature: "countMaterials(root: Object3D)",
+      returns: "number",
+      category: "utility",
+      description: "Unique material count (by reference) across the subtree.",
+      example: "const mats = countMaterials(root);"
+    },
+    {
+      name: "getJointNames",
+      signature: "getJointNames(root: Object3D)",
+      returns: "string[]",
+      category: "utility",
+      description: "All node names beginning with `Joint_`. Use to sanity-check animation targets.",
+      example: "const joints = getJointNames(root);"
+    },
+    {
+      name: "validateAsset",
+      signature: "validateAsset(root: Object3D, category: 'character' | 'prop' | 'vfx' | 'environment' | 'architecture' | 'vegetation' | 'vehicle')",
+      returns: "{ valid, errors, warnings }",
+      category: "utility",
+      description: "Checks geometry and material costs for the selected category. No default triangle limit; choose detail for the intended runtime and inspect measured draw calls.",
+      example: "const v = validateAsset(root, 'prop');"
+    }
+  ];
+});
+
 // src/validation.ts
 import * as acorn from "acorn";
 import * as walk from "acorn-walk";
@@ -18018,8 +18940,45 @@ function collectStaticStringBindings(ast) {
   }
   return values;
 }
-var GeneratedSourcePolicyError, FORBIDDEN_AMBIENT_IDENTIFIERS, FORBIDDEN_THREE_CONSTRUCTORS, ROTATION_OPTION_FNS;
+var SANDBOX_CALLABLES, GeneratedSourcePolicyError, FORBIDDEN_AMBIENT_IDENTIFIERS, FORBIDDEN_THREE_CONSTRUCTORS, ROTATION_OPTION_FNS;
 var init_validation = __esm(() => {
+  init_list_primitives();
+  SANDBOX_CALLABLES = new Set([
+    ...listPrimitives().map((primitive) => primitive.name),
+    "Array",
+    "BigInt",
+    "Boolean",
+    "Error",
+    "Float32Array",
+    "Float64Array",
+    "Int16Array",
+    "Int32Array",
+    "Int8Array",
+    "Map",
+    "Number",
+    "Object",
+    "Promise",
+    "Proxy",
+    "RangeError",
+    "Reflect",
+    "RegExp",
+    "Set",
+    "String",
+    "Symbol",
+    "TypeError",
+    "Uint16Array",
+    "Uint32Array",
+    "Uint8Array",
+    "WeakMap",
+    "WeakSet",
+    "decodeURIComponent",
+    "encodeURIComponent",
+    "isFinite",
+    "isNaN",
+    "parseFloat",
+    "parseInt",
+    "structuredClone"
+  ]);
   GeneratedSourcePolicyError = class GeneratedSourcePolicyError extends Error {
     code;
     line;

--- a/dist/mcp-server.mjs
+++ b/dist/mcp-server.mjs
@@ -1676,6 +1676,928 @@ var init_capture_cache = __esm(() => {
   init_capture_limits();
 });
 
+// src/geometry-catalog.ts
+var geometryPrimitives;
+var init_geometry_catalog = __esm(() => {
+  geometryPrimitives = [
+    {
+      name: "copyGeometry",
+      signature: "copyGeometry(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "instancing",
+      description: "Returns an independent geometry with copied vertex buffers. Use before direct mutation of a cached primitive.",
+      example: "const editable = copyGeometry(boxGeo(1, 1, 1)); editable.translate(0, 0.5, 0);"
+    },
+    {
+      name: "copyMaterial",
+      signature: "copyMaterial(material: Material)",
+      returns: "THREE.Material (same subtype)",
+      category: "instancing",
+      description: "Copies material properties so edits do not change other parts. Referenced textures remain shared.",
+      example: "const red = copyMaterial(steel); red.color.set(0xaa2222);"
+    },
+    {
+      name: "meshGeo",
+      signature: "meshGeo({ positions: number[], indices?: number[], normals?: number[], uvs?: number[], tangents?: number[] })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Builds an owned triangle mesh from flat numeric arrays. Validates finite values, attribute lengths and indices; computes normals if absent. Counterclockwise winding.",
+      example: "const triangle = meshGeo({ positions: [0,0,0, 1,0,0, 0,1,0], indices: [0,1,2] });"
+    },
+    {
+      name: "parametricSurface",
+      signature: "parametricSurface(sample: (u,v) => [x,y,z], opts?: { u?: [0,1], v?: [0,1], uSegments?: 24, vSegments?: 24, periodicU?: false, periodicV?: false, orientation?: 'uv'|'vu' })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Samples an equation into an owned surface with UVs. Periodic endpoints must coincide; UV seams retain matching normals. A surface is not automatically a watertight solid.",
+      example: "const canopy = parametricSurface((u,v) => [u, 0.3*Math.sin(u*3)*Math.cos(v*2), v], { u: [-2,2], v: [-1,1] });"
+    },
+    {
+      name: "geometryDiagnostics",
+      signature: "geometryDiagnostics(geometry: BufferGeometry, tolerance?: 1e-6)",
+      returns: "{ vertices, triangles, boundaryEdges, nonManifoldEdges, orientationConflicts, degenerateTriangles, invalidIndices, nonFiniteVertices }",
+      category: "utility",
+      description: "Counts mesh topology problems after position-based seam matching. Open boundaries are valid for sheets; closed edges alone do not prove a self-intersection-free solid.",
+      example: "const topology = geometryDiagnostics(shell);"
+    },
+    {
+      name: "creaseNormals",
+      signature: "creaseNormals(geometry: BufferGeometry, opts?: { angle?: 60, tolerance?: number })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Returns owned geometry with angle-limited smooth normals, preserving UV corners. Angle is degrees. Invalidates tangents; use after shaping for sharp rims and smooth walls.",
+      example: "const shell = creaseNormals(cylinderGeo(1,1,2,32), { angle: 45 });"
+    },
+    {
+      name: "bend",
+      signature: "bend(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Bends local +Y toward +X through angle degrees. Returns owned geometry and updated normals/bounds; preserves UVs, invalidates tangents. Frame rotation is Euler XYZ degrees.",
+      promptNotes: "Deformation interval uses local Y distances; outside vertices stay unchanged. Add enough segments before bending. Falloff returns 0..1; use it to avoid a discontinuity at a selected interval boundary.",
+      example: "const arch = bend(planeGeo(1,4,4,32), { angle: 90 });"
+    },
+    {
+      name: "twist",
+      signature: "twist(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Rotates the cross-section progressively around local +Y, reaching angle degrees at the end. Returns owned geometry; frame rotation uses Euler XYZ degrees.",
+      example: "const spiral = twist(column, { angle: 120 });"
+    },
+    {
+      name: "taper",
+      signature: "taper(geometry, { startScale?: [1,1], endScale: [x,z], frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Scales local X/Z across the local Y interval using positive start/end scale pairs. Returns owned geometry; preserves UVs and invalidates tangents.",
+      example: "const narrowed = taper(column, { endScale: [0.4,0.7] });"
+    },
+    {
+      name: "displace",
+      signature: "displace(geometry, offset: ([x,y,z], t) => [dx,dy,dz], opts?: { frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Adds an authored displacement vector in the chosen local frame. Returns owned geometry; callback coordinates are local and t is normalized along the interval.",
+      example: "const rippled = displace(surface, ([x,y,z]) => [0, 0.1*Math.sin(x*8), 0]);"
+    },
+    {
+      name: "sweepProfile",
+      signature: "sweepProfile(profile: [x,z][], path: [x,y,z][], opts?: { cap?: true, closed?: false, up?: [x,y,z], twist?: 0, scale?: number | [x,z][] })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Sweeps a simple noncircular profile along polyline stations using transported frames. Supports total twist in degrees and per-station scales. Generates UVs and optional caps.",
+      promptNotes: "First version supports one simple profile without holes. Closed paths omit the repeated endpoint and require twist to be a multiple of 360. up sets the initial profile +Z direction and cannot parallel the path. Tight-turn warnings do not replace visual inspection for self-intersections.",
+      example: "const rail = sweepProfile([[-.1,-.2],[.1,-.2],[.1,.2],[-.1,.2]], [[0,0,0],[0,1,0],[1,2,0]]);"
+    },
+    {
+      name: "loftProfiles",
+      signature: "loftProfiles(sections: { profile: [x,z][], frame?: { origin, rotation } }[], opts?: { cap?: true })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Joins corresponding simple profiles in explicit local XZ planes. Each frame uses Euler XYZ degrees and local +Y along the loft. Profiles need equal point counts and corresponding vertices.",
+      promptNotes: "No holes or automatic profile correspondence. Opposite winding is normalized while preserving the first point. Caps close boundaries but do not prove the loft has no self-intersections.",
+      example: "const hull = loftProfiles([{ profile: wide }, { profile: narrow, frame: { origin: [0,2,0] } }]);"
+    },
+    {
+      name: "implicitSurface",
+      signature: "await implicitSurface(sample: ([x,y,z]) => signedValue, { bounds: { min, max }, edgeLength, maxCells?: 1000000, maxEvaluations?: 8000000, level?: 0, tolerance?: -1, smooth?: true })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "geometry",
+      description: "Experimental positive-inside implicit field sampled into a solid mesh. Requires explicit bounds and resolution; checks grid size and actual evaluation count. Output has no UVs.",
+      promptNotes: "Use async build and await. Smaller edgeLength increases cost sharply. This helper cannot stop a callback that never returns; the host evaluator process provides that boundary. Thin features and geometric accuracy require inspection.",
+      example: "const blob = await implicitSurface(([x,y,z]) => 1-Math.hypot(x,y,z), { bounds: { min: [-1.2,-1.2,-1.2], max: [1.2,1.2,1.2] }, edgeLength: 0.15 });"
+    }
+  ];
+});
+
+// src/list-primitives.ts
+function listPrimitives() {
+  return PRIMITIVES.map((p) => ({ ...p }));
+}
+var PRIMITIVES;
+var init_list_primitives = __esm(() => {
+  init_geometry_catalog();
+  PRIMITIVES = [
+    ...geometryPrimitives,
+    {
+      name: "createRoot",
+      signature: "createRoot(name: string)",
+      returns: "THREE.Object3D",
+      category: "structure",
+      description: "Creates the root Object3D for an asset. Call first in build().",
+      example: "const root = createRoot('FuelDrum');"
+    },
+    {
+      name: "createPivot",
+      signature: "createPivot(name: string, position?: [x, y, z], parent?: Object3D)",
+      returns: "THREE.Object3D (prefixed `Joint_`)",
+      category: "structure",
+      description: "Creates an empty pivot node for skeletal animation. Name is auto-prefixed with `Joint_`.",
+      example: "const hip = createPivot('Hip', [0, 1, 0], root);"
+    },
+    {
+      name: "createJointChain",
+      signature: "createJointChain(name, segments: { role, offset, aliases?, side?, localForwardAxis?, localBendAxis?, endEffector?, contact? }[], opts?: { parent?, parentRole? })",
+      returns: "{ root, end, nodes, byRole, descriptors }",
+      category: "structure",
+      description: "Creates one body-plan-neutral deterministic Joint_* chain with explicit parent edges, rest frames, local axes, end effectors, contacts, and semantic metadata.",
+      example: "const leg = createJointChain('LegL', [{ role: 'hip.left', offset: [0, 1, -0.2], side: 'left' }, { role: 'knee.left', offset: [0, -0.5, 0], side: 'left' }, { role: 'ankle.left', offset: [0, -0.5, 0], side: 'left', endEffector: true, contact: true }], { parent: root });",
+      promptNotes: "Use only the resolved body-plan graph. Offsets are local to the previous joint; contact end effectors must land at world Y=0."
+    },
+    {
+      name: "createVehicleFrame",
+      signature: "createVehicleFrame(name, opts?: { chassis?, axles?, seats?, contacts?, steering?, propulsion?, parent? })",
+      returns: "{ root, chassis, axles, seats, contacts, steering, propulsion }",
+      category: "structure",
+      description: "Creates a canonical +X-forward/+Y-up/+Z-right vehicle frame with typed semantic sockets for chassis, support, steering, and propulsion.",
+      example: "const frame = createVehicleFrame('CarFrame', { axles: [{ id: 'front', position: [1.2, 0.45, 0] }, { id: 'rear', position: [-1.2, 0.45, 0] }], parent: root });",
+      promptNotes: "Generated vehicles keep +X as front. Boats and other non-wheeled subtypes use declared support/propulsion sockets, not wheel rules."
+    },
+    {
+      name: "createWheelGeometrySet",
+      signature: "createWheelGeometrySet(radius: number, width: number)",
+      returns: "{ tire, rim, hub } shared THREE.BufferGeometry set",
+      category: "instancing",
+      description: "Creates one reusable +Z-axle tire/rim/hub geometry set for instanced wheel assemblies.",
+      example: "const wheelGeo = createWheelGeometrySet(0.45, 0.22);"
+    },
+    {
+      name: "createWheelAssembly",
+      signature: "createWheelAssembly(name, { tire, rim, hub? }, { radius, width, side, index, position?, rimRadius?, hubRadius?, steering?, loadBearing?, geometries?, parent? })",
+      returns: "{ root, steeringPivot?, spinPivot, tire, rim, hub, contact, radius, width, side, index, spinAxis }",
+      category: "structure",
+      description: "Creates one axle-centered wheel pivot containing concentric tire/rim/hub roles, a contact marker, +Z spin frame, and optional steering pivot.",
+      example: "createWheelAssembly('FrontLeft', { tire: rubber, rim: metal }, { radius: 0.45, width: 0.22, side: 'left', index: 'front', position: [1.2, 0.45, -0.9], steering: true, geometries: wheelGeo, parent: frame.root });",
+      promptNotes: "Keep tire, rim, and hub descendants concentric at the axle pivot. Reuse one geometry set across matching wheels."
+    },
+    {
+      name: "createPart",
+      signature: "createPart(name, geometry, material, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, pivot, parent })",
+      returns: "THREE.Object3D (mesh or wrapping pivot)",
+      category: "structure",
+      description: "Creates a mesh, optionally wrapped in a pivot, and attaches it to `opts.parent`. `rotation` is in DEGREES (like rotationTrack), NOT radians: [0, 0, 90] is a quarter turn; [0, 0, 1.57] is a no-op.",
+      example: "createPart('Barrel', cylinderGeo(0.1, 0.1, 1), gameMaterial(0x556b2f), { position: [0, 0.5, 0], rotation: [0, 0, 90], parent: root });",
+      promptNotes: "AUTO-ADDS to opts.parent. NEVER call parent.add(createPart(...)) — pass { parent } instead. rotation is DEGREES — writing radians (e.g. 0.785 or Math.PI/4) silently produces ~zero rotation."
+    },
+    {
+      name: "beamBetween",
+      signature: "beamBetween(name, start: [x,y,z], end: [x,y,z], radius, material, opts?: { segments, parent })",
+      returns: "THREE.Object3D (prefixed `Mesh_`)",
+      category: "structure",
+      description: "Creates a cylindrical rail/strut exactly between two endpoints. Use for braces, gun barrels, skid struts, cables, and scaffolding.",
+      example: "beamBetween('SkidBraceA', [0.8, 0.3, 0.7], [0.8, 1.0, 0.45], 0.025, black, { parent: root });"
+    },
+    {
+      name: "snapTo",
+      signature: "snapTo(part: Object3D, host: Object3D, opts?: { axis?: 'x'|'y'|'z', overlap?: 0.02 })",
+      returns: "THREE.Object3D (the part, for chaining)",
+      category: "structure",
+      description: 'Translates `part` by the minimal vector that brings its bounding box into contact with `host` (plus a small overlap). The direct cure for a "Floating parts" warning — attach the part instead of eyeballing a corrective offset. No-op if they already touch.',
+      example: `const scope = createPart('Scope', cylinderXGeo(0.04, 0.04, 0.3), steel, { parent: root, position: [0.1, 0.32, 0] });
+snapTo(scope, receiver);`
+    },
+    {
+      name: "createLadder",
+      signature: "createLadder(name, { bottom, top, material, width?, rungCount?, railRadius?, rungRadius?, widthAxis?, parent? })",
+      returns: "{ leftRail: Object3D, rightRail: Object3D, rungs: Object3D[] }",
+      category: "structure",
+      description: "Builds two continuous rails plus evenly-spaced rungs. Use this instead of loose boxes for ladders.",
+      example: "createLadder('TowerLadder', { bottom: [0,0,0], top: [0,2.2,0], width: 0.45, rungCount: 7, material: steel, parent: root });"
+    },
+    {
+      name: "createWingPair",
+      signature: "createWingPair(name, material, { rootZ, span, rootChord, tipChord, sweep?, thickness?, dihedral?, rootX?, rootY?, parent? })",
+      returns: "{ right: Object3D, left: Object3D }",
+      category: "structure",
+      description: "Creates mirrored trapezoid aircraft wings with roots attached at +/-rootZ. Use for aircraft wings and helicopter stub wings.",
+      example: "createWingPair('MainWing', olive, { rootX: 0, rootY: 1.0, rootZ: 0.42, span: 2.4, rootChord: 0.9, tipChord: 0.35, sweep: 0.25, dihedral: 0.08, parent: root });"
+    },
+    {
+      name: "room",
+      signature: "room(name, material, { width?, depth?, height?, wallThickness?, floor?, floorThickness?, openings?: [{ wall: 'front'|'back'|'left'|'right', kind?: 'door'|'window', offset?, width?, height?, sill? }], parent? })",
+      returns: "{ root: Object3D, walls: { front, back, left, right }, floor: Object3D | null }",
+      category: "structure",
+      description: "Builds a HOLLOW, enterable room: four thin walls + a floor, human-scaled (defaults: 2.8m ceiling, a centered 1.1x2.1m front door so it is enterable by default). `front` faces +X; the floor sits on the ground. The keystone of an architecture asset — add a roof with createRoofPlanes and fixtures as separate parts.",
+      example: "const { root: hut } = room('Hut', wood, { width: 5, depth: 4, height: 2.8, openings: [{ wall: 'front', kind: 'door' }, { wall: 'right', kind: 'window' }], parent: root });",
+      promptNotes: "Use for any building the player enters. Do NOT model a building as a solid block — room() guarantees real interior space and a doorway gap. Pass openings to add windows / side doors."
+    },
+    {
+      name: "wallWithOpening",
+      signature: "wallWithOpening(name, material, { length, height, thickness, axis?: 'x'|'z', opening?: { kind?: 'door'|'window', offset?, width?, height?, sill? }, parent? })",
+      returns: "THREE.Object3D (wall container)",
+      category: "structure",
+      description: "A single wall panel with an optional real door/window cut, composed from solid box segments (side panels + lintel + window sill) — no CSG. Base at local Y=0, centered on the run axis. Use to compose custom building layouts or interior dividing walls beyond the default room().",
+      example: "wallWithOpening('Partition', plaster, { length: 4, height: 2.8, thickness: 0.12, axis: 'x', opening: { kind: 'door', offset: 0.5 }, parent: root });"
+    },
+    {
+      name: "createRoofPlanes",
+      signature: "createRoofPlanes(name, material, { width, depth, height, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
+      returns: "{ root: Object3D, slopes: [Object3D, Object3D] }",
+      category: "structure",
+      description: "A pitched roof: two thin slopes meeting at one ridge and falling DOWN-AND-OUTWARD (opposite tilts — never mirrored the same way), footprint-matched with an eave overhang. Eave at local Y=0, ridge at Y=height, so position the group at Y=wallHeight. Returns a named group (e.g. `Roof`) the engine can lift to reveal the interior.",
+      example: `const { root: roof } = createRoofPlanes('Roof', shingle, { width: 5, depth: 4, height: 1.6, overhang: 0.4, ridgeAxis: 'x', parent: root });
+roof.position.y = 2.8;`,
+      promptNotes: "The two slopes must fall AWAY from each other from the ridge — createRoofPlanes does this for you. Drop it onto the walls (position.y = wall height)."
+    },
+    {
+      name: "createGableRoof",
+      signature: "createGableRoof(name, material, { spanX, spanZ, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
+      returns: "{ root, slopes: [Object3D, Object3D], faces: [RoofFaceFrame, RoofFaceFrame], rise, pitchDegrees }",
+      category: "structure",
+      description: "Explicit-axis gable roof using unambiguous footprint spans. Each face owns a rigid frame with ridge tangent, outward normal, downhill direction, ridge/eave endpoints, dimensions, and a live local-to-world transform.",
+      example: "const roof = createGableRoof('Roof', shingles, { spanX: 8, spanZ: 5, pitchDegrees: 35, overhang: 0.35, ridgeAxis: 'x', parent: root });",
+      promptNotes: "Prefer this over width/depth roof math. ridgeAxis is the direction of the ridge; roof panels run along each returned face downhill direction."
+    },
+    {
+      name: "createGableEndPanel",
+      signature: "createGableEndPanel(name, material, { span, rise, thickness?, ridgeAxis?: 'x'|'z', side?: 'positive'|'negative', openings?: [{ id?, offset?, bottom?, width, height }], parent? })",
+      returns: "{ root, geometry, openings }",
+      category: "structure",
+      description: "Exact thick triangular end closure for a gable roof, with optional rectangular openings cut from the geometry and semantic boundary metadata.",
+      example: "createGableEndPanel('FrontGable', siding, { span: 5, rise: 1.8, ridgeAxis: 'x', side: 'positive', parent: root });"
+    },
+    {
+      name: "createGableShell",
+      signature: "createGableShell(name, { wall, roof, floor?, gable? }, { spanX, spanZ, wallHeight?, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, wallThickness?, floorThickness?, closedEnds?, enterable?, openings?, gableOpenings?, parent? })",
+      returns: "{ root, walls, floor, roof, gables, openings }",
+      category: "structure",
+      description: "Closed-by-default, correct-by-construction gable building: hollow room, floor, two opposing roof slopes, two complete gable ends, and a real front doorway when enterable.",
+      example: "const house = createGableShell('House', { wall: plaster, roof: shingles }, { spanX: 8, spanZ: 5, wallHeight: 2.8, pitchDegrees: 35, ridgeAxis: 'x', parent: root });",
+      promptNotes: "Use for complete gable buildings. It stamps wall, floor, slope, gable, opening, adjacency, coverage, and separability semantics for deterministic QA and roof-off views."
+    },
+    {
+      name: "createRoofSurfaceLayout",
+      signature: "createRoofSurfaceLayout(name, material, { face, kind: 'panels'|'shingles'|'seams'|'corrugations', parent?, panelWidth?, rowHeight?, spacing?, thickness? })",
+      returns: "{ root, items: Object3D[] }",
+      category: "structure",
+      description: "Places roof-local panels, shingles, seams, or corrugations from a returned RoofFaceFrame, so repeated elements run ridge-to-eave for either ridge axis without manual Euler rotations.",
+      example: "for (const face of roof.faces) createRoofSurfaceLayout('Panels_' + face.side, metal, { face, kind: 'panels', parent: roof.root });",
+      promptNotes: "Always pass the face object returned by createGableRoof/createGableShell. Never infer the panel rotation from world axes."
+    },
+    {
+      name: "createStairs",
+      signature: "createStairs(name, material, { steps?, totalRise, totalRun, width, axis?: 'x'|'z', treadThickness?, riser?, parent? })",
+      returns: "{ root: Object3D, steps: Object3D[] }",
+      category: "structure",
+      description: "A straight flight of stairs: box treads (with optional risers) climbing totalRise over totalRun from local origin toward +axis. Use for porch/entry steps or to connect storeys in a multi-storey building.",
+      example: "createStairs('Porch', stone, { steps: 4, totalRise: 0.6, totalRun: 1.0, width: 1.4, axis: 'x', parent: root });"
+    },
+    {
+      name: "boxGeo",
+      signature: "boxGeo(width: number, height: number, depth: number)",
+      returns: "THREE.BoxGeometry",
+      category: "geometry",
+      description: "6-face box. 12 tris regardless of size. Cheapest geometry.",
+      example: "const geo = boxGeo(1, 0.5, 2);"
+    },
+    {
+      name: "sphereGeo",
+      signature: "sphereGeo(radius: number, widthSegments?: 8, heightSegments?: 6)",
+      returns: "THREE.SphereGeometry",
+      category: "geometry",
+      description: "UV sphere. Default 8x6 segments = 84 tris. Bump segments for smoother curves.",
+      example: "const geo = sphereGeo(0.5, 12, 8);"
+    },
+    {
+      name: "cylinderGeo",
+      signature: "cylinderGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Y-axis cylinder. Use radiusTop != radiusBottom for cones / tapered pieces.",
+      example: "const geo = cylinderGeo(0.25, 0.25, 1, 12);"
+    },
+    {
+      name: "cylinderYGeo",
+      signature: "cylinderYGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Alias for cylinderGeo — a Y-axis cylinder. Provided because the sandbox exposes cylinderXGeo / cylinderZGeo and the symmetric Y form is commonly reached for.",
+      example: "const geo = cylinderYGeo(0.25, 0.25, 1, 12);"
+    },
+    {
+      name: "cylinderXGeo",
+      signature: "cylinderXGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Cylinder pre-rotated to run along +X/-X. Use for fuselages, cannons, barrels, axles, and forward-facing tubes.",
+      example: "const geo = cylinderXGeo(0.1, 0.1, 1.2, 12);"
+    },
+    {
+      name: "cylinderZGeo",
+      signature: "cylinderZGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Cylinder pre-rotated to run along +Z/-Z. Use for side-mounted weapons, rails, crossbars, and pipes.",
+      example: "const geo = cylinderZGeo(0.08, 0.08, 0.9, 10);"
+    },
+    {
+      name: "cylinderOnAxis",
+      signature: "cylinderOnAxis(center: [x,y,z], normal: [x,y,z], radiusBottom: number, height: number, opts?: { radiusTop?, segments? })",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Frame-first cylinder: position + axis specified directly, no post-hoc rotation. Use when the cylinder needs to point along a non-cardinal direction (struts inside CSG operands, antennas off a tilted surface). For cardinal axes prefer the terser cylinderXGeo / cylinderYGeo / cylinderZGeo helpers.",
+      example: "const strut = cylinderOnAxis([0.5, 0.7, 0], [1, 1, 0.3], 0.05, 0.9);"
+    },
+    {
+      name: "capsuleGeo",
+      signature: "capsuleGeo(radius: number, height: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Stadium shape (cylinder with hemispherical caps). Good for limbs.",
+      example: "const geo = capsuleGeo(0.1, 0.5, 6);"
+    },
+    {
+      name: "capsuleYGeo",
+      signature: "capsuleYGeo(radius: number, height: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Alias for capsuleGeo — a Y-axis capsule. Provided for symmetry with capsuleXGeo / capsuleZGeo.",
+      example: "const geo = capsuleYGeo(0.1, 0.5, 6);"
+    },
+    {
+      name: "capsuleXGeo",
+      signature: "capsuleXGeo(radius: number, length: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Capsule pre-rotated to run along +X/-X. Use for aircraft bodies, rounded vehicle hulls, and missiles.",
+      example: "const geo = capsuleXGeo(0.35, 2.4, 10);"
+    },
+    {
+      name: "capsuleZGeo",
+      signature: "capsuleZGeo(radius: number, length: number, segments?: 6)",
+      returns: "THREE.CapsuleGeometry",
+      category: "geometry",
+      description: "Capsule pre-rotated to run along +Z/-Z. Use for lateral pods, floats, and side tanks.",
+      example: "const geo = capsuleZGeo(0.18, 1.1, 8);"
+    },
+    {
+      name: "coneGeo",
+      signature: "coneGeo(radius: number, height: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Y-axis cone (pointed up). Use for spikes, roofs, projectiles.",
+      example: "const geo = coneGeo(0.3, 0.8, 8);"
+    },
+    {
+      name: "coneYGeo",
+      signature: "coneYGeo(radius: number, height: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Alias for coneGeo — a Y-axis cone (point +Y). Provided for symmetry with coneXGeo / coneZGeo.",
+      example: "const geo = coneYGeo(0.3, 0.8, 8);"
+    },
+    {
+      name: "coneXGeo",
+      signature: "coneXGeo(radius: number, length: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Cone pre-rotated so its point faces +X. Use for noses, rockets, shells, and forward-facing tips.",
+      example: "const geo = coneXGeo(0.18, 0.45, 12);"
+    },
+    {
+      name: "coneZGeo",
+      signature: "coneZGeo(radius: number, length: number, segments?: 8)",
+      returns: "THREE.ConeGeometry",
+      category: "geometry",
+      description: "Cone pre-rotated so its point faces +Z. Use for side-facing projectiles and tips.",
+      example: "const geo = coneZGeo(0.12, 0.35, 10);"
+    },
+    {
+      name: "taperConeGeo",
+      signature: "taperConeGeo(radiusBottom: number, radiusTop: number, height: number, axis?: 'x'|'y'|'z', segments?: 8)",
+      returns: "THREE.CylinderGeometry",
+      category: "geometry",
+      description: "Truncated cone (frustum) — exposes both bottom and top radius. radiusTop=0 matches coneGeo, radiusTop=radiusBottom matches cylinderGeo. Use for pylon caps, soda cans, lampshades, anything tapered that does not come to a point. axis selects orientation (default Y).",
+      example: "const cap = taperConeGeo(0.3, 0.18, 0.4);  // frustum"
+    },
+    {
+      name: "torusGeo",
+      signature: "torusGeo(radius: number, tube: number, radialSegments?: 8, tubularSegments?: 12)",
+      returns: "THREE.TorusGeometry",
+      category: "geometry",
+      description: "Donut shape. For rings, tyres, barrel ribs.",
+      example: "const geo = torusGeo(0.4, 0.04, 8, 16);"
+    },
+    {
+      name: "planeGeo",
+      signature: "planeGeo(width: number, height: number, widthSegments?: 1, heightSegments?: 1)",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Flat quad for TEXTURED surfaces (ground, signs, walls with albedo maps). For solid-color decals like red stars, hull numbers, stamps, or window cutouts on no-texture assets use decalBox — a bare planeGeo without a texture will render as a disconnected 2-tri square and get flagged as a stray plane.",
+      example: "const geo = planeGeo(4, 4);"
+    },
+    {
+      name: "decalBox",
+      signature: "decalBox(width: number, height: number, depth?: 0.01)",
+      returns: "THREE.BoxGeometry",
+      category: "geometry",
+      description: "Thin box for solid-color surface decals: red stars, hull numbers, stamps, no-texture windows. Unlike planeGeo, has real depth so it visibly attaches to its host surface. Must be placed on a surface with position + rotation.",
+      example: `const star = decalBox(0.18, 0.18, 0.01);
+createPart('Mesh_StarPort', star, gameMaterial(0xc61f2a), { position: [0.4, 0.6, 0.41], parent: fuselage });`,
+      promptNotes: "Offset at least 0.01 outside the host surface to avoid z-fighting (a 0.8-wide hull has faces at z=±0.4, so place the decal at z=±0.41)."
+    },
+    {
+      name: "foliageCardGeo",
+      signature: "foliageCardGeo(opts?: { width?, height?, yPivot?: 0..1 })",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Single-quad foliage card with a configurable Y pivot. yPivot=0 plants the quad on the ground. Pair with an alpha-tested material and a leaf/plant sprite.",
+      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
+const quad = foliageCardGeo({ width: 4, height: 6, yPivot: 0 });
+createPart('Mesh_Fern', quad, leaves, { parent: root });`
+    },
+    {
+      name: "crossedQuadsGeo",
+      signature: "crossedQuadsGeo(opts?: { width?, height?, planes?: 2 | 3, yPivot? })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Cross-billboard bush primitive: 2 or 3 planes intersecting along the Y axis. Reads as a dense plant from any angle, cheaper than real geometry.",
+      example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
+const bush = crossedQuadsGeo({ width: 2, height: 2, planes: 3 });
+createPart('Mesh_Bush', bush, leaves, { parent: root });`
+    },
+    {
+      name: "octaGridPlane",
+      signature: "octaGridPlane({ tilesX, tilesY, width?, height?, yPivot? })",
+      returns: "THREE.PlaneGeometry",
+      category: "geometry",
+      description: "Atlas-ready billboard quad. UVs are pre-scaled to cover one tile of a tilesX×tilesY atlas; the consumer shader adds per-instance tile offsets at draw time.",
+      example: "const card = octaGridPlane({ tilesX: 4, tilesY: 4, width: 6, height: 6 });"
+    },
+    {
+      name: "wingGeo",
+      signature: "wingGeo(opts?: { span, rootChord, tipChord, sweep, thickness, dihedral })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Trapezoid wing panel. Local root edge is at Z=0, span extends toward +Z, positive sweep moves the tip aft along -X.",
+      example: "const geo = wingGeo({ span: 2.2, rootChord: 0.8, tipChord: 0.3, sweep: 0.25, dihedral: 0.08 });"
+    },
+    {
+      name: "gearGeo",
+      signature: "gearGeo(opts?: { teeth?: 12, rootRadius?: 0.8, tipRadius?: 1.0, boreRadius?: 0.2, height?: 0.3, toothWidthFrac?: 0.5 })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Stylized gear with flat edges and an optional center bore; no CSG. Use boreRadius < rootRadius < tipRadius. Radii are absolute: an omitted rootRadius stays 0.8 when tipRadius changes. Set all three radii for small gears.",
+      example: `const g = gearGeo({ teeth: 28, rootRadius: 0.063, tipRadius: 0.075, boreRadius: 0.012, height: 0.024 });
+createPart('Gear', g, gameMaterial(0x909090, { metalness: 0.8 }), { parent: root });`
+    },
+    {
+      name: "bladeGeo",
+      signature: "bladeGeo(opts?: { length?: 1.5, baseWidth?: 0.1, thickness?: 0.015, tipLength?: 0.25, edgeBevel?: 0 })",
+      returns: "THREE.BufferGeometry",
+      category: "geometry",
+      description: "Parametric sword blade: rectangular base tapering to a point over tipLength. edgeBevel > 0 pinches the cross-section toward a diamond ridge.",
+      example: `const b = bladeGeo({ length: 1.6, baseWidth: 0.09, tipLength: 0.3, edgeBevel: 0.5 });
+createPart('Blade', b, steel, { position: [0, 0, 0], parent: root });`
+    },
+    {
+      name: "gameMaterial",
+      signature: "gameMaterial(color, opts?: { metalness, roughness, emissive, emissiveIntensity, flatShading })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Flat-shaded PBR material. Default for game-ready low-poly. Use for 95% of parts.",
+      example: "const mat = gameMaterial(0x8b7355, { roughness: 0.9 });"
+    },
+    {
+      name: "materialRecipe",
+      signature: "await materialRecipe(recipeId, overrides?: { baseColor?, roughness?, metalness?, opacity?, alphaCutoff?, doubleSided?, emissiveColor?, emissiveIntensity?, textureResources? })",
+      returns: "Promise<THREE.MeshStandardMaterial>",
+      category: "material",
+      description: "Resolves a versioned portable bark/leaf/wood/stone/rubber/painted-metal/cloth/skin/glass/emissive recipe to standard glTF PBR.",
+      example: "const bark = await materialRecipe('kiln.material.bark.v1', { baseColor: '#6b4328' });",
+      promptNotes: "Use only listed kiln.material.*.v1 IDs and approved kiln.texture.* resource IDs. Leaf is MASK, glass is BLEND, and host file paths are forbidden."
+    },
+    {
+      name: "compilePortableMaterialSpecV2",
+      signature: "await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', name?, baseColor?, roughness?, metalness?, emissive?, emissiveIntensity?, alphaMode?, alphaCutoff?, doubleSided?, textures?: { baseColor?, normal?, metallicRoughness?, emissive?, occlusion? } })",
+      returns: "Promise<THREE.MeshStandardMaterial>",
+      category: "material",
+      description: "Compiles the strict portable material contract. Texture refs are either typed procedural V2 specs or closed approved kiln.texture.* IDs; paths, URLs, raw textures, callbacks, and shader source are rejected.",
+      example: "const steel = await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', roughness: 0.45, metalness: 0.85, textures: { metallicRoughness: { kind: 'procedural', spec: { schemaVersion: 2, usage: 'metallicRoughness', size: 64, layers: [{ op: 'solid', color: 0x0080cc }] } } } });",
+      promptNotes: "Use metallicRoughness as one packed G=roughness/B=metalness map. Every procedural ref usage must match its slot; resource refs must be approved for that exact slot."
+    },
+    {
+      name: "basicMaterial",
+      signature: "basicMaterial(color, opts?: { transparent, opacity })",
+      returns: "THREE.MeshBasicMaterial",
+      category: "material",
+      description: "Unlit flat material. For UI / effects where lighting is baked in.",
+      example: "const mat = basicMaterial(0xffffff, { transparent: true, opacity: 0.5 });"
+    },
+    {
+      name: "glassMaterial",
+      signature: "glassMaterial(color, opts?: { opacity, roughness, metalness })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Semi-transparent double-sided material. Panels need ~0.05 offset to avoid z-fighting.",
+      example: "const mat = glassMaterial(0x66ccff, { opacity: 0.3 });"
+    },
+    {
+      name: "lambertMaterial",
+      signature: "lambertMaterial(color, opts?: { flatShading, emissive })",
+      returns: "THREE.MeshLambertMaterial",
+      category: "material",
+      description: "Cheaper than gameMaterial. No metalness/roughness. Use when PBR is overkill.",
+      example: "const mat = lambertMaterial(0x2a4d14, { flatShading: true });"
+    },
+    {
+      name: "rotationTrack",
+      signature: "rotationTrack(jointName: string, keyframes: Array<{ time, rotation: [xDeg, yDeg, zDeg] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.QuaternionKeyframeTrack",
+      category: "animation",
+      description: "Rotation track in degrees, auto-converted to quaternions. Joint name must include `Joint_` prefix.",
+      example: "rotationTrack('Joint_Lid', [{ time: 0, rotation: [0, 0, 0] }, { time: 1, rotation: [90, 0, 0] }]);"
+    },
+    {
+      name: "positionTrack",
+      signature: "positionTrack(jointName: string, keyframes: Array<{ time, position: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.VectorKeyframeTrack",
+      category: "animation",
+      description: "Position track in world units. Always use `position:` not `value:` in keyframes.",
+      example: "positionTrack('Joint_Body', [{ time: 0, position: [0, 0, 0] }, { time: 1, position: [0, 0.1, 0] }]);"
+    },
+    {
+      name: "scaleTrack",
+      signature: "scaleTrack(jointName: string, keyframes: Array<{ time, scale: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
+      returns: "THREE.VectorKeyframeTrack",
+      category: "animation",
+      description: "Uniform or per-axis scale track.",
+      example: "scaleTrack('Joint_Chest', [{ time: 0, scale: [1, 1, 1] }, { time: 1, scale: [1.1, 1.1, 1.1] }]);"
+    },
+    {
+      name: "createClip",
+      signature: "createClip(name: string, duration: number, tracks: KeyframeTrack[])",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Collects tracks into a named clip. Returned from animate().",
+      example: "return [createClip('Open', 1, [rotationTrack('Joint_Lid', [...])])];"
+    },
+    {
+      name: "idleBreathing",
+      signature: "idleBreathing(bodyJoint: string, duration?: 2, amount?: 0.02)",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Gentle Y-axis bob. For NPC idle states.",
+      example: "return [idleBreathing('Joint_Body')];"
+    },
+    {
+      name: "bobbingAnimation",
+      signature: "bobbingAnimation(rootName: string, duration?: 2, height?: 0.1)",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "Floating / bobbing loop for pickups and effects.",
+      example: "return [bobbingAnimation('Joint_Root', 1.5, 0.08)];"
+    },
+    {
+      name: "spinAnimation",
+      signature: "spinAnimation(jointName: string, duration?: 2, axis?: 'x' | 'y' | 'z')",
+      returns: "THREE.AnimationClip",
+      category: "animation",
+      description: "360° rotation over `duration` around `axis`.",
+      example: "return [spinAnimation('Joint_Rotor', 0.5, 'y')];"
+    },
+    {
+      name: "cloneGeometry",
+      signature: "cloneGeometry(geo: BufferGeometry)",
+      returns: "THREE.BufferGeometry (same ref)",
+      category: "instancing",
+      description: "Deprecated name: returns the SAME geometry, without copying. Use copyGeometry for independent vertex edits, or pass the original geometry directly for intentional sharing.",
+      example: "const wheelGeo = cylinderGeo(0.4, 0.4, 0.2, 12);"
+    },
+    {
+      name: "cloneMaterial",
+      signature: "cloneMaterial(mat: Material)",
+      returns: "THREE.Material (same ref)",
+      category: "instancing",
+      description: "Deprecated name: returns the SAME material. Use copyMaterial for independent property edits, or pass the original for intentional sharing.",
+      example: "const rubberMat = gameMaterial(0x1a1a1a, { roughness: 0.95 });"
+    },
+    {
+      name: "createInstance",
+      signature: "createInstance(name, source, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, parent })",
+      returns: "THREE.Object3D",
+      category: "instancing",
+      description: "Creates a new mesh reusing an existing part's geometry + material at a new transform. Cheapest way to replicate wheels / bolts / fence posts / windows. `rotation` is in DEGREES, like createPart.",
+      example: `const wheelFL = createPart('WheelFL', wheelGeo, rubberMat, { position: [-0.8, 0.3, 1.2], parent: root });
+createInstance('WheelFR', wheelFL, { position: [0.8, 0.3, 1.2], parent: root });
+createInstance('WheelRL', wheelFL, { position: [-0.8, 0.3, -1.2], parent: root });
+createInstance('WheelRR', wheelFL, { position: [0.8, 0.3, -1.2], parent: root });`
+    },
+    {
+      name: "boolUnion",
+      signature: "await boolUnion(name: string, ...parts: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Merges two or more parts into one watertight manifold mesh. Default flat shading (hard edges) — pass { smooth: true } as last arg for averaged normals on organic merges.",
+      example: `const body = new THREE.Mesh(boxGeo(2, 1, 1), steel);
+const turret = new THREE.Mesh(cylinderGeo(0.3, 0.3, 0.4, 16), steel);
+turret.position.y = 0.5;
+const hull = await boolUnion('Hull', body, turret);`
+    },
+    {
+      name: "boolDiff",
+      signature: "await boolDiff(name: string, body: Object3D, ...cutters: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Subtracts cutters from a body (holes, button recesses, window slots). Default flat shading for sharp mechanical edges.",
+      example: `const body = new THREE.Mesh(cylinderGeo(1, 1, 0.3, 32), steel);
+const teeth = [...]; // 8 radially-arrayed box meshes
+const gear = await boolDiff('Gear', body, ...teeth);  // hard-edged`
+    },
+    {
+      name: "roundedBoxGeo",
+      signature: "await roundedBoxGeo(width: number, height: number, depth: number, radius: number, opts?: { style?: 'round' | 'chamfer', segments?: 12, smooth?: boolean })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "A box with all twelve edges rounded (or chamfered) at the EXACT outer size requested — roundedBoxGeo(1, 1, 1, 0.1) measures 1x1x1, it does not grow. Use it anywhere boxGeo reads too sharp: consoles, crates, appliances, handheld props, machined blocks.",
+      promptNotes: "Real objects almost never have perfectly sharp box edges, and a small radius is the single cheapest upgrade to how manufactured an asset looks. Prefer this over boxGeo for anything moulded, cast, or machined. Keep radius small relative to the box (5-10% of the smallest dimension); radius must be less than half the smallest dimension or the call throws. style: 'chamfer' reads as machined metal, 'round' as moulded plastic. This is async — build() must be async and the call must use await.",
+      example: `const geo = await roundedBoxGeo(1.2, 0.6, 0.8, 0.05);
+createPart('Console', geo, plastic, { position: [0, 0.3, 0], parent: root });`
+    },
+    {
+      name: "extrudeProfile",
+      signature: "await extrudeProfile(profile: [number, number][], opts?: { depth?: 1, holes?: [number, number][][], bevel?: 0, bevelStyle?: 'round' | 'chamfer', segments?: 12, twist?: 0, taper?: number | [number, number], divisions?: number, axis?: 'x' | 'y' | 'z', center?: true, smooth?: false })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "Sweeps a closed 2D outline into a watertight solid, with optional holes, corner rounding/chamfering, twist, and taper. The way to build any cross-section that is not a box or a cylinder: L-brackets, I-beams, gaskets, washers, star and gear plates, signage, extruded trim.",
+      promptNotes: "The bevel rounds the edges PARALLEL to the sweep axis (the profile corners) — the two flat caps stay sharp. For a box rounded on all twelve edges use roundedBoxGeo instead. Holes are subtracted, so their winding order does not matter. A bevel larger than half the outline's narrowest feature throws rather than silently returning an empty solid. Output is manifold, so it feeds straight into boolUnion / boolDiff / boolIntersect. Async — await it inside an async build().",
+      example: `// L-bracket, inner AND outer corners filleted
+const outline = [[0, 0], [2, 0], [2, 0.4], [0.4, 0.4], [0.4, 2], [0, 2]];
+const geo = await extrudeProfile(outline, { depth: 0.5, bevel: 0.06 });
+createPart('Bracket', geo, steel, { parent: root });`
+    },
+    {
+      name: "revolveProfile",
+      signature: "await revolveProfile(profile: [number, number][], opts?: { segments?: 24, angle?: 360, bevel?: 0, bevelStyle?: 'round' | 'chamfer', bevelSegments?: 12, axis?: 'x' | 'y' | 'z', smooth?: true })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "csg",
+      description: "Revolves a closed 2D outline around an axis into a watertight SOLID, optionally rounding the profile corners first. Bottles, tanks, pressure vessels, wheels, turned wood, domes, buttons, pills.",
+      promptNotes: "Use this instead of lathe/revolveGeo whenever the result must survive a boolean or needs a rounded rim — lathe and revolveGeo build an open surface, this builds a closed solid. Profile convention matches lathe: x is distance from the axis, y is position along it, and only the x >= 0 side is used. Async — await it inside an async build().",
+      example: `// capsule tank with a rounded rim, then carve a port into it
+const profile = [[0, -0.5], [0.4, -0.5], [0.4, 0.5], [0, 0.5]];
+const body = await revolveProfile(profile, { bevel: 0.08, segments: 32 });
+const tank = await boolDiff('Tank', createPart('B', body, steel), portCutter);`
+    },
+    {
+      name: "circleProfile",
+      signature: "circleProfile(radius: number, segments?: 24, center?: [number, number])",
+      returns: "[number, number][]",
+      category: "csg",
+      description: "Builds a closed circular outline for extrudeProfile / revolveProfile, so you never hand-write the trigonometry. Synchronous.",
+      example: `const washer = await extrudeProfile(circleProfile(1), {
+  depth: 0.1,
+  holes: [circleProfile(0.4), circleProfile(0.1, 16, [0.7, 0])],
+});`
+    },
+    {
+      name: "boolIntersect",
+      signature: "await boolIntersect(name: string, a: Object3D, b: Object3D, opts?: { smooth?: false })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Keeps only the volume where both operands overlap. Default flat shading.",
+      example: "const lens = await boolIntersect('Lens', boxMesh, sphereMesh);"
+    },
+    {
+      name: "hull",
+      signature: "await hull(name: string, ...parts: Object3D[], opts?: { smooth?: true })",
+      returns: "Promise<THREE.Mesh>",
+      category: "csg",
+      description: "Tightest convex mesh enclosing all input points. Default smooth shading (rocks, collision volumes). Pass { smooth: false } for a faceted look.",
+      example: `const rockChunks = [...]; // scattered box meshes
+const rock = await hull('Rock', ...rockChunks);`
+    },
+    {
+      name: "arrayLinear",
+      signature: "arrayLinear(namePrefix, source, count, offset: [x,y,z], parent?)",
+      returns: "THREE.Object3D[]",
+      category: "arrays",
+      description: "Places N copies of `source` along a constant offset vector. Copies share geometry + material via createInstance.",
+      example: `const post = createPart('Post0', cylinderGeo(0.05,0.05,1.5,6), wood, { position: [0,0.75,0], parent: root });
+arrayLinear('Post', post, 10, [0.5, 0, 0], root);`
+    },
+    {
+      name: "arrayRadial",
+      signature: "arrayRadial(namePrefix, source, count, axis?: 'x'|'y'|'z', parent?)",
+      returns: "THREE.Object3D[]",
+      category: "arrays",
+      description: "Places N copies of `source` around the given axis. Source's local rotation is oriented outward. Perfect for gear teeth, radial bolts, circle of columns.",
+      example: `const bolt = createPart('Bolt0', cylinderGeo(0.02,0.02,0.1,6), steel, { position: [1,0,0], parent: root });
+arrayRadial('Bolt', bolt, 8, 'y', root);`
+    },
+    {
+      name: "mirror",
+      signature: "mirror(name, source, axis: 'x'|'y'|'z', parent?)",
+      returns: "THREE.Object3D",
+      category: "arrays",
+      description: "Reflects source across the plane whose normal is `axis`. Uses negative scale (winding flip handled by viewers).",
+      example: "mirror('WingR', wingL, 'x', root);"
+    },
+    {
+      name: "subdivide",
+      signature: "subdivide(geometry: BufferGeometry, iterations?: 1, opts?: { preserveUV?: boolean, split?: boolean, uvSmooth?: boolean, preserveEdges?: boolean, flatOnly?: boolean, weld?: boolean })",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Loop subdivision returns new geometry; each iteration roughly quadruples triangles and smooths the surface. Use preserveUV:true for textured meshes. Legacy position-only welding discards UVs and reports that loss. This smooths shapes, not selected-edge beveling.",
+      example: "const smoothRock = subdivide(boxGeo(1, 1, 1), 2);"
+    },
+    {
+      name: "mergeVertices",
+      signature: "mergeVertices(geometry: BufferGeometry, opts?: { tolerance?: 1e-4, positionOnly?: boolean } | number)",
+      returns: "THREE.BufferGeometry",
+      category: "mesh-ops",
+      description: "Returns indexed geometry. Default welding preserves attribute seams, so a textured cube retains separate face corners. positionOnly:true welds coincident positions and discards other attributes; use it explicitly when changing topology and regenerate shading/UVs afterward.",
+      example: `const welded = mergeVertices(boxGeo(1, 1, 1), { positionOnly: true });
+const rock = displace(subdivide(welded, 2), ([x,y,z]) => [0.08*Math.sin(y*7+z*3), 0.04*Math.sin(x*9), 0]);`
+    },
+    {
+      name: "curveToMesh",
+      signature: "curveToMesh(points: [x,y,z][], radius, tubularSegs?: 32, radialSegs?: 8, closed?: false)",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Sweeps a circular profile along a path. Equivalent to Blender's Curve to Mesh node with a circle profile. Use for pipes, cables, tubular frames.",
+      example: "const pipe = curveToMesh([[0,0,0],[0,1,0],[1,1,0],[1,2,0]], 0.1);"
+    },
+    {
+      name: "pipeAlongPath",
+      signature: "pipeAlongPath(points: [x,y,z][], radius: number, opts?: { bendRadius?: 0, closed?: false, tubularSegments?: 32, radialSegments?: 8 })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Path-driven swept circle with optional bend smoothing. Generalises beamBetween (point-to-point) and curveToMesh (raw spline) into one helper. bendRadius>0 inserts interpolated waypoints near interior corners so the spline reads as a rounded turn instead of pinching to the control point.",
+      example: "const cable = pipeAlongPath([[0, 0.5, 0], [1, 0.5, 0], [1, 0.5, 2]], 0.02, { bendRadius: 0.1 });"
+    },
+    {
+      name: "lathe",
+      signature: "lathe(profile: [x,y][], segments?: 12)",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Surface of revolution. Spins a 2D profile around the Y axis. For bottles, vases, wheels, turned wood parts.",
+      example: "const vase = lathe([[0.1,0],[0.3,0.5],[0.2,1],[0.1,1.2]], 16);"
+    },
+    {
+      name: "revolveGeo",
+      signature: "revolveGeo(profile: [x,y][], opts?: { angle?: 2π, axis?: [x,y,z]=[0,1,0], segments?: 12 })",
+      returns: "THREE.BufferGeometry",
+      category: "curves",
+      description: "Surface of revolution with explicit axis + sweep angle. Generalises lathe — use it when you need a partial sweep (half-dome, 90° wedge) or revolution around a non-Y axis. Profile convention is identical to lathe: x = radial distance, y = position along the axis.",
+      example: `// Half-dome (180° sweep around +Y):
+const quarter = [...Array(8)].map((_, i) => { const t = (i/7)*Math.PI/2; return [Math.cos(t), Math.sin(t)] as [number, number]; });
+const dome = revolveGeo(quarter, { angle: Math.PI });`
+    },
+    {
+      name: "bezierCurve",
+      signature: "bezierCurve(controlPoints: [x,y,z][], samples?: 32)",
+      returns: "[x,y,z][]",
+      category: "curves",
+      description: "Samples a quadratic (3 ctrl pts) or cubic (4 ctrl pts) Bézier into a point list you can feed into curveToMesh.",
+      example: `const path = bezierCurve([[0,0,0],[1,2,0],[3,2,0],[4,0,0]], 24);
+const geo = curveToMesh(path, 0.1);`
+    },
+    {
+      name: "autoUnwrap",
+      signature: "await autoUnwrap(geometry: BufferGeometry, opts?: { resolution?: 1024, padding?: 2, useNormals?: false })",
+      returns: "Promise<THREE.BufferGeometry>",
+      category: "uv",
+      description: "xatlas-based UV atlas for ANY geometry (CSG output, subdivided, deformed). Output is a packed atlas with arbitrary per-chart rotation — use for non-tileable baked textures. For directional tileable textures on box/cylinder/plane primitives, prefer the shape-aware unwraps below.",
+      example: `const unwrapped = await autoUnwrap(someCsgResult, { resolution: 1024 });
+const mesh = new THREE.Mesh(unwrapped, bakedPbr);`
+    },
+    {
+      name: "boxUnwrap",
+      signature: "boxUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Preserves BoxGeometry's built-in per-face UVs — every face maps [0,1] with consistent orientation. Use for crates/blocks with a tileable texture. Sync; no WASM cost.",
+      example: `const crate = boxUnwrap(boxGeo(1, 1, 1));
+const mesh = new THREE.Mesh(crate, pbrMaterial({ albedo: planksTex }));`
+    },
+    {
+      name: "cylinderUnwrap",
+      signature: "cylinderUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Preserves CylinderGeometry's built-in UVs: u wraps around the axis (horizontal texture features ring the cylinder), v runs up the height. Caps use circle-in-square. Sync; no WASM cost.",
+      example: `const barrel = cylinderUnwrap(cylinderGeo(0.5, 0.5, 1.2, 24));
+const mesh = new THREE.Mesh(barrel, pbrMaterial({ albedo: bandsTex }));`
+    },
+    {
+      name: "planeUnwrap",
+      signature: "planeUnwrap(geometry: BufferGeometry)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Projects xy-extent of the bbox to [0,1]. Use for signs/decals/posters where you want ONE readable texture and no edge-face bleeding. Sync.",
+      example: `const sign = planeUnwrap(planeGeo(1, 0.6));
+const mesh = new THREE.Mesh(sign, pbrMaterial({ albedo: kilnTextTex }));`
+    },
+    {
+      name: "panelRemapV",
+      signature: "panelRemapV(geo, vScale=0.30, vOffset=0, uScale=1, uOffset=0)",
+      returns: "THREE.BufferGeometry",
+      category: "uv",
+      description: "Scales an existing UV attribute so a small mesh samples a sub-region of a SHARED texture. Replaces the broken texture.clone() pattern (Three.js Texture.clone() runs JSON.stringify on userData, mangling encoded PNG bytes — panelRemapV avoids that by remapping UVs on the geometry instead). Typical use: multi-zone albedo where v=0..0.30 is plain panel and v=0.30..1 has windows/markings — small parts call panelRemapV(unwrap(geo), 0.30) to sample only the clean strip.",
+      example: `const cowlGeo = panelRemapV(cylinderUnwrap(capsuleXGeo(0.45, 1.0)), 0.30);
+const cowl = new THREE.Mesh(cowlGeo, bodyMat); // SAME bodyMat as fuselage, no clone needed`
+    },
+    {
+      name: "loadApprovedTexture",
+      signature: "await loadApprovedTexture(resourceId)",
+      returns: "Promise<THREE.DataTexture>",
+      category: "textures",
+      description: "Loads one approved kiln.texture.* resource ID through the host-injected closed resolver. The registry fixes bytes, MIME, usage, dimensions, hash, and deadline; paths, URLs, byte arrays, resolver objects, hashes, and options are rejected.",
+      example: "const bark = await loadApprovedTexture('kiln.texture.bark-brown-01-albedo.v1');",
+      promptNotes: "Use only a concrete resource ID listed in material capabilities; never invent one. Prefer materialRecipe when a recipe already binds the family, or proceduralTexture V2 for authored surfaces. NEVER texture.clone() a loaded texture (clone() corrupts encoded bytes and breaks GLB export)."
+    },
+    {
+      name: "proceduralTexture",
+      signature: "proceduralTexture({ schemaVersion: 2, size?: 4..1024 pow2, usage?, name?, layers: [{ op: 'solid'|'checker'|'stripes'|'gradient'|'bricks'|'noise', ...params, blend?: 'normal'|'multiply'|'screen'|'overlay', opacity?: 0..1 }] })",
+      returns: "THREE.DataTexture (tiling, sRGB or linear per usage)",
+      category: "textures",
+      description: "Builds a tiling texture from a bounded layer stack — no image file needed. Layers composite bottom-first. Noise is seeded and tileable, so the same spec always produces the same bytes and a repeating material shows no seam. Baked to PNG and embedded in the GLB automatically.",
+      example: "const bark = proceduralTexture({ schemaVersion: 2, size: 256, usage: 'albedo', name: 'Bark', layers: [{ op: 'solid', color: 0x5a4632 }, { op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4, blend: 'overlay' }] });",
+      promptNotes: "Sync — no await. Strict V2 JSON boundary: unknown/prototype keys, callbacks, paths, URLs, and shader source are rejected. Prefer this over approved resources for describable surfaces. Max 8 layers, power-of-two size up to 1024. Only the six listed ops exist."
+    },
+    {
+      name: "normalMapFromHeight",
+      signature: "normalMapFromHeight(source: THREE.Texture, { strength?: number, name?: string })",
+      returns: "THREE.DataTexture (linear normal map)",
+      category: "textures",
+      description: "Derives a tangent-space normal map from the source texture's brightness, treating it as height. The cheap way to get real PBR surface relief out of a procedural albedo. Wraps at the edges, so a tiling source gives a tiling normal map.",
+      example: `const bark = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4 }] });
+const mat = pbrMaterial({ albedo: bark, normal: normalMapFromHeight(bark, { strength: 4 }) });`,
+      promptNotes: "strength 1 is subtle, 4-8 reads clearly at normal viewing distance. Output is always linear data — never assign it to an albedo/emissive slot."
+    },
+    {
+      name: "pbrMaterial",
+      signature: "pbrMaterial({ albedo?, normal?, roughness?, metalness?, metallicRoughness?, emissive?, aoMap?, alphaMode?, alphaCutoff?, doubleSided? })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Portable glTF PBR material. Use an explicit packed metallicRoughness texture (G=roughness, B=metalness); separate data maps are rejected instead of silently dropping a channel. Supports OPAQUE/MASK/BLEND and double-sided output.",
+      example: `const wood = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x4f301c, colorB: 0x9a6b3e, scale: 8, octaves: 3, seed: 4 }] });
+const crate = pbrMaterial({ albedo: wood, roughness: 0.85, metalness: 0 });`
+    },
+    {
+      name: "foliageMaterial",
+      signature: "foliageMaterial(albedo, { alphaCutoff?, roughness?, doubleSided? })",
+      returns: "THREE.MeshStandardMaterial",
+      category: "material",
+      description: "Portable foliage material that defaults to glTF MASK, cutoff 0.5, rough nonmetal, and double-sided. Use an alpha-bearing albedo texture.",
+      example: "const mat = await materialRecipe('kiln.material.leaf.v1');"
+    },
+    {
+      name: "countTriangles",
+      signature: "countTriangles(root: Object3D)",
+      returns: "number",
+      category: "utility",
+      description: "Sums triangle count across every mesh in the subtree.",
+      example: "meta.tris = countTriangles(root);"
+    },
+    {
+      name: "countMaterials",
+      signature: "countMaterials(root: Object3D)",
+      returns: "number",
+      category: "utility",
+      description: "Unique material count (by reference) across the subtree.",
+      example: "const mats = countMaterials(root);"
+    },
+    {
+      name: "getJointNames",
+      signature: "getJointNames(root: Object3D)",
+      returns: "string[]",
+      category: "utility",
+      description: "All node names beginning with `Joint_`. Use to sanity-check animation targets.",
+      example: "const joints = getJointNames(root);"
+    },
+    {
+      name: "validateAsset",
+      signature: "validateAsset(root: Object3D, category: 'character' | 'prop' | 'vfx' | 'environment' | 'architecture' | 'vegetation' | 'vehicle')",
+      returns: "{ valid, errors, warnings }",
+      category: "utility",
+      description: "Checks geometry and material costs for the selected category. No default triangle limit; choose detail for the intended runtime and inspect measured draw calls.",
+      example: "const v = validateAsset(root, 'prop');"
+    }
+  ];
+});
+
 // src/evaluator/authoring-diagnostic.ts
 function authoringDiagnosticAdvice(diagnostic) {
   if (diagnostic === "UNBOUND_VARIABLE")
@@ -1690,7 +2612,7 @@ function rethrowAuthoringError(error) {
   }
   throw error;
 }
-var UNBOUND_VARIABLE_ADVICE = "Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying.", GEAR_RADII_ORDER_ADVICE = "gearGeo requires boreRadius < rootRadius < tipRadius; specify rootRadius when changing tipRadius. Omitted radii keep their absolute defaults.", ROUNDED_BOX_RADIUS_ADVICE = "roundedBoxGeo: radius must be less than half the smallest dimension. Reduce radius or increase the smallest dimension; equality is invalid.", AuthoringDiagnosticError;
+var UNBOUND_VARIABLE_ADVICE = "Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying. If it was meant to be a Kiln helper, call kiln_list_primitives to confirm the exact name and signature; the sandbox exposes only those globals.", GEAR_RADII_ORDER_ADVICE = "gearGeo requires boreRadius < rootRadius < tipRadius; specify rootRadius when changing tipRadius. Omitted radii keep their absolute defaults.", ROUNDED_BOX_RADIUS_ADVICE = "roundedBoxGeo: radius must be less than half the smallest dimension. Reduce radius or increase the smallest dimension; equality is invalid.", AuthoringDiagnosticError;
 var init_authoring_diagnostic = __esm(() => {
   AuthoringDiagnosticError = class AuthoringDiagnosticError extends Error {
     diagnostic;
@@ -19811,7 +20733,73 @@ function validate(code, _opts = {}) {
       line: smell.line
     });
   }
+  warnings.push(...unknownHelperWarnings(ast));
   return toResult(issues, warnings, analysis.estimatedTris);
+}
+function unknownHelperWarnings(ast) {
+  const declared = new Set;
+  const bind = (node) => {
+    const target = node;
+    if (!target?.type)
+      return;
+    if (target.type === "Identifier")
+      declared.add(target["name"]);
+    else if (target.type === "ObjectPattern")
+      for (const prop of target["properties"])
+        bind(prop.value ?? prop.argument);
+    else if (target.type === "ArrayPattern")
+      for (const el of target["elements"])
+        bind(el);
+    else if (target.type === "AssignmentPattern")
+      bind(target["left"]);
+    else if (target.type === "RestElement")
+      bind(target["argument"]);
+  };
+  const params = (node) => {
+    const fn = node;
+    if (fn.id?.name)
+      declared.add(fn.id.name);
+    for (const param of fn.params ?? [])
+      bind(param);
+  };
+  walk.simple(ast, {
+    VariableDeclarator(node) {
+      bind(node.id);
+    },
+    FunctionDeclaration(node) {
+      params(node);
+    },
+    FunctionExpression(node) {
+      params(node);
+    },
+    ArrowFunctionExpression(node) {
+      params(node);
+    },
+    ClassDeclaration(node) {
+      params(node);
+    },
+    CatchClause(node) {
+      bind(node.param);
+    }
+  });
+  const seen = new Map;
+  walk.simple(ast, {
+    CallExpression(node) {
+      const callee = node.callee;
+      if (callee?.type !== "Identifier" || !callee.name)
+        return;
+      const name = callee.name;
+      if (declared.has(name) || SANDBOX_CALLABLES.has(name) || seen.has(name))
+        return;
+      seen.set(name, node.loc?.start?.line);
+    }
+  });
+  return [...seen].map(([name, line]) => ({
+    code: "UNKNOWN_HELPER",
+    message: `${name}() is not declared in this program and is not a Kiln sandbox global; the build will fail when it runs.`,
+    fixHint: "Call kiln_list_primitives to confirm the helper name and signature, or declare the function in this program.",
+    ...line === undefined ? {} : { line }
+  }));
 }
 function assertGeneratedSourceSafe(code) {
   let ast;
@@ -20327,8 +21315,45 @@ function hasBreak(body) {
   });
   return found;
 }
-var GeneratedSourcePolicyError, FORBIDDEN_AMBIENT_IDENTIFIERS, FORBIDDEN_THREE_CONSTRUCTORS, ROTATION_OPTION_FNS;
+var SANDBOX_CALLABLES, GeneratedSourcePolicyError, FORBIDDEN_AMBIENT_IDENTIFIERS, FORBIDDEN_THREE_CONSTRUCTORS, ROTATION_OPTION_FNS;
 var init_validation = __esm(() => {
+  init_list_primitives();
+  SANDBOX_CALLABLES = new Set([
+    ...listPrimitives().map((primitive) => primitive.name),
+    "Array",
+    "BigInt",
+    "Boolean",
+    "Error",
+    "Float32Array",
+    "Float64Array",
+    "Int16Array",
+    "Int32Array",
+    "Int8Array",
+    "Map",
+    "Number",
+    "Object",
+    "Promise",
+    "Proxy",
+    "RangeError",
+    "Reflect",
+    "RegExp",
+    "Set",
+    "String",
+    "Symbol",
+    "TypeError",
+    "Uint16Array",
+    "Uint32Array",
+    "Uint8Array",
+    "WeakMap",
+    "WeakSet",
+    "decodeURIComponent",
+    "encodeURIComponent",
+    "isFinite",
+    "isNaN",
+    "parseFloat",
+    "parseInt",
+    "structuredClone"
+  ]);
   GeneratedSourcePolicyError = class GeneratedSourcePolicyError extends Error {
     code;
     line;
@@ -26425,6 +27450,7 @@ async function readAssetResource(library, uri) {
 // src/mcp-server.ts
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { AsyncLocalStorage } from "async_hooks";
+import { fileURLToPath as fileURLToPath4 } from "url";
 
 // src/tools/registry.ts
 init_capture_cache();
@@ -26594,924 +27620,8 @@ function createKilnSourceDef(store) {
 }
 
 // src/tools/discovery.ts
+init_list_primitives();
 import { z as z3 } from "zod";
-
-// src/geometry-catalog.ts
-var geometryPrimitives = [
-  {
-    name: "copyGeometry",
-    signature: "copyGeometry(geometry: BufferGeometry)",
-    returns: "THREE.BufferGeometry",
-    category: "instancing",
-    description: "Returns an independent geometry with copied vertex buffers. Use before direct mutation of a cached primitive.",
-    example: "const editable = copyGeometry(boxGeo(1, 1, 1)); editable.translate(0, 0.5, 0);"
-  },
-  {
-    name: "copyMaterial",
-    signature: "copyMaterial(material: Material)",
-    returns: "THREE.Material (same subtype)",
-    category: "instancing",
-    description: "Copies material properties so edits do not change other parts. Referenced textures remain shared.",
-    example: "const red = copyMaterial(steel); red.color.set(0xaa2222);"
-  },
-  {
-    name: "meshGeo",
-    signature: "meshGeo({ positions: number[], indices?: number[], normals?: number[], uvs?: number[], tangents?: number[] })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Builds an owned triangle mesh from flat numeric arrays. Validates finite values, attribute lengths and indices; computes normals if absent. Counterclockwise winding.",
-    example: "const triangle = meshGeo({ positions: [0,0,0, 1,0,0, 0,1,0], indices: [0,1,2] });"
-  },
-  {
-    name: "parametricSurface",
-    signature: "parametricSurface(sample: (u,v) => [x,y,z], opts?: { u?: [0,1], v?: [0,1], uSegments?: 24, vSegments?: 24, periodicU?: false, periodicV?: false, orientation?: 'uv'|'vu' })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Samples an equation into an owned surface with UVs. Periodic endpoints must coincide; UV seams retain matching normals. A surface is not automatically a watertight solid.",
-    example: "const canopy = parametricSurface((u,v) => [u, 0.3*Math.sin(u*3)*Math.cos(v*2), v], { u: [-2,2], v: [-1,1] });"
-  },
-  {
-    name: "geometryDiagnostics",
-    signature: "geometryDiagnostics(geometry: BufferGeometry, tolerance?: 1e-6)",
-    returns: "{ vertices, triangles, boundaryEdges, nonManifoldEdges, orientationConflicts, degenerateTriangles, invalidIndices, nonFiniteVertices }",
-    category: "utility",
-    description: "Counts mesh topology problems after position-based seam matching. Open boundaries are valid for sheets; closed edges alone do not prove a self-intersection-free solid.",
-    example: "const topology = geometryDiagnostics(shell);"
-  },
-  {
-    name: "creaseNormals",
-    signature: "creaseNormals(geometry: BufferGeometry, opts?: { angle?: 60, tolerance?: number })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Returns owned geometry with angle-limited smooth normals, preserving UV corners. Angle is degrees. Invalidates tangents; use after shaping for sharp rims and smooth walls.",
-    example: "const shell = creaseNormals(cylinderGeo(1,1,2,32), { angle: 45 });"
-  },
-  {
-    name: "bend",
-    signature: "bend(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Bends local +Y toward +X through angle degrees. Returns owned geometry and updated normals/bounds; preserves UVs, invalidates tangents. Frame rotation is Euler XYZ degrees.",
-    promptNotes: "Deformation interval uses local Y distances; outside vertices stay unchanged. Add enough segments before bending. Falloff returns 0..1; use it to avoid a discontinuity at a selected interval boundary.",
-    example: "const arch = bend(planeGeo(1,4,4,32), { angle: 90 });"
-  },
-  {
-    name: "twist",
-    signature: "twist(geometry, { angle, frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Rotates the cross-section progressively around local +Y, reaching angle degrees at the end. Returns owned geometry; frame rotation uses Euler XYZ degrees.",
-    example: "const spiral = twist(column, { angle: 120 });"
-  },
-  {
-    name: "taper",
-    signature: "taper(geometry, { startScale?: [1,1], endScale: [x,z], frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Scales local X/Z across the local Y interval using positive start/end scale pairs. Returns owned geometry; preserves UVs and invalidates tangents.",
-    example: "const narrowed = taper(column, { endScale: [0.4,0.7] });"
-  },
-  {
-    name: "displace",
-    signature: "displace(geometry, offset: ([x,y,z], t) => [dx,dy,dz], opts?: { frame?: { origin, rotation }, interval?: [minY,maxY], falloff?: t => weight })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Adds an authored displacement vector in the chosen local frame. Returns owned geometry; callback coordinates are local and t is normalized along the interval.",
-    example: "const rippled = displace(surface, ([x,y,z]) => [0, 0.1*Math.sin(x*8), 0]);"
-  },
-  {
-    name: "sweepProfile",
-    signature: "sweepProfile(profile: [x,z][], path: [x,y,z][], opts?: { cap?: true, closed?: false, up?: [x,y,z], twist?: 0, scale?: number | [x,z][] })",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Sweeps a simple noncircular profile along polyline stations using transported frames. Supports total twist in degrees and per-station scales. Generates UVs and optional caps.",
-    promptNotes: "First version supports one simple profile without holes. Closed paths omit the repeated endpoint and require twist to be a multiple of 360. up sets the initial profile +Z direction and cannot parallel the path. Tight-turn warnings do not replace visual inspection for self-intersections.",
-    example: "const rail = sweepProfile([[-.1,-.2],[.1,-.2],[.1,.2],[-.1,.2]], [[0,0,0],[0,1,0],[1,2,0]]);"
-  },
-  {
-    name: "loftProfiles",
-    signature: "loftProfiles(sections: { profile: [x,z][], frame?: { origin, rotation } }[], opts?: { cap?: true })",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Joins corresponding simple profiles in explicit local XZ planes. Each frame uses Euler XYZ degrees and local +Y along the loft. Profiles need equal point counts and corresponding vertices.",
-    promptNotes: "No holes or automatic profile correspondence. Opposite winding is normalized while preserving the first point. Caps close boundaries but do not prove the loft has no self-intersections.",
-    example: "const hull = loftProfiles([{ profile: wide }, { profile: narrow, frame: { origin: [0,2,0] } }]);"
-  },
-  {
-    name: "implicitSurface",
-    signature: "await implicitSurface(sample: ([x,y,z]) => signedValue, { bounds: { min, max }, edgeLength, maxCells?: 1000000, maxEvaluations?: 8000000, level?: 0, tolerance?: -1, smooth?: true })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "geometry",
-    description: "Experimental positive-inside implicit field sampled into a solid mesh. Requires explicit bounds and resolution; checks grid size and actual evaluation count. Output has no UVs.",
-    promptNotes: "Use async build and await. Smaller edgeLength increases cost sharply. This helper cannot stop a callback that never returns; the host evaluator process provides that boundary. Thin features and geometric accuracy require inspection.",
-    example: "const blob = await implicitSurface(([x,y,z]) => 1-Math.hypot(x,y,z), { bounds: { min: [-1.2,-1.2,-1.2], max: [1.2,1.2,1.2] }, edgeLength: 0.15 });"
-  }
-];
-
-// src/list-primitives.ts
-var PRIMITIVES = [
-  ...geometryPrimitives,
-  {
-    name: "createRoot",
-    signature: "createRoot(name: string)",
-    returns: "THREE.Object3D",
-    category: "structure",
-    description: "Creates the root Object3D for an asset. Call first in build().",
-    example: "const root = createRoot('FuelDrum');"
-  },
-  {
-    name: "createPivot",
-    signature: "createPivot(name: string, position?: [x, y, z], parent?: Object3D)",
-    returns: "THREE.Object3D (prefixed `Joint_`)",
-    category: "structure",
-    description: "Creates an empty pivot node for skeletal animation. Name is auto-prefixed with `Joint_`.",
-    example: "const hip = createPivot('Hip', [0, 1, 0], root);"
-  },
-  {
-    name: "createJointChain",
-    signature: "createJointChain(name, segments: { role, offset, aliases?, side?, localForwardAxis?, localBendAxis?, endEffector?, contact? }[], opts?: { parent?, parentRole? })",
-    returns: "{ root, end, nodes, byRole, descriptors }",
-    category: "structure",
-    description: "Creates one body-plan-neutral deterministic Joint_* chain with explicit parent edges, rest frames, local axes, end effectors, contacts, and semantic metadata.",
-    example: "const leg = createJointChain('LegL', [{ role: 'hip.left', offset: [0, 1, -0.2], side: 'left' }, { role: 'knee.left', offset: [0, -0.5, 0], side: 'left' }, { role: 'ankle.left', offset: [0, -0.5, 0], side: 'left', endEffector: true, contact: true }], { parent: root });",
-    promptNotes: "Use only the resolved body-plan graph. Offsets are local to the previous joint; contact end effectors must land at world Y=0."
-  },
-  {
-    name: "createVehicleFrame",
-    signature: "createVehicleFrame(name, opts?: { chassis?, axles?, seats?, contacts?, steering?, propulsion?, parent? })",
-    returns: "{ root, chassis, axles, seats, contacts, steering, propulsion }",
-    category: "structure",
-    description: "Creates a canonical +X-forward/+Y-up/+Z-right vehicle frame with typed semantic sockets for chassis, support, steering, and propulsion.",
-    example: "const frame = createVehicleFrame('CarFrame', { axles: [{ id: 'front', position: [1.2, 0.45, 0] }, { id: 'rear', position: [-1.2, 0.45, 0] }], parent: root });",
-    promptNotes: "Generated vehicles keep +X as front. Boats and other non-wheeled subtypes use declared support/propulsion sockets, not wheel rules."
-  },
-  {
-    name: "createWheelGeometrySet",
-    signature: "createWheelGeometrySet(radius: number, width: number)",
-    returns: "{ tire, rim, hub } shared THREE.BufferGeometry set",
-    category: "instancing",
-    description: "Creates one reusable +Z-axle tire/rim/hub geometry set for instanced wheel assemblies.",
-    example: "const wheelGeo = createWheelGeometrySet(0.45, 0.22);"
-  },
-  {
-    name: "createWheelAssembly",
-    signature: "createWheelAssembly(name, { tire, rim, hub? }, { radius, width, side, index, position?, rimRadius?, hubRadius?, steering?, loadBearing?, geometries?, parent? })",
-    returns: "{ root, steeringPivot?, spinPivot, tire, rim, hub, contact, radius, width, side, index, spinAxis }",
-    category: "structure",
-    description: "Creates one axle-centered wheel pivot containing concentric tire/rim/hub roles, a contact marker, +Z spin frame, and optional steering pivot.",
-    example: "createWheelAssembly('FrontLeft', { tire: rubber, rim: metal }, { radius: 0.45, width: 0.22, side: 'left', index: 'front', position: [1.2, 0.45, -0.9], steering: true, geometries: wheelGeo, parent: frame.root });",
-    promptNotes: "Keep tire, rim, and hub descendants concentric at the axle pivot. Reuse one geometry set across matching wheels."
-  },
-  {
-    name: "createPart",
-    signature: "createPart(name, geometry, material, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, pivot, parent })",
-    returns: "THREE.Object3D (mesh or wrapping pivot)",
-    category: "structure",
-    description: "Creates a mesh, optionally wrapped in a pivot, and attaches it to `opts.parent`. `rotation` is in DEGREES (like rotationTrack), NOT radians: [0, 0, 90] is a quarter turn; [0, 0, 1.57] is a no-op.",
-    example: "createPart('Barrel', cylinderGeo(0.1, 0.1, 1), gameMaterial(0x556b2f), { position: [0, 0.5, 0], rotation: [0, 0, 90], parent: root });",
-    promptNotes: "AUTO-ADDS to opts.parent. NEVER call parent.add(createPart(...)) — pass { parent } instead. rotation is DEGREES — writing radians (e.g. 0.785 or Math.PI/4) silently produces ~zero rotation."
-  },
-  {
-    name: "beamBetween",
-    signature: "beamBetween(name, start: [x,y,z], end: [x,y,z], radius, material, opts?: { segments, parent })",
-    returns: "THREE.Object3D (prefixed `Mesh_`)",
-    category: "structure",
-    description: "Creates a cylindrical rail/strut exactly between two endpoints. Use for braces, gun barrels, skid struts, cables, and scaffolding.",
-    example: "beamBetween('SkidBraceA', [0.8, 0.3, 0.7], [0.8, 1.0, 0.45], 0.025, black, { parent: root });"
-  },
-  {
-    name: "snapTo",
-    signature: "snapTo(part: Object3D, host: Object3D, opts?: { axis?: 'x'|'y'|'z', overlap?: 0.02 })",
-    returns: "THREE.Object3D (the part, for chaining)",
-    category: "structure",
-    description: 'Translates `part` by the minimal vector that brings its bounding box into contact with `host` (plus a small overlap). The direct cure for a "Floating parts" warning — attach the part instead of eyeballing a corrective offset. No-op if they already touch.',
-    example: `const scope = createPart('Scope', cylinderXGeo(0.04, 0.04, 0.3), steel, { parent: root, position: [0.1, 0.32, 0] });
-snapTo(scope, receiver);`
-  },
-  {
-    name: "createLadder",
-    signature: "createLadder(name, { bottom, top, material, width?, rungCount?, railRadius?, rungRadius?, widthAxis?, parent? })",
-    returns: "{ leftRail: Object3D, rightRail: Object3D, rungs: Object3D[] }",
-    category: "structure",
-    description: "Builds two continuous rails plus evenly-spaced rungs. Use this instead of loose boxes for ladders.",
-    example: "createLadder('TowerLadder', { bottom: [0,0,0], top: [0,2.2,0], width: 0.45, rungCount: 7, material: steel, parent: root });"
-  },
-  {
-    name: "createWingPair",
-    signature: "createWingPair(name, material, { rootZ, span, rootChord, tipChord, sweep?, thickness?, dihedral?, rootX?, rootY?, parent? })",
-    returns: "{ right: Object3D, left: Object3D }",
-    category: "structure",
-    description: "Creates mirrored trapezoid aircraft wings with roots attached at +/-rootZ. Use for aircraft wings and helicopter stub wings.",
-    example: "createWingPair('MainWing', olive, { rootX: 0, rootY: 1.0, rootZ: 0.42, span: 2.4, rootChord: 0.9, tipChord: 0.35, sweep: 0.25, dihedral: 0.08, parent: root });"
-  },
-  {
-    name: "room",
-    signature: "room(name, material, { width?, depth?, height?, wallThickness?, floor?, floorThickness?, openings?: [{ wall: 'front'|'back'|'left'|'right', kind?: 'door'|'window', offset?, width?, height?, sill? }], parent? })",
-    returns: "{ root: Object3D, walls: { front, back, left, right }, floor: Object3D | null }",
-    category: "structure",
-    description: "Builds a HOLLOW, enterable room: four thin walls + a floor, human-scaled (defaults: 2.8m ceiling, a centered 1.1x2.1m front door so it is enterable by default). `front` faces +X; the floor sits on the ground. The keystone of an architecture asset — add a roof with createRoofPlanes and fixtures as separate parts.",
-    example: "const { root: hut } = room('Hut', wood, { width: 5, depth: 4, height: 2.8, openings: [{ wall: 'front', kind: 'door' }, { wall: 'right', kind: 'window' }], parent: root });",
-    promptNotes: "Use for any building the player enters. Do NOT model a building as a solid block — room() guarantees real interior space and a doorway gap. Pass openings to add windows / side doors."
-  },
-  {
-    name: "wallWithOpening",
-    signature: "wallWithOpening(name, material, { length, height, thickness, axis?: 'x'|'z', opening?: { kind?: 'door'|'window', offset?, width?, height?, sill? }, parent? })",
-    returns: "THREE.Object3D (wall container)",
-    category: "structure",
-    description: "A single wall panel with an optional real door/window cut, composed from solid box segments (side panels + lintel + window sill) — no CSG. Base at local Y=0, centered on the run axis. Use to compose custom building layouts or interior dividing walls beyond the default room().",
-    example: "wallWithOpening('Partition', plaster, { length: 4, height: 2.8, thickness: 0.12, axis: 'x', opening: { kind: 'door', offset: 0.5 }, parent: root });"
-  },
-  {
-    name: "createRoofPlanes",
-    signature: "createRoofPlanes(name, material, { width, depth, height, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
-    returns: "{ root: Object3D, slopes: [Object3D, Object3D] }",
-    category: "structure",
-    description: "A pitched roof: two thin slopes meeting at one ridge and falling DOWN-AND-OUTWARD (opposite tilts — never mirrored the same way), footprint-matched with an eave overhang. Eave at local Y=0, ridge at Y=height, so position the group at Y=wallHeight. Returns a named group (e.g. `Roof`) the engine can lift to reveal the interior.",
-    example: `const { root: roof } = createRoofPlanes('Roof', shingle, { width: 5, depth: 4, height: 1.6, overhang: 0.4, ridgeAxis: 'x', parent: root });
-roof.position.y = 2.8;`,
-    promptNotes: "The two slopes must fall AWAY from each other from the ridge — createRoofPlanes does this for you. Drop it onto the walls (position.y = wall height)."
-  },
-  {
-    name: "createGableRoof",
-    signature: "createGableRoof(name, material, { spanX, spanZ, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, parent? })",
-    returns: "{ root, slopes: [Object3D, Object3D], faces: [RoofFaceFrame, RoofFaceFrame], rise, pitchDegrees }",
-    category: "structure",
-    description: "Explicit-axis gable roof using unambiguous footprint spans. Each face owns a rigid frame with ridge tangent, outward normal, downhill direction, ridge/eave endpoints, dimensions, and a live local-to-world transform.",
-    example: "const roof = createGableRoof('Roof', shingles, { spanX: 8, spanZ: 5, pitchDegrees: 35, overhang: 0.35, ridgeAxis: 'x', parent: root });",
-    promptNotes: "Prefer this over width/depth roof math. ridgeAxis is the direction of the ridge; roof panels run along each returned face downhill direction."
-  },
-  {
-    name: "createGableEndPanel",
-    signature: "createGableEndPanel(name, material, { span, rise, thickness?, ridgeAxis?: 'x'|'z', side?: 'positive'|'negative', openings?: [{ id?, offset?, bottom?, width, height }], parent? })",
-    returns: "{ root, geometry, openings }",
-    category: "structure",
-    description: "Exact thick triangular end closure for a gable roof, with optional rectangular openings cut from the geometry and semantic boundary metadata.",
-    example: "createGableEndPanel('FrontGable', siding, { span: 5, rise: 1.8, ridgeAxis: 'x', side: 'positive', parent: root });"
-  },
-  {
-    name: "createGableShell",
-    signature: "createGableShell(name, { wall, roof, floor?, gable? }, { spanX, spanZ, wallHeight?, rise?, pitchDegrees?, overhang?, ridgeAxis?: 'x'|'z', thickness?, wallThickness?, floorThickness?, closedEnds?, enterable?, openings?, gableOpenings?, parent? })",
-    returns: "{ root, walls, floor, roof, gables, openings }",
-    category: "structure",
-    description: "Closed-by-default, correct-by-construction gable building: hollow room, floor, two opposing roof slopes, two complete gable ends, and a real front doorway when enterable.",
-    example: "const house = createGableShell('House', { wall: plaster, roof: shingles }, { spanX: 8, spanZ: 5, wallHeight: 2.8, pitchDegrees: 35, ridgeAxis: 'x', parent: root });",
-    promptNotes: "Use for complete gable buildings. It stamps wall, floor, slope, gable, opening, adjacency, coverage, and separability semantics for deterministic QA and roof-off views."
-  },
-  {
-    name: "createRoofSurfaceLayout",
-    signature: "createRoofSurfaceLayout(name, material, { face, kind: 'panels'|'shingles'|'seams'|'corrugations', parent?, panelWidth?, rowHeight?, spacing?, thickness? })",
-    returns: "{ root, items: Object3D[] }",
-    category: "structure",
-    description: "Places roof-local panels, shingles, seams, or corrugations from a returned RoofFaceFrame, so repeated elements run ridge-to-eave for either ridge axis without manual Euler rotations.",
-    example: "for (const face of roof.faces) createRoofSurfaceLayout('Panels_' + face.side, metal, { face, kind: 'panels', parent: roof.root });",
-    promptNotes: "Always pass the face object returned by createGableRoof/createGableShell. Never infer the panel rotation from world axes."
-  },
-  {
-    name: "createStairs",
-    signature: "createStairs(name, material, { steps?, totalRise, totalRun, width, axis?: 'x'|'z', treadThickness?, riser?, parent? })",
-    returns: "{ root: Object3D, steps: Object3D[] }",
-    category: "structure",
-    description: "A straight flight of stairs: box treads (with optional risers) climbing totalRise over totalRun from local origin toward +axis. Use for porch/entry steps or to connect storeys in a multi-storey building.",
-    example: "createStairs('Porch', stone, { steps: 4, totalRise: 0.6, totalRun: 1.0, width: 1.4, axis: 'x', parent: root });"
-  },
-  {
-    name: "boxGeo",
-    signature: "boxGeo(width: number, height: number, depth: number)",
-    returns: "THREE.BoxGeometry",
-    category: "geometry",
-    description: "6-face box. 12 tris regardless of size. Cheapest geometry.",
-    example: "const geo = boxGeo(1, 0.5, 2);"
-  },
-  {
-    name: "sphereGeo",
-    signature: "sphereGeo(radius: number, widthSegments?: 8, heightSegments?: 6)",
-    returns: "THREE.SphereGeometry",
-    category: "geometry",
-    description: "UV sphere. Default 8x6 segments = 84 tris. Bump segments for smoother curves.",
-    example: "const geo = sphereGeo(0.5, 12, 8);"
-  },
-  {
-    name: "cylinderGeo",
-    signature: "cylinderGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Y-axis cylinder. Use radiusTop != radiusBottom for cones / tapered pieces.",
-    example: "const geo = cylinderGeo(0.25, 0.25, 1, 12);"
-  },
-  {
-    name: "cylinderYGeo",
-    signature: "cylinderYGeo(radiusTop: number, radiusBottom: number, height: number, segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Alias for cylinderGeo — a Y-axis cylinder. Provided because the sandbox exposes cylinderXGeo / cylinderZGeo and the symmetric Y form is commonly reached for.",
-    example: "const geo = cylinderYGeo(0.25, 0.25, 1, 12);"
-  },
-  {
-    name: "cylinderXGeo",
-    signature: "cylinderXGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Cylinder pre-rotated to run along +X/-X. Use for fuselages, cannons, barrels, axles, and forward-facing tubes.",
-    example: "const geo = cylinderXGeo(0.1, 0.1, 1.2, 12);"
-  },
-  {
-    name: "cylinderZGeo",
-    signature: "cylinderZGeo(radiusTop: number, radiusBottom: number, length: number, segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Cylinder pre-rotated to run along +Z/-Z. Use for side-mounted weapons, rails, crossbars, and pipes.",
-    example: "const geo = cylinderZGeo(0.08, 0.08, 0.9, 10);"
-  },
-  {
-    name: "cylinderOnAxis",
-    signature: "cylinderOnAxis(center: [x,y,z], normal: [x,y,z], radiusBottom: number, height: number, opts?: { radiusTop?, segments? })",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Frame-first cylinder: position + axis specified directly, no post-hoc rotation. Use when the cylinder needs to point along a non-cardinal direction (struts inside CSG operands, antennas off a tilted surface). For cardinal axes prefer the terser cylinderXGeo / cylinderYGeo / cylinderZGeo helpers.",
-    example: "const strut = cylinderOnAxis([0.5, 0.7, 0], [1, 1, 0.3], 0.05, 0.9);"
-  },
-  {
-    name: "capsuleGeo",
-    signature: "capsuleGeo(radius: number, height: number, segments?: 6)",
-    returns: "THREE.CapsuleGeometry",
-    category: "geometry",
-    description: "Stadium shape (cylinder with hemispherical caps). Good for limbs.",
-    example: "const geo = capsuleGeo(0.1, 0.5, 6);"
-  },
-  {
-    name: "capsuleYGeo",
-    signature: "capsuleYGeo(radius: number, height: number, segments?: 6)",
-    returns: "THREE.CapsuleGeometry",
-    category: "geometry",
-    description: "Alias for capsuleGeo — a Y-axis capsule. Provided for symmetry with capsuleXGeo / capsuleZGeo.",
-    example: "const geo = capsuleYGeo(0.1, 0.5, 6);"
-  },
-  {
-    name: "capsuleXGeo",
-    signature: "capsuleXGeo(radius: number, length: number, segments?: 6)",
-    returns: "THREE.CapsuleGeometry",
-    category: "geometry",
-    description: "Capsule pre-rotated to run along +X/-X. Use for aircraft bodies, rounded vehicle hulls, and missiles.",
-    example: "const geo = capsuleXGeo(0.35, 2.4, 10);"
-  },
-  {
-    name: "capsuleZGeo",
-    signature: "capsuleZGeo(radius: number, length: number, segments?: 6)",
-    returns: "THREE.CapsuleGeometry",
-    category: "geometry",
-    description: "Capsule pre-rotated to run along +Z/-Z. Use for lateral pods, floats, and side tanks.",
-    example: "const geo = capsuleZGeo(0.18, 1.1, 8);"
-  },
-  {
-    name: "coneGeo",
-    signature: "coneGeo(radius: number, height: number, segments?: 8)",
-    returns: "THREE.ConeGeometry",
-    category: "geometry",
-    description: "Y-axis cone (pointed up). Use for spikes, roofs, projectiles.",
-    example: "const geo = coneGeo(0.3, 0.8, 8);"
-  },
-  {
-    name: "coneYGeo",
-    signature: "coneYGeo(radius: number, height: number, segments?: 8)",
-    returns: "THREE.ConeGeometry",
-    category: "geometry",
-    description: "Alias for coneGeo — a Y-axis cone (point +Y). Provided for symmetry with coneXGeo / coneZGeo.",
-    example: "const geo = coneYGeo(0.3, 0.8, 8);"
-  },
-  {
-    name: "coneXGeo",
-    signature: "coneXGeo(radius: number, length: number, segments?: 8)",
-    returns: "THREE.ConeGeometry",
-    category: "geometry",
-    description: "Cone pre-rotated so its point faces +X. Use for noses, rockets, shells, and forward-facing tips.",
-    example: "const geo = coneXGeo(0.18, 0.45, 12);"
-  },
-  {
-    name: "coneZGeo",
-    signature: "coneZGeo(radius: number, length: number, segments?: 8)",
-    returns: "THREE.ConeGeometry",
-    category: "geometry",
-    description: "Cone pre-rotated so its point faces +Z. Use for side-facing projectiles and tips.",
-    example: "const geo = coneZGeo(0.12, 0.35, 10);"
-  },
-  {
-    name: "taperConeGeo",
-    signature: "taperConeGeo(radiusBottom: number, radiusTop: number, height: number, axis?: 'x'|'y'|'z', segments?: 8)",
-    returns: "THREE.CylinderGeometry",
-    category: "geometry",
-    description: "Truncated cone (frustum) — exposes both bottom and top radius. radiusTop=0 matches coneGeo, radiusTop=radiusBottom matches cylinderGeo. Use for pylon caps, soda cans, lampshades, anything tapered that does not come to a point. axis selects orientation (default Y).",
-    example: "const cap = taperConeGeo(0.3, 0.18, 0.4);  // frustum"
-  },
-  {
-    name: "torusGeo",
-    signature: "torusGeo(radius: number, tube: number, radialSegments?: 8, tubularSegments?: 12)",
-    returns: "THREE.TorusGeometry",
-    category: "geometry",
-    description: "Donut shape. For rings, tyres, barrel ribs.",
-    example: "const geo = torusGeo(0.4, 0.04, 8, 16);"
-  },
-  {
-    name: "planeGeo",
-    signature: "planeGeo(width: number, height: number, widthSegments?: 1, heightSegments?: 1)",
-    returns: "THREE.PlaneGeometry",
-    category: "geometry",
-    description: "Flat quad for TEXTURED surfaces (ground, signs, walls with albedo maps). For solid-color decals like red stars, hull numbers, stamps, or window cutouts on no-texture assets use decalBox — a bare planeGeo without a texture will render as a disconnected 2-tri square and get flagged as a stray plane.",
-    example: "const geo = planeGeo(4, 4);"
-  },
-  {
-    name: "decalBox",
-    signature: "decalBox(width: number, height: number, depth?: 0.01)",
-    returns: "THREE.BoxGeometry",
-    category: "geometry",
-    description: "Thin box for solid-color surface decals: red stars, hull numbers, stamps, no-texture windows. Unlike planeGeo, has real depth so it visibly attaches to its host surface. Must be placed on a surface with position + rotation.",
-    example: `const star = decalBox(0.18, 0.18, 0.01);
-createPart('Mesh_StarPort', star, gameMaterial(0xc61f2a), { position: [0.4, 0.6, 0.41], parent: fuselage });`,
-    promptNotes: "Offset at least 0.01 outside the host surface to avoid z-fighting (a 0.8-wide hull has faces at z=±0.4, so place the decal at z=±0.41)."
-  },
-  {
-    name: "foliageCardGeo",
-    signature: "foliageCardGeo(opts?: { width?, height?, yPivot?: 0..1 })",
-    returns: "THREE.PlaneGeometry",
-    category: "geometry",
-    description: "Single-quad foliage card with a configurable Y pivot. yPivot=0 plants the quad on the ground. Pair with an alpha-tested material and a leaf/plant sprite.",
-    example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
-const quad = foliageCardGeo({ width: 4, height: 6, yPivot: 0 });
-createPart('Mesh_Fern', quad, leaves, { parent: root });`
-  },
-  {
-    name: "crossedQuadsGeo",
-    signature: "crossedQuadsGeo(opts?: { width?, height?, planes?: 2 | 3, yPivot? })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Cross-billboard bush primitive: 2 or 3 planes intersecting along the Y axis. Reads as a dense plant from any angle, cheaper than real geometry.",
-    example: `const leaves = await materialRecipe('kiln.material.leaf.v1');
-const bush = crossedQuadsGeo({ width: 2, height: 2, planes: 3 });
-createPart('Mesh_Bush', bush, leaves, { parent: root });`
-  },
-  {
-    name: "octaGridPlane",
-    signature: "octaGridPlane({ tilesX, tilesY, width?, height?, yPivot? })",
-    returns: "THREE.PlaneGeometry",
-    category: "geometry",
-    description: "Atlas-ready billboard quad. UVs are pre-scaled to cover one tile of a tilesX×tilesY atlas; the consumer shader adds per-instance tile offsets at draw time.",
-    example: "const card = octaGridPlane({ tilesX: 4, tilesY: 4, width: 6, height: 6 });"
-  },
-  {
-    name: "wingGeo",
-    signature: "wingGeo(opts?: { span, rootChord, tipChord, sweep, thickness, dihedral })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Trapezoid wing panel. Local root edge is at Z=0, span extends toward +Z, positive sweep moves the tip aft along -X.",
-    example: "const geo = wingGeo({ span: 2.2, rootChord: 0.8, tipChord: 0.3, sweep: 0.25, dihedral: 0.08 });"
-  },
-  {
-    name: "gearGeo",
-    signature: "gearGeo(opts?: { teeth?: 12, rootRadius?: 0.8, tipRadius?: 1.0, boreRadius?: 0.2, height?: 0.3, toothWidthFrac?: 0.5 })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Stylized gear with flat edges and an optional center bore; no CSG. Use boreRadius < rootRadius < tipRadius. Radii are absolute: an omitted rootRadius stays 0.8 when tipRadius changes. Set all three radii for small gears.",
-    example: `const g = gearGeo({ teeth: 28, rootRadius: 0.063, tipRadius: 0.075, boreRadius: 0.012, height: 0.024 });
-createPart('Gear', g, gameMaterial(0x909090, { metalness: 0.8 }), { parent: root });`
-  },
-  {
-    name: "bladeGeo",
-    signature: "bladeGeo(opts?: { length?: 1.5, baseWidth?: 0.1, thickness?: 0.015, tipLength?: 0.25, edgeBevel?: 0 })",
-    returns: "THREE.BufferGeometry",
-    category: "geometry",
-    description: "Parametric sword blade: rectangular base tapering to a point over tipLength. edgeBevel > 0 pinches the cross-section toward a diamond ridge.",
-    example: `const b = bladeGeo({ length: 1.6, baseWidth: 0.09, tipLength: 0.3, edgeBevel: 0.5 });
-createPart('Blade', b, steel, { position: [0, 0, 0], parent: root });`
-  },
-  {
-    name: "gameMaterial",
-    signature: "gameMaterial(color, opts?: { metalness, roughness, emissive, emissiveIntensity, flatShading })",
-    returns: "THREE.MeshStandardMaterial",
-    category: "material",
-    description: "Flat-shaded PBR material. Default for game-ready low-poly. Use for 95% of parts.",
-    example: "const mat = gameMaterial(0x8b7355, { roughness: 0.9 });"
-  },
-  {
-    name: "materialRecipe",
-    signature: "await materialRecipe(recipeId, overrides?: { baseColor?, roughness?, metalness?, opacity?, alphaCutoff?, doubleSided?, emissiveColor?, emissiveIntensity?, textureResources? })",
-    returns: "Promise<THREE.MeshStandardMaterial>",
-    category: "material",
-    description: "Resolves a versioned portable bark/leaf/wood/stone/rubber/painted-metal/cloth/skin/glass/emissive recipe to standard glTF PBR.",
-    example: "const bark = await materialRecipe('kiln.material.bark.v1', { baseColor: '#6b4328' });",
-    promptNotes: "Use only listed kiln.material.*.v1 IDs and approved kiln.texture.* resource IDs. Leaf is MASK, glass is BLEND, and host file paths are forbidden."
-  },
-  {
-    name: "compilePortableMaterialSpecV2",
-    signature: "await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', name?, baseColor?, roughness?, metalness?, emissive?, emissiveIntensity?, alphaMode?, alphaCutoff?, doubleSided?, textures?: { baseColor?, normal?, metallicRoughness?, emissive?, occlusion? } })",
-    returns: "Promise<THREE.MeshStandardMaterial>",
-    category: "material",
-    description: "Compiles the strict portable material contract. Texture refs are either typed procedural V2 specs or closed approved kiln.texture.* IDs; paths, URLs, raw textures, callbacks, and shader source are rejected.",
-    example: "const steel = await compilePortableMaterialSpecV2({ schemaVersion: 2, model: 'pbrMetallicRoughness', roughness: 0.45, metalness: 0.85, textures: { metallicRoughness: { kind: 'procedural', spec: { schemaVersion: 2, usage: 'metallicRoughness', size: 64, layers: [{ op: 'solid', color: 0x0080cc }] } } } });",
-    promptNotes: "Use metallicRoughness as one packed G=roughness/B=metalness map. Every procedural ref usage must match its slot; resource refs must be approved for that exact slot."
-  },
-  {
-    name: "basicMaterial",
-    signature: "basicMaterial(color, opts?: { transparent, opacity })",
-    returns: "THREE.MeshBasicMaterial",
-    category: "material",
-    description: "Unlit flat material. For UI / effects where lighting is baked in.",
-    example: "const mat = basicMaterial(0xffffff, { transparent: true, opacity: 0.5 });"
-  },
-  {
-    name: "glassMaterial",
-    signature: "glassMaterial(color, opts?: { opacity, roughness, metalness })",
-    returns: "THREE.MeshStandardMaterial",
-    category: "material",
-    description: "Semi-transparent double-sided material. Panels need ~0.05 offset to avoid z-fighting.",
-    example: "const mat = glassMaterial(0x66ccff, { opacity: 0.3 });"
-  },
-  {
-    name: "lambertMaterial",
-    signature: "lambertMaterial(color, opts?: { flatShading, emissive })",
-    returns: "THREE.MeshLambertMaterial",
-    category: "material",
-    description: "Cheaper than gameMaterial. No metalness/roughness. Use when PBR is overkill.",
-    example: "const mat = lambertMaterial(0x2a4d14, { flatShading: true });"
-  },
-  {
-    name: "rotationTrack",
-    signature: "rotationTrack(jointName: string, keyframes: Array<{ time, rotation: [xDeg, yDeg, zDeg] }>, interp?: 'LINEAR' | 'STEP')",
-    returns: "THREE.QuaternionKeyframeTrack",
-    category: "animation",
-    description: "Rotation track in degrees, auto-converted to quaternions. Joint name must include `Joint_` prefix.",
-    example: "rotationTrack('Joint_Lid', [{ time: 0, rotation: [0, 0, 0] }, { time: 1, rotation: [90, 0, 0] }]);"
-  },
-  {
-    name: "positionTrack",
-    signature: "positionTrack(jointName: string, keyframes: Array<{ time, position: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
-    returns: "THREE.VectorKeyframeTrack",
-    category: "animation",
-    description: "Position track in world units. Always use `position:` not `value:` in keyframes.",
-    example: "positionTrack('Joint_Body', [{ time: 0, position: [0, 0, 0] }, { time: 1, position: [0, 0.1, 0] }]);"
-  },
-  {
-    name: "scaleTrack",
-    signature: "scaleTrack(jointName: string, keyframes: Array<{ time, scale: [x, y, z] }>, interp?: 'LINEAR' | 'STEP')",
-    returns: "THREE.VectorKeyframeTrack",
-    category: "animation",
-    description: "Uniform or per-axis scale track.",
-    example: "scaleTrack('Joint_Chest', [{ time: 0, scale: [1, 1, 1] }, { time: 1, scale: [1.1, 1.1, 1.1] }]);"
-  },
-  {
-    name: "createClip",
-    signature: "createClip(name: string, duration: number, tracks: KeyframeTrack[])",
-    returns: "THREE.AnimationClip",
-    category: "animation",
-    description: "Collects tracks into a named clip. Returned from animate().",
-    example: "return [createClip('Open', 1, [rotationTrack('Joint_Lid', [...])])];"
-  },
-  {
-    name: "idleBreathing",
-    signature: "idleBreathing(bodyJoint: string, duration?: 2, amount?: 0.02)",
-    returns: "THREE.AnimationClip",
-    category: "animation",
-    description: "Gentle Y-axis bob. For NPC idle states.",
-    example: "return [idleBreathing('Joint_Body')];"
-  },
-  {
-    name: "bobbingAnimation",
-    signature: "bobbingAnimation(rootName: string, duration?: 2, height?: 0.1)",
-    returns: "THREE.AnimationClip",
-    category: "animation",
-    description: "Floating / bobbing loop for pickups and effects.",
-    example: "return [bobbingAnimation('Joint_Root', 1.5, 0.08)];"
-  },
-  {
-    name: "spinAnimation",
-    signature: "spinAnimation(jointName: string, duration?: 2, axis?: 'x' | 'y' | 'z')",
-    returns: "THREE.AnimationClip",
-    category: "animation",
-    description: "360° rotation over `duration` around `axis`.",
-    example: "return [spinAnimation('Joint_Rotor', 0.5, 'y')];"
-  },
-  {
-    name: "cloneGeometry",
-    signature: "cloneGeometry(geo: BufferGeometry)",
-    returns: "THREE.BufferGeometry (same ref)",
-    category: "instancing",
-    description: "Deprecated name: returns the SAME geometry, without copying. Use copyGeometry for independent vertex edits, or pass the original geometry directly for intentional sharing.",
-    example: "const wheelGeo = cylinderGeo(0.4, 0.4, 0.2, 12);"
-  },
-  {
-    name: "cloneMaterial",
-    signature: "cloneMaterial(mat: Material)",
-    returns: "THREE.Material (same ref)",
-    category: "instancing",
-    description: "Deprecated name: returns the SAME material. Use copyMaterial for independent property edits, or pass the original for intentional sharing.",
-    example: "const rubberMat = gameMaterial(0x1a1a1a, { roughness: 0.95 });"
-  },
-  {
-    name: "createInstance",
-    signature: "createInstance(name, source, opts?: { position, rotation: [xDeg, yDeg, zDeg], scale, parent })",
-    returns: "THREE.Object3D",
-    category: "instancing",
-    description: "Creates a new mesh reusing an existing part's geometry + material at a new transform. Cheapest way to replicate wheels / bolts / fence posts / windows. `rotation` is in DEGREES, like createPart.",
-    example: `const wheelFL = createPart('WheelFL', wheelGeo, rubberMat, { position: [-0.8, 0.3, 1.2], parent: root });
-createInstance('WheelFR', wheelFL, { position: [0.8, 0.3, 1.2], parent: root });
-createInstance('WheelRL', wheelFL, { position: [-0.8, 0.3, -1.2], parent: root });
-createInstance('WheelRR', wheelFL, { position: [0.8, 0.3, -1.2], parent: root });`
-  },
-  {
-    name: "boolUnion",
-    signature: "await boolUnion(name: string, ...parts: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
-    returns: "Promise<THREE.Mesh>",
-    category: "csg",
-    description: "Merges two or more parts into one watertight manifold mesh. Default flat shading (hard edges) — pass { smooth: true } as last arg for averaged normals on organic merges.",
-    example: `const body = new THREE.Mesh(boxGeo(2, 1, 1), steel);
-const turret = new THREE.Mesh(cylinderGeo(0.3, 0.3, 0.4, 16), steel);
-turret.position.y = 0.5;
-const hull = await boolUnion('Hull', body, turret);`
-  },
-  {
-    name: "boolDiff",
-    signature: "await boolDiff(name: string, body: Object3D, ...cutters: Object3D[], opts?: { smooth?: false, preserveAttributes?: boolean })",
-    returns: "Promise<THREE.Mesh>",
-    category: "csg",
-    description: "Subtracts cutters from a body (holes, button recesses, window slots). Default flat shading for sharp mechanical edges.",
-    example: `const body = new THREE.Mesh(cylinderGeo(1, 1, 0.3, 32), steel);
-const teeth = [...]; // 8 radially-arrayed box meshes
-const gear = await boolDiff('Gear', body, ...teeth);  // hard-edged`
-  },
-  {
-    name: "roundedBoxGeo",
-    signature: "await roundedBoxGeo(width: number, height: number, depth: number, radius: number, opts?: { style?: 'round' | 'chamfer', segments?: 12, smooth?: boolean })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "csg",
-    description: "A box with all twelve edges rounded (or chamfered) at the EXACT outer size requested — roundedBoxGeo(1, 1, 1, 0.1) measures 1x1x1, it does not grow. Use it anywhere boxGeo reads too sharp: consoles, crates, appliances, handheld props, machined blocks.",
-    promptNotes: "Real objects almost never have perfectly sharp box edges, and a small radius is the single cheapest upgrade to how manufactured an asset looks. Prefer this over boxGeo for anything moulded, cast, or machined. Keep radius small relative to the box (5-10% of the smallest dimension); radius must be less than half the smallest dimension or the call throws. style: 'chamfer' reads as machined metal, 'round' as moulded plastic. This is async — build() must be async and the call must use await.",
-    example: `const geo = await roundedBoxGeo(1.2, 0.6, 0.8, 0.05);
-createPart('Console', geo, plastic, { position: [0, 0.3, 0], parent: root });`
-  },
-  {
-    name: "extrudeProfile",
-    signature: "await extrudeProfile(profile: [number, number][], opts?: { depth?: 1, holes?: [number, number][][], bevel?: 0, bevelStyle?: 'round' | 'chamfer', segments?: 12, twist?: 0, taper?: number | [number, number], divisions?: number, axis?: 'x' | 'y' | 'z', center?: true, smooth?: false })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "csg",
-    description: "Sweeps a closed 2D outline into a watertight solid, with optional holes, corner rounding/chamfering, twist, and taper. The way to build any cross-section that is not a box or a cylinder: L-brackets, I-beams, gaskets, washers, star and gear plates, signage, extruded trim.",
-    promptNotes: "The bevel rounds the edges PARALLEL to the sweep axis (the profile corners) — the two flat caps stay sharp. For a box rounded on all twelve edges use roundedBoxGeo instead. Holes are subtracted, so their winding order does not matter. A bevel larger than half the outline's narrowest feature throws rather than silently returning an empty solid. Output is manifold, so it feeds straight into boolUnion / boolDiff / boolIntersect. Async — await it inside an async build().",
-    example: `// L-bracket, inner AND outer corners filleted
-const outline = [[0, 0], [2, 0], [2, 0.4], [0.4, 0.4], [0.4, 2], [0, 2]];
-const geo = await extrudeProfile(outline, { depth: 0.5, bevel: 0.06 });
-createPart('Bracket', geo, steel, { parent: root });`
-  },
-  {
-    name: "revolveProfile",
-    signature: "await revolveProfile(profile: [number, number][], opts?: { segments?: 24, angle?: 360, bevel?: 0, bevelStyle?: 'round' | 'chamfer', bevelSegments?: 12, axis?: 'x' | 'y' | 'z', smooth?: true })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "csg",
-    description: "Revolves a closed 2D outline around an axis into a watertight SOLID, optionally rounding the profile corners first. Bottles, tanks, pressure vessels, wheels, turned wood, domes, buttons, pills.",
-    promptNotes: "Use this instead of lathe/revolveGeo whenever the result must survive a boolean or needs a rounded rim — lathe and revolveGeo build an open surface, this builds a closed solid. Profile convention matches lathe: x is distance from the axis, y is position along it, and only the x >= 0 side is used. Async — await it inside an async build().",
-    example: `// capsule tank with a rounded rim, then carve a port into it
-const profile = [[0, -0.5], [0.4, -0.5], [0.4, 0.5], [0, 0.5]];
-const body = await revolveProfile(profile, { bevel: 0.08, segments: 32 });
-const tank = await boolDiff('Tank', createPart('B', body, steel), portCutter);`
-  },
-  {
-    name: "circleProfile",
-    signature: "circleProfile(radius: number, segments?: 24, center?: [number, number])",
-    returns: "[number, number][]",
-    category: "csg",
-    description: "Builds a closed circular outline for extrudeProfile / revolveProfile, so you never hand-write the trigonometry. Synchronous.",
-    example: `const washer = await extrudeProfile(circleProfile(1), {
-  depth: 0.1,
-  holes: [circleProfile(0.4), circleProfile(0.1, 16, [0.7, 0])],
-});`
-  },
-  {
-    name: "boolIntersect",
-    signature: "await boolIntersect(name: string, a: Object3D, b: Object3D, opts?: { smooth?: false })",
-    returns: "Promise<THREE.Mesh>",
-    category: "csg",
-    description: "Keeps only the volume where both operands overlap. Default flat shading.",
-    example: "const lens = await boolIntersect('Lens', boxMesh, sphereMesh);"
-  },
-  {
-    name: "hull",
-    signature: "await hull(name: string, ...parts: Object3D[], opts?: { smooth?: true })",
-    returns: "Promise<THREE.Mesh>",
-    category: "csg",
-    description: "Tightest convex mesh enclosing all input points. Default smooth shading (rocks, collision volumes). Pass { smooth: false } for a faceted look.",
-    example: `const rockChunks = [...]; // scattered box meshes
-const rock = await hull('Rock', ...rockChunks);`
-  },
-  {
-    name: "arrayLinear",
-    signature: "arrayLinear(namePrefix, source, count, offset: [x,y,z], parent?)",
-    returns: "THREE.Object3D[]",
-    category: "arrays",
-    description: "Places N copies of `source` along a constant offset vector. Copies share geometry + material via createInstance.",
-    example: `const post = createPart('Post0', cylinderGeo(0.05,0.05,1.5,6), wood, { position: [0,0.75,0], parent: root });
-arrayLinear('Post', post, 10, [0.5, 0, 0], root);`
-  },
-  {
-    name: "arrayRadial",
-    signature: "arrayRadial(namePrefix, source, count, axis?: 'x'|'y'|'z', parent?)",
-    returns: "THREE.Object3D[]",
-    category: "arrays",
-    description: "Places N copies of `source` around the given axis. Source's local rotation is oriented outward. Perfect for gear teeth, radial bolts, circle of columns.",
-    example: `const bolt = createPart('Bolt0', cylinderGeo(0.02,0.02,0.1,6), steel, { position: [1,0,0], parent: root });
-arrayRadial('Bolt', bolt, 8, 'y', root);`
-  },
-  {
-    name: "mirror",
-    signature: "mirror(name, source, axis: 'x'|'y'|'z', parent?)",
-    returns: "THREE.Object3D",
-    category: "arrays",
-    description: "Reflects source across the plane whose normal is `axis`. Uses negative scale (winding flip handled by viewers).",
-    example: "mirror('WingR', wingL, 'x', root);"
-  },
-  {
-    name: "subdivide",
-    signature: "subdivide(geometry: BufferGeometry, iterations?: 1, opts?: { preserveUV?: boolean, split?: boolean, uvSmooth?: boolean, preserveEdges?: boolean, flatOnly?: boolean, weld?: boolean })",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Loop subdivision returns new geometry; each iteration roughly quadruples triangles and smooths the surface. Use preserveUV:true for textured meshes. Legacy position-only welding discards UVs and reports that loss. This smooths shapes, not selected-edge beveling.",
-    example: "const smoothRock = subdivide(boxGeo(1, 1, 1), 2);"
-  },
-  {
-    name: "mergeVertices",
-    signature: "mergeVertices(geometry: BufferGeometry, opts?: { tolerance?: 1e-4, positionOnly?: boolean } | number)",
-    returns: "THREE.BufferGeometry",
-    category: "mesh-ops",
-    description: "Returns indexed geometry. Default welding preserves attribute seams, so a textured cube retains separate face corners. positionOnly:true welds coincident positions and discards other attributes; use it explicitly when changing topology and regenerate shading/UVs afterward.",
-    example: `const welded = mergeVertices(boxGeo(1, 1, 1), { positionOnly: true });
-const rock = displace(subdivide(welded, 2), ([x,y,z]) => [0.08*Math.sin(y*7+z*3), 0.04*Math.sin(x*9), 0]);`
-  },
-  {
-    name: "curveToMesh",
-    signature: "curveToMesh(points: [x,y,z][], radius, tubularSegs?: 32, radialSegs?: 8, closed?: false)",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Sweeps a circular profile along a path. Equivalent to Blender's Curve to Mesh node with a circle profile. Use for pipes, cables, tubular frames.",
-    example: "const pipe = curveToMesh([[0,0,0],[0,1,0],[1,1,0],[1,2,0]], 0.1);"
-  },
-  {
-    name: "pipeAlongPath",
-    signature: "pipeAlongPath(points: [x,y,z][], radius: number, opts?: { bendRadius?: 0, closed?: false, tubularSegments?: 32, radialSegments?: 8 })",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Path-driven swept circle with optional bend smoothing. Generalises beamBetween (point-to-point) and curveToMesh (raw spline) into one helper. bendRadius>0 inserts interpolated waypoints near interior corners so the spline reads as a rounded turn instead of pinching to the control point.",
-    example: "const cable = pipeAlongPath([[0, 0.5, 0], [1, 0.5, 0], [1, 0.5, 2]], 0.02, { bendRadius: 0.1 });"
-  },
-  {
-    name: "lathe",
-    signature: "lathe(profile: [x,y][], segments?: 12)",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Surface of revolution. Spins a 2D profile around the Y axis. For bottles, vases, wheels, turned wood parts.",
-    example: "const vase = lathe([[0.1,0],[0.3,0.5],[0.2,1],[0.1,1.2]], 16);"
-  },
-  {
-    name: "revolveGeo",
-    signature: "revolveGeo(profile: [x,y][], opts?: { angle?: 2π, axis?: [x,y,z]=[0,1,0], segments?: 12 })",
-    returns: "THREE.BufferGeometry",
-    category: "curves",
-    description: "Surface of revolution with explicit axis + sweep angle. Generalises lathe — use it when you need a partial sweep (half-dome, 90° wedge) or revolution around a non-Y axis. Profile convention is identical to lathe: x = radial distance, y = position along the axis.",
-    example: `// Half-dome (180° sweep around +Y):
-const quarter = [...Array(8)].map((_, i) => { const t = (i/7)*Math.PI/2; return [Math.cos(t), Math.sin(t)] as [number, number]; });
-const dome = revolveGeo(quarter, { angle: Math.PI });`
-  },
-  {
-    name: "bezierCurve",
-    signature: "bezierCurve(controlPoints: [x,y,z][], samples?: 32)",
-    returns: "[x,y,z][]",
-    category: "curves",
-    description: "Samples a quadratic (3 ctrl pts) or cubic (4 ctrl pts) Bézier into a point list you can feed into curveToMesh.",
-    example: `const path = bezierCurve([[0,0,0],[1,2,0],[3,2,0],[4,0,0]], 24);
-const geo = curveToMesh(path, 0.1);`
-  },
-  {
-    name: "autoUnwrap",
-    signature: "await autoUnwrap(geometry: BufferGeometry, opts?: { resolution?: 1024, padding?: 2, useNormals?: false })",
-    returns: "Promise<THREE.BufferGeometry>",
-    category: "uv",
-    description: "xatlas-based UV atlas for ANY geometry (CSG output, subdivided, deformed). Output is a packed atlas with arbitrary per-chart rotation — use for non-tileable baked textures. For directional tileable textures on box/cylinder/plane primitives, prefer the shape-aware unwraps below.",
-    example: `const unwrapped = await autoUnwrap(someCsgResult, { resolution: 1024 });
-const mesh = new THREE.Mesh(unwrapped, bakedPbr);`
-  },
-  {
-    name: "boxUnwrap",
-    signature: "boxUnwrap(geometry: BufferGeometry)",
-    returns: "THREE.BufferGeometry",
-    category: "uv",
-    description: "Preserves BoxGeometry's built-in per-face UVs — every face maps [0,1] with consistent orientation. Use for crates/blocks with a tileable texture. Sync; no WASM cost.",
-    example: `const crate = boxUnwrap(boxGeo(1, 1, 1));
-const mesh = new THREE.Mesh(crate, pbrMaterial({ albedo: planksTex }));`
-  },
-  {
-    name: "cylinderUnwrap",
-    signature: "cylinderUnwrap(geometry: BufferGeometry)",
-    returns: "THREE.BufferGeometry",
-    category: "uv",
-    description: "Preserves CylinderGeometry's built-in UVs: u wraps around the axis (horizontal texture features ring the cylinder), v runs up the height. Caps use circle-in-square. Sync; no WASM cost.",
-    example: `const barrel = cylinderUnwrap(cylinderGeo(0.5, 0.5, 1.2, 24));
-const mesh = new THREE.Mesh(barrel, pbrMaterial({ albedo: bandsTex }));`
-  },
-  {
-    name: "planeUnwrap",
-    signature: "planeUnwrap(geometry: BufferGeometry)",
-    returns: "THREE.BufferGeometry",
-    category: "uv",
-    description: "Projects xy-extent of the bbox to [0,1]. Use for signs/decals/posters where you want ONE readable texture and no edge-face bleeding. Sync.",
-    example: `const sign = planeUnwrap(planeGeo(1, 0.6));
-const mesh = new THREE.Mesh(sign, pbrMaterial({ albedo: kilnTextTex }));`
-  },
-  {
-    name: "panelRemapV",
-    signature: "panelRemapV(geo, vScale=0.30, vOffset=0, uScale=1, uOffset=0)",
-    returns: "THREE.BufferGeometry",
-    category: "uv",
-    description: "Scales an existing UV attribute so a small mesh samples a sub-region of a SHARED texture. Replaces the broken texture.clone() pattern (Three.js Texture.clone() runs JSON.stringify on userData, mangling encoded PNG bytes — panelRemapV avoids that by remapping UVs on the geometry instead). Typical use: multi-zone albedo where v=0..0.30 is plain panel and v=0.30..1 has windows/markings — small parts call panelRemapV(unwrap(geo), 0.30) to sample only the clean strip.",
-    example: `const cowlGeo = panelRemapV(cylinderUnwrap(capsuleXGeo(0.45, 1.0)), 0.30);
-const cowl = new THREE.Mesh(cowlGeo, bodyMat); // SAME bodyMat as fuselage, no clone needed`
-  },
-  {
-    name: "loadApprovedTexture",
-    signature: "await loadApprovedTexture(resourceId)",
-    returns: "Promise<THREE.DataTexture>",
-    category: "textures",
-    description: "Loads one approved kiln.texture.* resource ID through the host-injected closed resolver. The registry fixes bytes, MIME, usage, dimensions, hash, and deadline; paths, URLs, byte arrays, resolver objects, hashes, and options are rejected.",
-    example: "const bark = await loadApprovedTexture('kiln.texture.bark-brown-01-albedo.v1');",
-    promptNotes: "Use only a concrete resource ID listed in material capabilities; never invent one. Prefer materialRecipe when a recipe already binds the family, or proceduralTexture V2 for authored surfaces. NEVER texture.clone() a loaded texture (clone() corrupts encoded bytes and breaks GLB export)."
-  },
-  {
-    name: "proceduralTexture",
-    signature: "proceduralTexture({ schemaVersion: 2, size?: 4..1024 pow2, usage?, name?, layers: [{ op: 'solid'|'checker'|'stripes'|'gradient'|'bricks'|'noise', ...params, blend?: 'normal'|'multiply'|'screen'|'overlay', opacity?: 0..1 }] })",
-    returns: "THREE.DataTexture (tiling, sRGB or linear per usage)",
-    category: "textures",
-    description: "Builds a tiling texture from a bounded layer stack — no image file needed. Layers composite bottom-first. Noise is seeded and tileable, so the same spec always produces the same bytes and a repeating material shows no seam. Baked to PNG and embedded in the GLB automatically.",
-    example: "const bark = proceduralTexture({ schemaVersion: 2, size: 256, usage: 'albedo', name: 'Bark', layers: [{ op: 'solid', color: 0x5a4632 }, { op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4, blend: 'overlay' }] });",
-    promptNotes: "Sync — no await. Strict V2 JSON boundary: unknown/prototype keys, callbacks, paths, URLs, and shader source are rejected. Prefer this over approved resources for describable surfaces. Max 8 layers, power-of-two size up to 1024. Only the six listed ops exist."
-  },
-  {
-    name: "normalMapFromHeight",
-    signature: "normalMapFromHeight(source: THREE.Texture, { strength?: number, name?: string })",
-    returns: "THREE.DataTexture (linear normal map)",
-    category: "textures",
-    description: "Derives a tangent-space normal map from the source texture's brightness, treating it as height. The cheap way to get real PBR surface relief out of a procedural albedo. Wraps at the edges, so a tiling source gives a tiling normal map.",
-    example: `const bark = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x3d2f21, colorB: 0x7a6248, scale: 6, octaves: 4 }] });
-const mat = pbrMaterial({ albedo: bark, normal: normalMapFromHeight(bark, { strength: 4 }) });`,
-    promptNotes: "strength 1 is subtle, 4-8 reads clearly at normal viewing distance. Output is always linear data — never assign it to an albedo/emissive slot."
-  },
-  {
-    name: "pbrMaterial",
-    signature: "pbrMaterial({ albedo?, normal?, roughness?, metalness?, metallicRoughness?, emissive?, aoMap?, alphaMode?, alphaCutoff?, doubleSided? })",
-    returns: "THREE.MeshStandardMaterial",
-    category: "material",
-    description: "Portable glTF PBR material. Use an explicit packed metallicRoughness texture (G=roughness, B=metalness); separate data maps are rejected instead of silently dropping a channel. Supports OPAQUE/MASK/BLEND and double-sided output.",
-    example: `const wood = proceduralTexture({ schemaVersion: 2, usage: 'albedo', layers: [{ op: 'noise', colorA: 0x4f301c, colorB: 0x9a6b3e, scale: 8, octaves: 3, seed: 4 }] });
-const crate = pbrMaterial({ albedo: wood, roughness: 0.85, metalness: 0 });`
-  },
-  {
-    name: "foliageMaterial",
-    signature: "foliageMaterial(albedo, { alphaCutoff?, roughness?, doubleSided? })",
-    returns: "THREE.MeshStandardMaterial",
-    category: "material",
-    description: "Portable foliage material that defaults to glTF MASK, cutoff 0.5, rough nonmetal, and double-sided. Use an alpha-bearing albedo texture.",
-    example: "const mat = await materialRecipe('kiln.material.leaf.v1');"
-  },
-  {
-    name: "countTriangles",
-    signature: "countTriangles(root: Object3D)",
-    returns: "number",
-    category: "utility",
-    description: "Sums triangle count across every mesh in the subtree.",
-    example: "meta.tris = countTriangles(root);"
-  },
-  {
-    name: "countMaterials",
-    signature: "countMaterials(root: Object3D)",
-    returns: "number",
-    category: "utility",
-    description: "Unique material count (by reference) across the subtree.",
-    example: "const mats = countMaterials(root);"
-  },
-  {
-    name: "getJointNames",
-    signature: "getJointNames(root: Object3D)",
-    returns: "string[]",
-    category: "utility",
-    description: "All node names beginning with `Joint_`. Use to sanity-check animation targets.",
-    example: "const joints = getJointNames(root);"
-  },
-  {
-    name: "validateAsset",
-    signature: "validateAsset(root: Object3D, category: 'character' | 'prop' | 'vfx' | 'environment' | 'architecture' | 'vegetation' | 'vehicle')",
-    returns: "{ valid, errors, warnings }",
-    category: "utility",
-    description: "Checks geometry and material costs for the selected category. No default triangle limit; choose detail for the intended runtime and inspect measured draw calls.",
-    example: "const v = validateAsset(root, 'prop');"
-  }
-];
-function listPrimitives() {
-  return PRIMITIVES.map((p) => ({ ...p }));
-}
-
-// src/tools/discovery.ts
 init_protocol();
 init_capture_limits();
 var inputSchema = z3.object({
@@ -27835,10 +27945,12 @@ function createCachedEvaluatorPort(evaluator, options) {
 
 // src/tools/registry.ts
 init_validation();
+init_protocol();
 init_render();
-import * as THREE35 from "three";
+init_list_primitives();
 init_evaluator();
 init_material_resources();
+import * as THREE35 from "three";
 
 // src/edit-buffer.ts
 class KilnDraftBuffer {
@@ -28430,6 +28542,17 @@ function collectSceneMetrics(root) {
   }
   return { meshes, materials: materialSet.size, bbox, lowestPart };
 }
+function withSyntaxDetail(message, code) {
+  if (!message.startsWith(evaluatorOutcomeMessage("EXECUTION_REJECTED")))
+    return message;
+  let syntax;
+  try {
+    syntax = validate(code).errors.find((error) => error.startsWith("Syntax error:"));
+  } catch {
+    return message;
+  }
+  return syntax ? `${message} ${syntax}` : message;
+}
 async function runRender(input, context) {
   try {
     const { root, rendered } = await loadEvaluatedReviewScene(input.code, context);
@@ -28448,6 +28571,7 @@ async function runRender(input, context) {
       tris: rendered.tris,
       meshes: metrics.meshes,
       materials: metrics.materials,
+      ...rendered.meta.instanceability ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials } : {},
       bbox: metrics.bbox,
       lowestPart: metrics.lowestPart,
       ...instanceability ? {
@@ -28462,7 +28586,7 @@ async function runRender(input, context) {
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: []
     };
   }
@@ -28486,7 +28610,7 @@ async function runScreenshot(input, context) {
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: []
     };
   }
@@ -28519,6 +28643,7 @@ async function runRenderViews(input, context) {
         tris: rendered.tris,
         meshes: metrics.meshes,
         materials: metrics.materials,
+        ...rendered.meta.instanceability ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials } : {},
         bbox: metrics.bbox,
         lowestPart: metrics.lowestPart,
         views: grid2.views,
@@ -28615,6 +28740,7 @@ async function runRenderViews(input, context) {
       tris: rendered.tris,
       meshes: metrics.meshes,
       materials: metrics.materials,
+      ...rendered.meta.instanceability ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials } : {},
       bbox: metrics.bbox,
       lowestPart: metrics.lowestPart,
       ...rendered.meta.instanceability ? {
@@ -28638,7 +28764,7 @@ async function runRenderViews(input, context) {
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: []
     };
   }
@@ -30096,6 +30222,24 @@ async function createPackagedLocalToolContext(base = {}, env = process.env, inst
 // src/mcp-server.ts
 var MCP_SERVER_NAME = "kiln";
 var MCP_SERVER_VERSION = "0.6.0";
+var packagedSkillsDir = fileURLToPath4(new URL("../skills", import.meta.url));
+var MCP_SERVER_INSTRUCTIONS = `Kiln turns JavaScript you write into GLB 3D assets and returns rendered views for review.
+
+Work by reference. Send a program once to kiln_validate or kiln_render; the result carries a programRef. Keep it exactly as returned, including a short p_ handle, and use it for every later view and edit. kiln_source with that ref and a literal query returns exact edit anchors, and kiln_edit with that ref plus edits returns a new ref and renders by default. Do not resend a whole program to change part of it.
+
+Call kiln_list_primitives before writing code to get exact helper signatures, with capabilities: true for the runtime, source, export and camera contract. Read viewFidelity in any render result before judging materials: a geometry-flat CPU image is evidence about shape, not about material.
+
+Detailed workflows ship beside this server as Agent Skills, one directory each under ${packagedSkillsDir}:
+- kiln-setup-workspace: create a managed workspace for authoring, and verify its tools came up
+- kiln-author-asset: write a new asset and export a GLB
+- kiln-refine-asset: change a saved asset through revisions
+- kiln-qa-asset: verify geometry, export fidelity, and behaviour in the destination project
+- kiln-compose-scene: arrange several existing GLB assets into a scene
+- kiln-batch-dispatch: run comparable trials across harnesses or models
+
+Read the one matching the task before authoring; each names its own reference files.
+
+Most harnesses register skills only from their own directories, so these may not appear as registered skills where you are. If the user wants them registered, offer to copy the relevant directories into .claude/skills/ or .agents/skills/ in their project. Ask before writing, and say that registration takes effect in a new session.`;
 function kilnMcpToolDefs(context = {}) {
   return createKilnProgramToolRegistry(context);
 }
@@ -30144,7 +30288,7 @@ function createKilnMcpServer(context = {}) {
   const server = new McpServer({
     name: MCP_SERVER_NAME,
     version: MCP_SERVER_VERSION
-  });
+  }, { instructions: MCP_SERVER_INSTRUCTIONS });
   server.registerResource("kiln-asset-viewer", KILN_ASSET_WIDGET_URI, {
     description: "Interactive Kiln asset viewer and downloads",
     mimeType: "text/html;profile=mcp-app"
@@ -30251,5 +30395,6 @@ export {
   kilnMcpToolDefs,
   createKilnMcpServer,
   MCP_SERVER_VERSION,
-  MCP_SERVER_NAME
+  MCP_SERVER_NAME,
+  MCP_SERVER_INSTRUCTIONS
 };

--- a/docs/chatgpt.md
+++ b/docs/chatgpt.md
@@ -17,7 +17,7 @@ Local subprocess evaluation has deadlines and a sanitized environment; it is not
 
 Keep `skills/*/SKILL.md` and their adjacent `references/` directories as the maintained source. Skill descriptions provide discovery; instructions load on selection, and reference files provide modeling detail when needed. Avoid pasting the complete modeling catalog into every tool description or prompt.
 
-The repository now contains `.codex-plugin/plugin.json` and `.mcp.json` for local plugin hosts. Generated project workspaces continue to receive their own explicit skill copies. No global skills are installed.
+The repository contains `.codex-plugin/plugin.json` for local plugin hosts, carrying its MCP server inline with a plugin-root-relative `cwd`. Root `.mcp.json` is separate and serves a different case: a plain `git clone` opened directly in a harness, where no plugin variable is defined. Generated project workspaces continue to receive their own explicit skill copies. No global skills are installed.
 
 For ChatGPT, first register the connector and copy its technical `plugin_asdk_app...` ID from the connector page. Then build a separate package:
 

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -149,7 +149,7 @@ disruption instead of several.
 | ID | Task | State |
 | --- | --- | --- |
 | 3.1 | Install `git-filter-repo`. `pipx` and `pip3` are both absent on this machine, so it came from the distribution package instead: `pacman -S git-filter-repo`, version 2.47.0-3 | Done |
-| 3.2 | Commit all Phase 1 and Phase 2 changes first, so the rewrite carries them | Pending |
+| 3.2 | Commit all Phase 1 and Phase 2 changes first, so the rewrite carries them | Done; state was stale. The shipped rewrite demonstrably carries them -- corrected 2026-09-10 |
 | 3.3 | Re-verify fork and PR counts immediately before proceeding | Done; 0 forks, 0 open pull requests, 0 open issues, 21 stars, unchanged from the Phase 0 reading |
 | 3.4 | Add `.gitignore` guards for the removed paths | Done; `examples/renders/*.png`, `examples/renders/*.gif` and `assets/video/` are ignored, inert while the files are still tracked and effective the moment 3.5 removes them |
 | 3.4a | Move the render-existence assertions off `readdir`. Added during execution; resolved by splitting the check across the two layers that can each honestly make it. See the Phase 3 record | Done |
@@ -174,16 +174,16 @@ content-addressed ref and reused the build.
 
 | ID | Task | State |
 | --- | --- | --- |
-| 4.0 | Independently reproduce findings 4.5 to 4.9 before editing. They came from a delegated run and are not yet personally confirmed | Pending |
-| 4.1 | `--harness claude` writes skills to `./skills/`, so the harness registers none of them; they work only because `CLAUDE.md` instructs the agent to read them. Either install to `.claude/skills/` or correct `START.md`, which currently states they are installed | Pending |
-| 4.2 | `kiln_render` reports only "Generated asset execution was rejected." on a syntax error, while `kiln_validate` on the same source reports `Syntax error: Unexpected token (2:39)`. Surface the underlying message | Pending |
-| 4.3 | The same rejection for an unknown helper never names the identifier. Name it and point at `kiln_list_primitives` | Pending |
-| 4.4 | The MCP server sends an empty `instructions` field, so a client reading only `.mcp.json` gets 13 tools with no indication that `programRef` should be reused rather than re-sending source | Pending |
-| 4.5 | `.mcp.json` records an absolute `node` path, which breaks for `nvm` users after `nvm use`. `--repair` fixes it; `START.md` frames repair as relocation-only | Pending |
-| 4.6 | `scripts/create-workspace.mjs` exits 0 on a usage error and names `kiln-init`, which the caller did not invoke | Pending |
-| 4.7 | `START.md` offers no copy-pasteable first command | Pending |
-| 4.8 | Reconcile metric naming: top-level `materials: 8` against `qaReport` `materialCount: 2` and `drawCalls: 8` for one render | Pending |
-| 4.9 | Reconsider `kiln_validate` returning `valid: true` for a program using an undefined helper | Pending |
+| 4.0 | Independently reproduce findings 4.5 to 4.9 before editing. They came from a delegated run and are not yet personally confirmed | Done; all nine reproduced 2026-09-10 against `dist/mcp-server.mjs`. See "Phase 4 verification" |
+| 4.1 | `--harness claude` writes skills to `./skills/`, so the harness registers none of them; they work only because `CLAUDE.md` instructs the agent to read them | Confirmed, then superseded. The either/or in the original wording is wrong: `.claude/skills/` serves only Claude, while `.agents/skills/` serves codex, opencode, hermes and agy. Rescoped into Phase 7 |
+| 4.2 | `kiln_render` reports only "Generated asset execution was rejected." on a syntax error, while `kiln_validate` on the same source reports `Syntax error: Unexpected token (1:48)`. Surface the underlying message | Done; `runRenderViews` and `runScreenshot` now append the host-side acorn diagnostic. Verified: render reports `Syntax error: Unexpected token (1:48)`, matching validate. Safe because that parse precedes execution, so nothing crosses the evaluator boundary |
+| 4.3 | The same rejection for an unknown helper never names the identifier. Name it and point at `kiln_list_primitives` | Done, within the boundary. The advice now points at `kiln_list_primitives`; the identifier is still not named, because only the sandboxed exception carries it and this module's contract forbids that. 4.9 names it from the host-side parse instead |
+| 4.4 | The MCP server sends an empty `instructions` field, so a client reading only `.mcp.json` gets 13 tools with no indication that `programRef` should be reused rather than re-sending source | Done; `instructions` is 1,776 characters, about 354 tokens, verified delivered in the initialize result and guarded by `src/__tests__/mcp-instructions.test.ts` |
+| 4.5 | `.mcp.json` records an absolute `node` path, which breaks for `nvm` users after `nvm use`. `--repair` fixes it; `START.md` frames repair as relocation-only | Done; `START.md` now says repair is needed after a replaced Node as well as a move, and explains that the manifest pins the interpreter the preflight validated |
+| 4.6 | `scripts/create-workspace.mjs` exits 0 on a usage error and names `kiln-init`, which the caller did not invoke | Refuted and closed. Measured without a pipe: no args exits 1, `--bogus` exits 1, `--help` exits 0; `kiln-init` is a real `bin` entry. The original finding read `$?` from a piped command |
+| 4.7 | `START.md` offers no copy-pasteable first command | Done; a fenced `cd` plus launch command, and a second block for repair, both carrying the workspace's own absolute path |
+| 4.8 | Corrected: `qaReport` carries neither `materialCount` nor `drawCalls`. The real defect is that top-level `materials` always equals `meshes` -- it counts per-mesh material slots, not distinct materials | Done additively. Root cause proven and different from the hypothesis: the metric measures a scene re-imported from GLB. `distinctMaterials` now comes from the post-dedup GLB metrics at all three result sites. 20 parts sharing one material report `materials: 20, distinctMaterials: 1` |
+| 4.9 | Reconsider `kiln_validate` returning `valid: true` for a program using an undefined helper | Done as a warning. `validate` names the undeclared called identifier with its line, from the host-side parse. Zero false positives across all 86 example programs; local functions and arrow consts are not flagged. Promoting it to an error would change `valid` for source that parses, and is left as a contract decision |
 
 ## Phase 5 — Test-artifact cleanup
 
@@ -582,3 +582,445 @@ file that `scripts/create-workspace.mjs` writes, not to the shipped manifest.
 Phases 0, 1, 2, 3 and 5 are complete. Phase 4 remains open and is now partly
 verified: 4.4 confirmed, 4.5 needs rewording, 4.6 partly refuted earlier. Phase 6
 is open and untouched.
+
+## Phase 4 verification
+
+Run on 2026-09-10 against `dist/mcp-server.mjs` over stdio, after first reading
+`skills/kiln-author-asset/SKILL.md` and `references/program-contract.md` so the
+probe programs were contract-valid (`const meta` plus `function build()`, no
+imports, exports or TypeScript). Omitting that step is what invalidated the
+earlier delegated run.
+
+Two findings changed on measurement. 4.6 is refuted outright. 4.8 was described
+wrongly in the original table and is a different, worse defect than recorded.
+
+Engine health measured in passing, so it is on the record rather than assumed:
+server start 1.3 s; one-part render 913 ms; five parts 862 ms; twenty parts
+798 ms; an identical re-render 57 ms from cache. Render cost is flat in part
+count. An earlier impression that renders were slow was a probe script leaking
+uncleared `setTimeout` handles, not engine behaviour.
+
+Protocol negotiation is correct and current: the server echoes `2025-06-18` and
+`2025-11-25` when asked, and falls back to `2025-11-25` for anything newer,
+which is `LATEST_PROTOCOL_VERSION` in the pinned SDK 1.30.0. The `2026-01-26`
+literal in `src/viewer/chat-app.ts` is the MCP-UI `ui/initialize` protocol, a
+different protocol, and is not an inconsistency.
+
+## Phase 7 -- Cross-harness skills and clean-room loadout
+
+Opened 2026-09-10. Phase 4 task 4.1 was scoped as a Claude-only choice between
+`.claude/skills/` and a `START.md` correction. Reading each harness's own
+documentation shows that framing was wrong, and that the gap is a whole class of
+defect rather than one setting.
+
+### The documented harness matrix
+
+| Harness | Project-local skill paths | Instruction file |
+| --- | --- | --- |
+| claude (Claude Code) | `.claude/skills/` only | `CLAUDE.md` only; does not read `AGENTS.md` |
+| codex (OpenAI Codex) | `.agents/skills/`, scanned from cwd up to repo root | `AGENTS.md` |
+| opencode | `.opencode/skills/`, `.claude/skills/`, `.agents/skills/` | `AGENTS.md` |
+| hermes (NousResearch) | `.hermes/skills/`, `.agents/skills/` | -- |
+| agy (Google Antigravity) | `.agents/skills/` | `agents.md` |
+
+`.agents/skills/` serves four of the five; Claude Code is the sole holdout.
+
+An important nuance, checked against the specification rather than inferred:
+`.agents/skills/` is a **de-facto convention, not part of the standard.** Agent
+Skills became a formal open standard on 2025-12-18 with the specification at
+`agentskills.io/specification`, adopted across 20-plus platforms, but that
+specification deliberately defines only the skill *format* -- directory layout
+and `SKILL.md` frontmatter -- and says nothing about where agents should look for
+skills. Discovery is left entirely to implementations, which is exactly why the
+matrix above has five different answers and why no single directory can serve
+all of them.
+
+Two corrections to earlier belief. Codex does support skills, from December
+2025; the claim that it had no native concept was wrong. And `skills/` at the
+repository root is not a mistake -- it is the plugin convention, auto-discovered
+from a Claude Code plugin root and declared explicitly by
+`.codex-plugin/plugin.json`. The layout is correct for the path it was built for.
+
+### Three install paths, one of them served
+
+| Path | Tools | Skills |
+| --- | --- | --- |
+| Installed as a plugin | yes | yes -- Claude by auto-discovery, Codex by explicit field |
+| `git clone` plus an agent | **no, see 7.1** | no -- root `skills/` is not a discovery path outside plugin context |
+| `kiln-init` workspace | yes, all five harnesses | opencode only |
+| Ad-hoc: configure the server by hand, open an empty folder | yes | files exist in the install root but sit in no scanned directory |
+
+### Clean rooms invert the registration rule
+
+A generated workspace is a plain directory; `create-workspace.mjs` writes a
+`.gitignore` but never runs `git init`. Both opencode and hermes gate
+project-local skill discovery on being inside a git checkout, so convention
+directories alone cannot be relied on there. Explicit configuration therefore
+beats convention in a clean room, which reverses the first proposal drafted for
+this phase: opencode's `skills.paths` must be KEPT, not replaced. It is a real
+key, verified against the published `opencode.ai/config.json` schema
+("Additional paths to skill folders").
+
+### Repo-side and workspace-side skills are different audiences
+
+All five existing skills are workspace-side: they assume a live `kiln_workspace`
+server and a workspace to author in. Nothing is repo-side, and `AGENTS.md` never
+mentions workspaces, `kiln-init` or clean rooms -- it addresses engine
+contributors only. An agent in a bare clone has no way to learn that
+`scripts/create-workspace.mjs` exists.
+
+This also rules out an approach that was nearly adopted: committing all five
+authoring skills to a root `.claude/skills/`. That would register, for an agent
+sitting in the engine checkout, skills whose own guidance is to keep the engine
+checkout out of the agent's task context. Root registers the repo-side skill
+only.
+
+| ID | Task | State |
+| --- | --- | --- |
+| 7.11 | Add specification validation of the skill files to CI. The standard ships a reference validator (`skills-ref validate`); a local equivalent avoids a new dependency. Guards the format against drift now that it is a published standard with 20-plus implementations | Done; folded into `check:skills` rather than adding a dependency on the reference validator |
+| 7.1 | Root `.mcp.json` borrowed Antigravity's `${PLUGIN_ROOT}` while serving Claude Code project config and the Codex plugin, neither of which defines it, so a fresh clone opened onto a `kiln` server that could not start | Done. Root `.mcp.json` now uses `${CLAUDE_PROJECT_DIR:-.}`, the documented project-scoped idiom; the Codex manifest carries its server inline with a plugin-root-relative `cwd`, the documented alternative to a path. Both expansion branches verified to start the server; `mcp_config.json` untouched; a guard test asserts no plugin variable returns to this file |
+| 7.2 | Author a repo-side `kiln-setup-workspace` skill: choosing a harness, generating the clean room, verifying `kiln_workspace` came up, and what `--repair` does and does not touch | Done; `skills/kiln-setup-workspace/`, specification-validated |
+| 7.3 | Register 7.2 at the repository root in both `.claude/skills/` and `.agents/skills/`. Copies, not symlinks: symlinks need developer mode or admin on Windows and a `core.symlinks` checkout | Done; committed to `.claude/skills/` and `.agents/skills/`. `.gitignore` needed the `.claude/*` plus negation form, because git will not descend into a wholly excluded directory |
+| 7.4 | Add a root `CLAUDE.md` containing the documented `@AGENTS.md` import, and an "authoring assets versus contributing to the engine" section to `AGENTS.md` naming 7.2. A skill cannot make itself discoverable, so this is the bootstrap | Done; root `CLAUDE.md` carries the documented `@AGENTS.md` import, and `AGENTS.md` gained an authoring-versus-contributing section |
+| 7.5 | Workspace generator: copy the authoring skills into `.claude/skills/` and `.agents/skills/` instead of plain `skills/`, upgrading four harnesses from prose to native registration | Done; all five harnesses now receive `.claude/skills/` and `.agents/skills/` alongside the maintained `skills/` |
+| 7.6 | Keep opencode `skills.paths`; add the hermes equivalent to the generated `.hermes/config.yaml`. The key is reported as `skills.external_dirs` but that came from prose, not a schema -- verify before writing it | Done; opencode `skills.paths` kept, hermes `skills.external_dirs` added after confirming the key and that its project-local scan needs a git checkout |
+| 7.7 | Populate the MCP `instructions` field from the five skill descriptions, as the harness-independent floor. Same work as 4.4 | Done; 1,776 characters, about 354 tokens, verified delivered in the initialize result |
+| 7.8 | Add a `check:skills` gate asserting the registered copies are byte-identical to canonical `skills/`, mirroring `check:toolchain`, and wire it into CI. This is what makes copying safe rather than a drift hazard | Done; `scripts/check-skills.mjs`, wired into CI before install, negative-tested against three distinct failure modes |
+| 7.9 | Trim `skills/kiln-batch-dispatch/references/clean-room-evaluation.md` to evaluation scope once 7.2 owns setup, so two documents do not describe workspace creation | Done; trimmed 42 lines to 30, setup now owned by 7.2 |
+| 7.10 | DECIDED: no `git init`. Clean rooms stay plain directories and skill registration goes through explicit configuration (7.6), which is independent of git state. Closed | Done |
+
+### Clone readiness, measured
+
+Verified 2026-09-10 against the live remote at `9b0c610`, in a fresh clone
+rather than the working tree: clone 3.3 s for 52 MB; `bun install
+--frozen-lockfile` 0.59 s, exit 0; `check:toolchain`, `typecheck` and `lint` all
+exit 0 with the unchanged 14-warning baseline; `bun run test` 1805 pass, 0 fail,
+2 skip. `dist/` is committed, so no build step precedes first use. Both
+previously flaky tests passed here, so they are intermittent rather than broken.
+
+Phase 6 does not gate a cloning developer: there is no `build:assets` script in
+`package.json`, and the only consumer of the poster receipts is the Pages
+workflow, already pinned to `windows-2022`. It stays maintainer-only work.
+
+## Decisions taken 2026-09-10
+
+| Ref | Decision | Rationale |
+| --- | --- | --- |
+| 7.1 | Split the two uses of `.mcp.json` | A fresh clone must not open onto a failing MCP server. The Codex plugin gets its own file; root `.mcp.json` becomes correct for a bare clone |
+| 4.8 | Add a correct `distinctMaterials` alongside `materials` rather than changing `materials` | Additive. Nothing reading the existing key breaks, including the instanceability grade. Root cause is still to be proven before any edit |
+| 7.10 | No `git init` for generated workspaces | Explicit configuration already covers opencode and hermes, and it works regardless of git state. Preserves the documented meaning of a clean room |
+| Scope | This pass covers Phase 7, the Phase 4 error-legibility and docs tasks, and 4.8. Phase 6 and the two intermittent tests stay out | Phase 6 needs a Windows or GPU host to re-record receipts and gates no cloning developer |
+
+### The ad-hoc path, and why `instructions` is not optional
+
+Raised by the owner 2026-09-10: a user may never create a clean room at all.
+They may start the MCP server, configure it in their coding agent, and open a
+new empty folder. That path works today for tools and for storage --
+`KILN_PROGRAM_STORE ?? '.kiln/programs'` resolves against the working directory,
+so the store is created in the folder the agent opened, which is the correct
+behaviour and not incidental.
+
+A correction to an earlier statement in this section: that user is not missing
+the skill files. All thirteen ship in the npm tarball and `skills/` sits as a
+sibling of `dist/`, so the server can compute its own install root and name a
+real absolute directory at runtime. What is missing is *registration* -- the
+files are in a location no harness scans. The MCP `instructions` field is the
+only channel that can tell that user the files exist and where. Task 7.7 therefore carries the whole
+loadout for this path and must be substantive on its own -- an orientation to
+the tool surface and the `programRef` contract -- rather than a pointer to skill
+files that are not present.
+
+### 7.1 is lower risk than first assessed
+
+`scripts/package-plugin.mjs` deletes `manifest.mcpServers` when it builds the
+Codex connector, so the published artifact is skills-only and never reads root
+`.mcp.json`. The `"mcpServers": "./.mcp.json"` field in
+`.codex-plugin/plugin.json` is effectively vestigial for the distributed plugin.
+Root `.mcp.json` can be made correct for a bare clone without disturbing the
+Codex packaging path. The Codex `plugin.json` schema could not be confirmed from
+OpenAI's published documentation; the packaging script is the authority used here.
+
+### The skills format is a published standard, and ours conforms
+
+Validated 2026-09-10 against `agentskills.io/specification`, not against this
+repository's own conventions.
+
+Required frontmatter is `name` (max 64 characters, lowercase alphanumerics and
+single hyphens, no leading, trailing or consecutive hyphens, and it **must match
+the parent directory name**) and `description` (max 1024 characters, stating both
+what the skill does and when to use it). Optional: `license`, `compatibility`
+(max 500), `metadata` (string-to-string map), and the experimental
+`allowed-tools`. The specification also sets progressive-disclosure guidance:
+name and description are loaded for every skill at startup, so roughly 100
+tokens each; the body loads on activation and should stay under 5000 tokens and
+500 lines; `references/`, `scripts/` and `assets/` load on demand and file
+references should stay one level deep.
+
+All five skills pass every one of those checks:
+
+| Skill | Lines | Description chars | Body tokens (approx) |
+| --- | --- | --- | --- |
+| kiln-author-asset | 47 | 117 | 911 |
+| kiln-batch-dispatch | 21 | 225 | 338 |
+| kiln-compose-scene | 20 | 133 | 239 |
+| kiln-qa-asset | 28 | 182 | 421 |
+| kiln-refine-asset | 45 | 160 | 795 |
+
+Names match their directories, no non-specification frontmatter keys are
+present, and the existing `references/` layout is the specification's own
+recommended convention. The content layer needs no change; only registration
+does.
+
+### `${PLUGIN_ROOT}` is not a variable in either plugin system
+
+Checked against both vendors rather than assumed from this repository. Claude
+Code expands `${CLAUDE_PLUGIN_ROOT}`, which is the token the Claude plugin
+manifest already uses correctly. Codex exposes no equivalent at all: its
+plugin-provided MCP servers take a relative `cwd` that Codex resolves against
+the installed plugin root, and the gap is tracked upstream in openai/codex
+issues 22842 and 22105. Codex `plugin.json` accepts `mcpServers` as either a
+relative path or an inline object, and `skills` as a relative path that
+supplements rather than replaces default discovery.
+
+**Correction, from this repository's own tests rather than vendor docs.**
+`${PLUGIN_ROOT}` *is* a real variable: it is Antigravity's, and root
+`mcp_config.json` uses it deliberately. `src/__tests__/mcp-bundle.test.ts`
+records the measurement -- on `agy` 1.1.25 the file validates at the plugin root
+(`mcpServers: 1 processed`) but is not merged into the session, so the test
+asserts only that it names the node bundle and pointedly does not assert that
+the variable expands. That file is correct and must be left alone.
+
+The defect is narrower than first written: root `.mcp.json` borrowed
+Antigravity's variable while serving two consumers that never define it -- Claude
+Code reading project-scoped configuration in a plain clone, and the Codex plugin
+manifest. Task 7.1 fixes that file only.
+
+### 7.7 shape: an index and a pointer, not the skill bodies
+
+Decided 2026-09-10 on the owner's suggestion that `instructions` should tell the
+agent to add skills to its workspace rather than carry them inline. Agreed, for
+two measured reasons.
+
+Inlining the five bodies would cost roughly 2704 tokens (911, 338, 239, 421 and
+795), paid at every session start by every client for content that is needed in
+perhaps one conversation. That is exactly what the specification's progressive
+disclosure model exists to prevent: name and description at startup, body only
+on activation. And the pointer can be concrete rather than aspirational, because
+`skills/` ships as a sibling of `dist/`.
+
+`instructions` therefore carries three things, in roughly 350 to 450 tokens:
+the tool-surface orientation and the `programRef` contract, which the ad-hoc user
+has no other way to learn; the five names with a one-line trigger each and the
+absolute source path; and one line offering to copy them into the workspace's
+`.claude/skills/` or `.agents/skills/`.
+
+Two constraints on the wording. The copy must be framed as something the agent
+proposes, not performs unasked -- an MCP server prompting unrequested writes into
+a user's project is a side effect, and someone who wanted one render should not
+find new directories afterwards. And the text must say the copy takes effect
+from the next session, because most harnesses will not register newly written
+skills mid-session; without that, the agent copies files, observes no new
+skills, and may retry.
+
+Deferred, not adopted: exposing the skills as MCP resources. That idea has a
+name and a specification -- see "Skills over MCP" below -- and this plan should
+use it rather than describe the mechanism informally.
+
+## Skills over MCP, and remote skill discovery
+
+Raised by the owner 2026-09-10 as a half-remembered "new skill paradigm exposed
+through MCP". It is real, and it matters for how much of Phase 7 is worth
+building by hand.
+
+### SEP-2640, the Skills Extension
+
+Extension identifier `io.modelcontextprotocol/skills`. It serves Agent Skills
+over MCP on the existing Resources primitive under a `skill://` URI scheme, with
+`skills/list` returning lightweight discovery metadata and `skills/activate`
+returning the full bundle plus scoped tools, prompts, resources and nested
+skills. Scoped primitives stay out of the top-level lists until activation, so
+progressive disclosure moves into the protocol itself.
+
+Ratified, this would collapse most of Phase 7: no per-harness directories, no
+filesystem copies, no registration step, and the ad-hoc path served by the same
+mechanism as every other path.
+
+It is not ratified. The SEP is an open pull request, accepted by core
+maintainers and still under review in the Skills Over MCP working group at 45
+commits, and it still requires reference-implementation completion, conformance
+tests and specification documentation. It is absent from the 2026-07-28 release
+candidate, which shipped MCP Apps and Tasks as the official extensions. It is an
+optional extension rather than a core primitive. Host support is prototype-level
+across gemini-cli, fast-agent, goose, codex and Claude Code. The SDK pinned here
+is 1.30.0 at protocol 2025-11-25, well before any of it.
+
+Decision: do not build on it in this pass. Building against an in-review API with
+no conformance tests would mean rewriting when it lands. Task 7.7 is already the
+manual form of `skills/list` -- an index plus a pointer -- so when the extension
+ratifies the same five skills become `skill://` resources and nothing authored
+now is wasted.
+
+### `.well-known/skills/`, which is usable today
+
+Cloudflare's Agent Skills Discovery RFC applies RFC 8615 well-known URIs to
+skill distribution, and it is already adopted by Mintlify, Docus and Vercel's
+skills CLI. It is what opencode's `skills.urls` config key consumes. Because
+this project already publishes a site, serving the five skills at
+`/.well-known/skills/` would let any opencode user fetch them by URL with no
+clone and no install. It does not depend on SEP-2640.
+
+| ID | Task | State |
+| --- | --- | --- |
+| 7.12 | Watch SEP-2640 to ratification, then expose the skills as `skill://` resources and retire the hand-built per-harness registration where clients support the extension | Deferred by decision; not this pass |
+| 7.13 | Publish the skills at `/.well-known/skills/` on the existing site per the Cloudflare discovery RFC, giving opencode `skills.urls` users a zero-install path | Pending; optional, independent of the rest of Phase 7 |
+
+### 7.1 execution record
+
+Root `.mcp.json` now reads `${CLAUDE_PROJECT_DIR:-.}/dist/mcp-server.mjs`.
+Claude Code expands `${VAR}` and `${VAR:-default}` in `command`, `args` and
+`env`, sets `CLAUDE_PROJECT_DIR` to the project root, and supports no `cwd`
+field for stdio servers -- so the default form is what makes the file resolve
+when nothing defines the variable. Verified by expanding both branches and
+launching each: unset falls back to `./dist/mcp-server.mjs` and starts; set
+resolves absolute and starts. The previous value failed with MODULE_NOT_FOUND.
+
+`.codex-plugin/plugin.json` no longer points at that shared file. It carries the
+server inline -- the documented alternative to a path -- with `"cwd": "."`, which
+Codex resolves against the installed plugin root. `scripts/package-plugin.mjs`
+still deletes `mcpServers` for the published connector: re-run after the change,
+16 files, `connectorBound: true`, `mcpServers` absent, `skills` preserved.
+
+Guarded by a new case in `src/__tests__/mcp-bundle.test.ts` asserting the exact
+argument and that neither `${PLUGIN_ROOT}` nor `${CLAUDE_PLUGIN_ROOT}` appears in
+root `.mcp.json`. Related suites re-run green: mcp-bundle, workspace-node-path,
+workspace-bootstrap, workspace-setup and integration-manifest, 18 tests then 6.
+`docs/chatgpt.md` corrected; the harness table in `docs/install.md` needed no
+change because it describes the generated workspace, not repository root.
+
+## Execution record, 2026-09-10
+
+All nineteen sequenced tasks are complete. Full gate on the working tree:
+`check:toolchain`, `check:skills`, `typecheck` and `lint` all exit 0 with the
+unchanged 14-warning / 11-info baseline, `bun run test` reports **1810 pass, 0
+fail, 2 skip** across 207 files, up from 1805 by the five tests added here, and
+`build:runtime` is byte-identical across consecutive runs.
+
+### What the docs changed about the plan
+
+Four claims written earlier in this document were wrong and are corrected in
+place above. `${PLUGIN_ROOT}` is real -- it is Antigravity's, used deliberately
+by root `mcp_config.json`, which this work left untouched. Codex has supported
+skills since December 2025. Root `skills/` is the plugin convention and was
+never misplaced. And the "SDK pinned here" was `@modelcontextprotocol/sdk`
+1.30.0, a transitive optional peer of `@google/genai` and `@strands-agents/sdk`
+that nothing in this repository imports; the direct dependencies are
+`@modelcontextprotocol/server` and `client` at 2.0.0, both the latest published,
+whose own `LATEST_PROTOCOL_VERSION` is `2025-11-25`. There was nothing to update.
+
+The skill format is a published standard, and all six skills validate against
+it: names match their directories, descriptions sit inside 1024 characters,
+bodies stay under the 500-line and 5000-token guidance, and no non-specification
+frontmatter key is present. `.agents/skills/` is a de-facto convention rather
+than part of that standard, which is why the matrix has five answers.
+
+### 4.8 root cause, which was not the hypothesis
+
+The leading hypothesis in this document -- that `mergeDocuments` gave each part a
+distinctly named material copy that `dedup()` would not merge -- was wrong.
+`loadEvaluatedReviewScene` renders to GLB and then **re-imports** the scene
+(`loadGlbReviewScene(rendered.glb)`), and `collectSceneMetrics` measures that
+re-imported scene, where authored sharing no longer survives as object identity.
+That is why `materials` could never disagree with `meshes`.
+
+The correct figure already existed, post-dedup, in
+`rendered.meta.instanceability.metrics.uniqueMaterials`. `distinctMaterials` is
+surfaced from it at all three render result sites. Verified: 20 parts sharing one
+material now report `materials: 20, distinctMaterials: 1`; 20 distinct report 20
+and 20. `materials` is unchanged and documented for what it actually measures.
+
+### 4.2 and 4.3 are bounded by a security boundary, not by effort
+
+`src/evaluator/authoring-diagnostic.ts` exists to stop exception text crossing
+out of the isolated evaluator: "No captured identifier, path, message, or stack
+crosses the boundary." Naming the identifier in a render rejection, as 4.3 asked,
+would breach that deliberately. What was added instead is engine-owned text
+pointing at `kiln_list_primitives`, and a test above it already asserts that
+arbitrary exceptions keep the generic rejection.
+
+4.2 is safe for a different reason: acorn parses host-side, before any generated
+code runs, which is exactly why `kiln_validate` can already report a position.
+Repeating that parse in the rejection path leaks nothing new. `kiln_render`
+routes through `runRenderViews`, not `runRender`, so the diagnostic is applied at
+both raw-source catches and deliberately not at the `programRef` paths, whose
+source was validated when it was saved.
+
+4.9 is where the identifier can be named, because that check is host-side and
+pre-execution. It reports a warning rather than an error, and its declaration
+set over-approximates -- every binding anywhere in the program counts as in
+scope -- so a shadowed or conditionally declared name is never falsely flagged.
+Measured against all 86 example programs: **zero** false positives; the
+undefined helper is named with its line. Promoting it to an error would change
+`valid` for programs that parse, and is left as a deliberate contract decision.
+
+### Left open, with reasons
+
+Task 7.13 (`/.well-known/skills/`) is grouped with Phase 6 as maintainer-side:
+publishing it runs through `pages.yml`, which is pinned to `windows-2022`, so it
+cannot be verified from a Linux checkout. Task 7.12 (SEP-2640) stays deferred
+until the SEP ratifies.
+
+A third order-dependent test was found and is **pre-existing**, not a
+regression: `authoring-diagnostic.test.ts` "shipping registry exposes repair
+advice from its isolated evaluator" fails when that file runs alone, with
+"Evaluator worker failed.", and passes in a full run. The pristine clone at
+`9b0c610` fails identically. It does not affect users: driving the shipped
+server directly over stdio returns the full advice, `kiln_list_primitives`
+pointer included. Test hygiene, tracked with the other two flaky tests.
+
+Codex's published plugin sample does not enumerate `command`, `args`, `cwd` or
+`env` for an inline `mcpServers` entry, so the `"cwd": "."` written into
+`.codex-plugin/plugin.json` rests on two secondary sources rather than the
+specification. It degrades gracefully -- the argument is relative, so it still
+resolves if `cwd` is ignored but the server already starts at the plugin root --
+and `scripts/package-plugin.mjs` deletes `mcpServers` from the published
+connector regardless.
+
+## Phase 8 -- `kiln save` writes nothing under Bun
+
+Found 2026-09-10 while confirming CI readiness, by chasing the test recorded
+above as merely flaky. It is not flaky in the way it looked, and it is not a
+test problem.
+
+| Runtime and entry | `kiln save` stdout | Exit |
+| --- | --- | --- |
+| `node dist/cli.mjs` | 2,061 bytes of JSON | 0 |
+| `bun dist/cli.mjs` | **0 bytes** | 0 |
+| `bun src/cli.ts` | **0 bytes** | 0 |
+
+The trigger is Bun, not the TypeScript source, and the failure is silent: exit 0,
+empty stdout, empty stderr, no unhandled rejection reported. The program store
+*is* written -- the source is imported and a `p_` ref file appears -- so the
+command runs partway and then stops without a diagnostic. `--help` prints
+correctly under Bun, so the entry guard is fine; `isDirectCliEntry()` was checked
+directly and both sides of its comparison match.
+
+This explains `src/asset-cli.test.ts` completely. That test invokes
+`spawnSync(process.execPath, [resolve('src/cli.ts'), 'save', ...])`, and under
+`bun test` `process.execPath` is Bun, so `saved.stdout` is empty and
+`JSON.parse('')` throws at line 34 -- while line 33's `expect(saved.status).toBe(0)`
+passes, because the exit code really is 0. Measured 1 pass in 4 isolated runs on
+this tree and 1 in 3 on a pristine `9b0c610`, so it is pre-existing and roughly a
+coin flip; it passed in both full-suite runs here and failed once under
+`test:coverage`.
+
+End users are not affected: every shipped launcher and manifest invokes `node`
+-- the workspace manifest pins the interpreter the preflight validated, and the
+plugin manifests use bare `node`. Contributors are, because `AGENTS.md`
+documents Bun as the toolchain.
+
+| ID | Task | State |
+| --- | --- | --- |
+| 8.1 | Find where the `save` path exits early under Bun without a diagnostic. The store write succeeds, so the divergence is after program import; suspect the in-process evaluator or an output flush racing process exit | Pending |
+| 8.2 | Decide whether the CLI should refuse to exit 0 having produced no output at all, independent of the Bun cause. A silent success is the part that made this look like flakiness for so long | Pending |
+| 8.3 | Point `src/asset-cli.test.ts` at an interpreter that reflects how the CLI actually ships, or assert non-empty stdout before parsing so the failure names the real cause | Pending |
+| 8.4 | Re-check the other two intermittent tests against this finding; a shared `spawnSync` under Bun may explain more than one of them | Pending |

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "scripts": {
     "kiln": "bun src/cli.ts",
     "check:toolchain": "bun scripts/check-toolchain.mjs",
+    "check:skills": "node scripts/check-skills.mjs",
     "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit",
     "build:mcp": "node scripts/build-runtime.mjs mcp",

--- a/scripts/check-skills.mjs
+++ b/scripts/check-skills.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Two checks that nothing else performs.
+ *
+ * First, the skill files are a published format now, not a local convention:
+ * Agent Skills became an open standard whose `name` and `description` rules are
+ * load-bearing for every harness that reads them. A violation is silent -- the
+ * harness simply skips the skill -- so the constraints are asserted here.
+ *
+ * Second, `skills/` is the maintained copy, but a bare clone registers nothing
+ * from it: Claude Code scans only `.claude/skills/`, while codex, opencode,
+ * hermes and agy scan `.agents/skills/`. Those copies exist so a fresh clone has
+ * a working loadout, and copies drift. Symlinks would avoid the duplication but
+ * need developer mode or an administrator on Windows, so the files are real and
+ * this check is what keeps them honest.
+ */
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repo = fileURLToPath(new URL('..', import.meta.url));
+const CANONICAL = 'skills';
+/** Skills that must also be registered at the repository root, and where. */
+const REGISTERED = ['kiln-setup-workspace'];
+const REGISTRIES = ['.claude/skills', '.agents/skills'];
+const SPEC_KEYS = new Set([
+  'name',
+  'description',
+  'license',
+  'compatibility',
+  'metadata',
+  'allowed-tools',
+]);
+
+const errors = [];
+
+/** Files under `dir`, relative to it, sorted, recursing into subdirectories. */
+async function tree(dir) {
+  const out = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await tree(full)).map((p) => join(entry.name, p)));
+    else out.push(entry.name);
+  }
+  return out.sort();
+}
+
+function frontmatter(text) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/u.exec(text);
+  if (!match) return null;
+  const fields = new Map();
+  for (const line of match[1].split(/\r?\n/u)) {
+    const kv = /^([A-Za-z-]+):\s*(.*)$/u.exec(line);
+    if (kv) fields.set(kv[1], kv[2]);
+  }
+  return fields;
+}
+
+/** The specification's own constraints, applied to one skill directory. */
+async function validate(label, dir, name) {
+  const file = join(dir, 'SKILL.md');
+  let text;
+  try {
+    text = await readFile(file, 'utf8');
+  } catch {
+    errors.push(`${label}: missing SKILL.md`);
+    return;
+  }
+  const fields = frontmatter(text);
+  if (!fields) {
+    errors.push(`${label}: SKILL.md has no YAML frontmatter`);
+    return;
+  }
+  const declared = fields.get('name');
+  const description = fields.get('description');
+  if (declared !== name) {
+    errors.push(`${label}: name is ${declared ?? '(absent)'} but must match the directory, ${name}`);
+  }
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/u.test(name) || name.length > 64) {
+    errors.push(`${label}: name must be 1-64 lowercase alphanumerics with single hyphens`);
+  }
+  if (!description) errors.push(`${label}: description is required`);
+  else if (description.length > 1024) {
+    errors.push(`${label}: description is ${description.length} characters, over the 1024 maximum`);
+  }
+  for (const key of fields.keys()) {
+    if (!SPEC_KEYS.has(key)) errors.push(`${label}: ${key} is not an Agent Skills frontmatter field`);
+  }
+  const lines = text.split(/\r?\n/u).length;
+  if (lines > 500) errors.push(`${label}: SKILL.md is ${lines} lines, over the recommended 500`);
+}
+
+const canonicalDir = join(repo, CANONICAL);
+const names = (await readdir(canonicalDir, { withFileTypes: true }))
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+if (names.length === 0) errors.push(`${CANONICAL}/ contains no skills`);
+for (const name of names) await validate(`${CANONICAL}/${name}`, join(canonicalDir, name), name);
+
+for (const registry of REGISTRIES) {
+  const dir = join(repo, registry);
+  try {
+    await stat(dir);
+  } catch {
+    errors.push(`${registry}/ is missing; a bare clone would register no skills there`);
+    continue;
+  }
+  const present = (await readdir(dir, { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+  const expected = [...REGISTERED].sort();
+  if (present.join(',') !== expected.join(',')) {
+    errors.push(`${registry}/ holds [${present.join(', ')}] but must hold exactly [${expected.join(', ')}]`);
+  }
+  for (const name of expected) {
+    if (!present.includes(name)) continue;
+    await validate(`${registry}/${name}`, join(dir, name), name);
+    const from = join(canonicalDir, name);
+    const to = join(dir, name);
+    const [a, b] = await Promise.all([tree(from), tree(to)]);
+    if (a.join('\n') !== b.join('\n')) {
+      errors.push(`${registry}/${name} has a different file list than ${CANONICAL}/${name}`);
+      continue;
+    }
+    for (const file of a) {
+      const [left, right] = await Promise.all([
+        readFile(join(from, file)),
+        readFile(join(to, file)),
+      ]);
+      if (!left.equals(right)) {
+        errors.push(
+          `${relative(repo, join(to, file))} differs from ${relative(repo, join(from, file))}; copy the maintained file over it`,
+        );
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+const mirrored = REGISTERED.length * REGISTRIES.length;
+console.log(
+  `Skills: ${names.length} conform to the Agent Skills specification; ${mirrored} registered copies are byte-identical.`,
+);

--- a/scripts/create-workspace.mjs
+++ b/scripts/create-workspace.mjs
@@ -10,6 +10,8 @@ const installation = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const quote = JSON.stringify;
 const hash = (value) => createHash('sha256').update(value).digest('hex');
 const harnesses = ['claude', 'codex', 'opencode', 'hermes', 'agy'];
+/** Where each harness family actually looks for skills, relative to the workspace. */
+const skillRegistries = ['.claude/skills', '.agents/skills'];
 const core = ['kiln-author-asset', 'kiln-refine-asset', 'kiln-qa-asset'];
 const optional = { compose: 'kiln-compose-scene', batch: 'kiln-batch-dispatch' };
 const inside = (parent, child) => { const rel = relative(parent, child); return !rel || (!isAbsolute(rel) && rel !== '..' && !rel.startsWith(`..${sep}`)); };
@@ -48,7 +50,11 @@ function managedFiles(root, runtime, harness, nodeExecutable) {
   }
   if (harness === 'opencode') files['opencode.json'] = quote({ $schema: 'https://opencode.ai/config.json', skills: { paths: [join(root, 'skills')] }, mcp: { kiln_workspace: { type: 'local', command: [mcp.command, server], environment: mcp.env, enabled: true } } });
   if (harness === 'hermes') {
-    files['.hermes/config.yaml'] = quote({ mcp_servers: { kiln_workspace: mcp } });
+    // Hermes scans project-local skills only inside a git checkout (nearest
+    // ancestor with .git), and a workspace is deliberately not one. `external_dirs`
+    // is unconditional, so it is what actually registers them here. YAML is a
+    // superset of JSON, so the JSON form below is valid config.
+    files['.hermes/config.yaml'] = quote({ mcp_servers: { kiln_workspace: mcp }, skills: { external_dirs: [join(root, '.agents', 'skills')] } });
     files['hermes.mjs'] = `import { spawn } from 'node:child_process';\nimport { dirname, join } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nconst root = dirname(fileURLToPath(import.meta.url));\nconst child = spawn('hermes', process.argv.slice(2), { cwd: root, stdio: 'inherit', windowsHide: true, env: { ...process.env, HERMES_HOME: join(root, '.hermes'), TERMINAL_CWD: root } });\nchild.on('error', (error) => { console.error(error.message); process.exitCode = 1; });\nchild.on('exit', (code) => { process.exitCode = code ?? 1; });\n`;
   }
   return { files, store, server };
@@ -58,7 +64,7 @@ const guide = `# Kiln asset workspace
 
 Use the kiln_workspace MCP server configured in this project to author and refine assets in this directory. Another server named kiln may use a different installation; do not substitute it silently. The engine is installed separately. Do not read its implementation or example collection to solve an asset task.
 
-- Read the relevant skill from this project's skills/ directory, not a global plugin copy. Use kiln_list_primitives on kiln_workspace for API signatures. If that server is unavailable, report the setup problem instead of using another installation.
+- This project's own skills are installed and registered for your harness; read the relevant one from here, never a global plugin copy. The maintained copies are in skills/, mirrored to .claude/skills/ and .agents/skills/ because harnesses scan different directories. Use kiln_list_primitives on kiln_workspace for API signatures. If that server is unavailable, report the setup problem instead of using another installation.
 - Import an existing file with node kiln.mjs source asset.kiln.js. It returns a programRef, normally a short immutable p_ handle. Copy it exactly; do not expand or shorten it.
 - For a new draft, pass code once to kiln_validate or kiln_render. Keep its programRef even if validation fails.
 - Use kiln_source with programRef and a literal query to read exact edit anchors. Follow nextOffset for more context.
@@ -151,10 +157,20 @@ export async function createWorkspace(directory, harness = 'claude', options = {
     await writeFile(join(stage, '.gitignore'), '.kiln/programs/\n.hermes/\n*.glb\n*.png\n');
     for (const name of ['AGENTS.md', 'CLAUDE.md']) await writeFile(join(stage, name), guide);
     for (const name of skills) await cp(join(runtime, 'skills', name), join(stage, 'skills', name), { recursive: true });
+    // Registration copies. No harness scans a bare `skills/`: Claude Code reads
+    // only `.claude/skills/`, while codex, opencode, hermes and agy read
+    // `.agents/skills/`. Without these the workspace has skill files that the
+    // agent can read only when told to, which is how it worked before. Copies
+    // rather than symlinks because those need developer mode or an
+    // administrator on Windows.
+    for (const registry of skillRegistries)
+      for (const name of skills)
+        await cp(join(runtime, 'skills', name), join(stage, registry, name), { recursive: true });
     manifest.skillHashes = await fileHashes(join(stage, 'skills'));
     await writeFile(join(stage, '.kiln/workspace.json'), quote(manifest));
-    const launch = harness === 'hermes' ? 'Run node hermes.mjs --ignore-rules. It uses a separate profile; authenticate in that profile or supply provider credentials through the environment.' : harness === 'agy' ? 'Run node agy.mjs from this directory. The launcher supplies the absolute project directory. For headless runs, use node agy.mjs --model MODEL --print \"Read AGENTS.md and the project skills. Use only kiln_workspace MCP tools. YOUR TASK.\". Print mode disables automatic slash-command/skill expansion to avoid automatic expansion of a global skill. Use absolute task-file paths in headless prompts and verify that tool calls use kiln_workspace; global configuration and authentication remain unchanged.' : `Open ${harness} in this directory.`;
-    await writeFile(join(stage, 'START.md'), `# Start making assets\n\n${launch} Accept the project/MCP trust prompts. Ask the agent to read AGENTS.md and create an asset. Kiln needs no separate model key.\n\nCore author/refine/QA skills are installed. Optional compose/batch skills are selected at setup with --skills compose,batch.\n\nKeep assets here and engine source outside. This separates task context, not operating-system permissions. User instructions and authentication can still apply.\n\nAfter relocating this workspace or the runtime, run node /current/kiln/scripts/create-workspace.mjs /absolute/workspace --repair. Repair updates generated runtime paths only and refuses edited configuration; it preserves skills, assets, and saved revisions.\n`);
+    const command = harness === 'hermes' ? 'node hermes.mjs --ignore-rules' : harness === 'agy' ? 'node agy.mjs' : harness;
+    const launch = harness === 'hermes' ? 'Hermes uses a separate profile; authenticate in that profile or supply provider credentials through the environment.' : harness === 'agy' ? 'The launcher supplies the absolute project directory. For headless runs, use node agy.mjs --model MODEL --print \"Read AGENTS.md and the project skills. Use only kiln_workspace MCP tools. YOUR TASK.\". Print mode disables automatic slash-command/skill expansion to avoid automatic expansion of a global skill. Use absolute task-file paths in headless prompts and verify that tool calls use kiln_workspace; global configuration and authentication remain unchanged.' : `This directory is configured for ${harness}.`;
+    await writeFile(join(stage, 'START.md'), `# Start making assets\n\n\`\`\`bash\ncd ${root}\n${command}\n\`\`\`\n\n${launch} Accept the project/MCP trust prompts. Ask the agent to read AGENTS.md and create an asset. Kiln needs no separate model key.\n\nCore author/refine/QA skills are installed and registered for this harness. Optional compose/batch skills are selected at setup with --skills compose,batch.\n\nKeep assets here and engine source outside. This separates task context, not operating-system permissions. User instructions and authentication can still apply.\n\nRun repair after anything that invalidates the generated absolute paths: moving this workspace, moving or reinstalling the runtime, or replacing the Node that setup recorded -- an nvm switch or uninstall does that, because the manifest pins the exact interpreter the preflight check validated.\n\n\`\`\`bash\nnode /current/kiln/scripts/create-workspace.mjs ${root} --repair\n\`\`\`\n\nRepair updates generated runtime paths only and refuses edited configuration; it preserves skills, assets, and saved revisions.\n`);
     if (exists) {
       // Windows cannot remove the caller's current directory, even when empty.
       // Move only staged entries and track them so a failed install rolls back.

--- a/skills/kiln-batch-dispatch/references/clean-room-evaluation.md
+++ b/skills/kiln-batch-dispatch/references/clean-room-evaluation.md
@@ -1,20 +1,8 @@
 # Clean-room evaluation
 
-With the Kiln package installed, create a fresh directory outside the engine checkout:
+Workspace creation, harness choice and verifying that the tools came up are covered by the `kiln-setup-workspace` skill; this file covers only what an evaluation adds on top. Create the workspace with `--skills batch` so this workflow is present in the candidate, and use a separate fresh workspace per candidate.
 
-```bash
-kiln-init /absolute/empty-workspace --harness opencode --skills batch
-```
-
-Supported harness names are `claude`, `codex`, `opencode`, `hermes`, and `agy`. Author, refine, and QA skills are installed by default; `--skills compose,batch` adds optional workflows. Read the generated project start instructions and run its local `node kiln.mjs` launcher.
-
-From an engine source checkout, the equivalent setup command is:
-
-```bash
-node scripts/create-workspace.mjs /absolute/empty-workspace --harness opencode --skills batch
-```
-
-The project contains its copied skills and their resources. Keep evaluation notes and output there; do not give the model the engine implementation or prior examples unless that is the comparison being tested.
+Keep evaluation notes and output in the workspace. Do not give the model the engine implementation or prior examples unless that is the comparison being tested.
 
 ## What isolation means
 

--- a/skills/kiln-setup-workspace/SKILL.md
+++ b/skills/kiln-setup-workspace/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: kiln-setup-workspace
+description: Create and verify a Kiln asset workspace for a chosen coding-agent harness. Use before authoring when the current directory is the engine repository, an empty folder, or any project without a working kiln_workspace server.
+license: MIT
+---
+
+# Set up a workspace for asset authoring
+
+This repository is the engine. Asset authoring happens in a separate workspace, and the two are different tasks with different tools. Establish which one is being asked before running anything.
+
+Authoring an asset needs a workspace. Changing the engine's own behaviour does not; read `AGENTS.md` at the repository root instead and stay in the checkout.
+
+Do not author assets inside the engine checkout. The authoring skills assume a workspace, and giving a model the engine implementation and the example collection alongside its task changes what it produces.
+
+## Create the workspace
+
+Choose an absolute path to an empty directory outside the checkout.
+
+```bash
+node scripts/create-workspace.mjs /absolute/empty-workspace --harness claude
+```
+
+From an installed package, the equivalent is `kiln-init /absolute/empty-workspace --harness claude`. Author, refine and QA skills are installed by default; `--skills compose,batch` adds the optional scene-composition and trial-dispatch workflows. Ask the user which harness they use rather than assuming; the choice writes different configuration and cannot be changed afterwards without a fresh workspace.
+
+| `--harness` | Launch from the workspace |
+| --- | --- |
+| `claude` | `claude` |
+| `codex` | `codex` |
+| `opencode` | `opencode` |
+| `agy` | `node agy.mjs` |
+| `hermes` | `node hermes.mjs --ignore-rules` |
+
+Antigravity and Hermes get a generated launcher because each needs arguments or a separate profile that the bare command does not supply. Hermes authenticates in its own profile; setup copies no credentials.
+
+## Verify the loadout before authoring
+
+Accept the project and MCP trust prompts, then confirm the server is actually live rather than assuming it from configuration. Call `kiln_list_primitives` on `kiln_workspace` with `capabilities: true`; it returns the runtime, source, export and camera contract and proves the tools resolved. A server named `kiln` from a global installation is a different thing. Do not substitute it silently; report the setup problem instead.
+
+Confirm the installed skills are readable at `skills/` in the workspace, and read the relevant one from there rather than a global copy. Whether the harness also registers them natively depends on the harness.
+
+## Relocation and repair
+
+Moving the workspace or the engine installation breaks the generated absolute paths, and so does replacing the Node that setup validated.
+
+```bash
+node /current/kiln/scripts/create-workspace.mjs /absolute/empty-workspace --repair
+```
+
+Repair rewrites generated runtime paths only. It preserves copied skills, saved revisions and assets, refuses configuration that was edited by hand, and does not upgrade the skills. To evaluate a different engine version, create a fresh workspace from that version so instructions and tools match.
+
+## What isolation means
+
+A separate workspace limits task context. It is not an operating-system sandbox, and it is not a git repository. User-level instructions, memory, authentication and filesystem permissions still apply. For comparing harnesses or models, read `skills/kiln-batch-dispatch/references/clean-room-evaluation.md` in the engine checkout, which covers recording inherited context and reporting trials.

--- a/src/__tests__/mcp-bundle.test.ts
+++ b/src/__tests__/mcp-bundle.test.ts
@@ -128,6 +128,13 @@ describe('harness manifests', () => {
    *
    * A bare `mcp.json` is read by neither harness, which is why it no longer
    * exists.
+   *
+   * Root `.mcp.json` is a third case with a different job, asserted separately
+   * below. It is not a plugin manifest: Claude Code reads it as project-scoped
+   * configuration in a plain `git clone`, where no plugin variable is defined at
+   * all. It once carried `${PLUGIN_ROOT}`, which only Antigravity intends to
+   * expand, so a fresh clone opened onto a `kiln` server that could not start --
+   * no tools, on first contact, before the reader had done anything wrong.
    */
   const cases = [
     { file: '.claude-plugin/plugin.json', variable: 'CLAUDE_PLUGIN_ROOT' },
@@ -147,4 +154,25 @@ describe('harness manifests', () => {
       expect(kiln!.args).toEqual([`\${${variable}}/dist/mcp-server.mjs`]);
     });
   }
+
+  it('root .mcp.json resolves in a bare clone, with no plugin variable', async () => {
+    const raw = JSON.parse(await readFile(join(REPO, '.mcp.json'), 'utf8')) as {
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    };
+    const kiln = raw.mcpServers['kiln'];
+    expect(kiln).toBeDefined();
+    expect(kiln!.command).toBe('node');
+    // Claude Code expands `${VAR:-default}` in project-scoped config, so the
+    // default is what makes this resolve when nothing sets the variable.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the harness expands this, so the assertion must hold the literal text
+    expect(kiln!.args).toEqual(['${CLAUDE_PROJECT_DIR:-.}/dist/mcp-server.mjs']);
+    // The regression itself: no plugin-root variable belongs in this file,
+    // because no plugin context defines one when a clone is opened directly.
+    for (const arg of kiln!.args) {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal tokens, not interpolation
+      expect(arg).not.toContain('${PLUGIN_ROOT}');
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal tokens, not interpolation
+      expect(arg).not.toContain('${CLAUDE_PLUGIN_ROOT}');
+    }
+  });
 });

--- a/src/__tests__/mcp-instructions.test.ts
+++ b/src/__tests__/mcp-instructions.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The `instructions` field is the only orientation channel that reaches every
+ * install shape. A user who configures the server by hand and opens an empty
+ * folder has no AGENTS.md, no CLAUDE.md and no registered skills; the skills
+ * still ship beside the server, so this text is what tells them so.
+ *
+ * It names its skills as literal strings, which is what makes it worth testing:
+ * a renamed or removed skill directory would leave the server advertising a
+ * path that does not exist, and nothing else would notice.
+ */
+import { describe, expect, it } from 'bun:test';
+import { stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MCP_SERVER_INSTRUCTIONS } from '../mcp-server';
+
+const repo = fileURLToPath(new URL('../..', import.meta.url));
+
+describe('MCP server instructions', () => {
+  it('names only skills that exist on disk', async () => {
+    const named = [...new Set(MCP_SERVER_INSTRUCTIONS.match(/kiln-[a-z-]+/g) ?? [])];
+    expect(named.length).toBeGreaterThan(0);
+    for (const name of named) {
+      const skill = join(repo, 'skills', name, 'SKILL.md');
+      expect((await stat(skill)).isFile()).toBe(true);
+    }
+  });
+
+  it('carries the contract an ad-hoc client cannot learn anywhere else', () => {
+    // Re-sending whole programs instead of reusing a ref is the failure this
+    // text exists to prevent, and viewFidelity is what stops a CPU image being
+    // read as material evidence.
+    expect(MCP_SERVER_INSTRUCTIONS).toContain('programRef');
+    expect(MCP_SERVER_INSTRUCTIONS).toContain('viewFidelity');
+    expect(MCP_SERVER_INSTRUCTIONS).toContain('kiln_list_primitives');
+  });
+
+  it('offers registration without instructing an unrequested write', () => {
+    expect(MCP_SERVER_INSTRUCTIONS).toContain('.claude/skills/');
+    expect(MCP_SERVER_INSTRUCTIONS).toContain('.agents/skills/');
+    // Two constraints on the wording: the copy is proposed, never performed
+    // unasked, and it does not take effect until the next session.
+    expect(MCP_SERVER_INSTRUCTIONS).toContain('Ask before writing');
+    expect(MCP_SERVER_INSTRUCTIONS).toContain('new session');
+  });
+
+  it('stays an index rather than the skill bodies', () => {
+    // The five authoring bodies are about 2,700 tokens. Inlining them would be
+    // paid at every session start by every client, which is what the Agent
+    // Skills progressive-disclosure model exists to avoid.
+    const approxTokens = MCP_SERVER_INSTRUCTIONS.split(/\s+/u).length * 1.3;
+    expect(approxTokens).toBeLessThan(700);
+  });
+});

--- a/src/__tests__/mcp-payload.test.ts
+++ b/src/__tests__/mcp-payload.test.ts
@@ -154,7 +154,11 @@ describe('always-on context cost', () => {
 
   it('skill discovery stays within the context budget', async () => {
     const { total, count } = await frontMatterChars();
-    expect(count).toBe(5);
+    // Six since kiln-setup-workspace was added: the authoring five plus the
+    // repo-side setup skill, which is the one an agent in a bare clone needs
+    // before any of the others apply. A hard count keeps adding a skill a
+    // deliberate act, because every one of these is paid at session start.
+    expect(count).toBe(6);
     // Front matter is a name and one sentence. Anything much past this is a
     // skill trying to teach from the index instead of from its body.
     expect(total).toBeLessThan(2048);

--- a/src/evaluator/authoring-diagnostic.ts
+++ b/src/evaluator/authoring-diagnostic.ts
@@ -1,7 +1,13 @@
 /** Closed, engine-owned repair hints. Never serialize exception messages or stacks. */
 export type AuthoringDiagnostic = 'UNBOUND_VARIABLE' | 'GEAR_RADII_ORDER' | 'ROUNDED_BOX_RADIUS';
+// Names no identifier on purpose. The identifier is only available from the
+// sandboxed exception message, and this module's contract is that no captured
+// identifier, path, message or stack crosses that boundary. Pointing at the
+// discovery tool is engine-owned text, so it costs nothing to include and is
+// the actionable half: an undeclared name here is usually a helper that does
+// not exist rather than a typo in a local.
 export const UNBOUND_VARIABLE_ADVICE =
-  'Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying.';
+  'Check variable spelling and scope: generated code used an undeclared variable. Read the current source and check declarations before retrying. If it was meant to be a Kiln helper, call kiln_list_primitives to confirm the exact name and signature; the sandbox exposes only those globals.';
 export const GEAR_RADII_ORDER_ADVICE =
   'gearGeo requires boreRadius < rootRadius < tipRadius; specify rootRadius when changing tipRadius. Omitted radii keep their absolute defaults.';
 export const ROUNDED_BOX_RADIUS_ADVICE =

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9,6 +9,7 @@ import { localAssetLibrary } from './assets-node';
 import { readAssetResource, type AssetLink } from './assets-resources';
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { fileURLToPath } from 'node:url';
 
 import {
   createKilnProgramToolRegistry,
@@ -23,6 +24,45 @@ import { createPackagedLocalToolContext } from './local-runtime';
 /** Server identity reported in the MCP handshake. */
 export const MCP_SERVER_NAME = 'kiln';
 export const MCP_SERVER_VERSION = '0.6.0';
+
+/**
+ * Absolute path to the skills that ship beside this server. Both entry shapes
+ * resolve correctly: `dist/mcp-server.mjs` and `src/mcp-server.ts` each sit one
+ * level below the installation root, where `skills/` lives. URL arithmetic only,
+ * so nothing touches the filesystem at module load.
+ */
+const packagedSkillsDir = fileURLToPath(new URL('../skills', import.meta.url));
+
+/**
+ * The spec's optional `instructions` field, returned in the initialize result.
+ *
+ * This is the only orientation channel that survives every install shape. A
+ * user who configures the server by hand and opens an empty folder has no
+ * AGENTS.md, no CLAUDE.md and no registered skills -- but the skills do ship
+ * beside the server, so the useful thing to say is that they exist and where.
+ *
+ * Deliberately an index and a pointer rather than the skill bodies themselves.
+ * The bodies are about 2,700 tokens and would be paid at every session start by
+ * every client, which is exactly what the Agent Skills progressive-disclosure
+ * model exists to avoid: names and descriptions up front, bodies on activation.
+ */
+export const MCP_SERVER_INSTRUCTIONS = `Kiln turns JavaScript you write into GLB 3D assets and returns rendered views for review.
+
+Work by reference. Send a program once to kiln_validate or kiln_render; the result carries a programRef. Keep it exactly as returned, including a short p_ handle, and use it for every later view and edit. kiln_source with that ref and a literal query returns exact edit anchors, and kiln_edit with that ref plus edits returns a new ref and renders by default. Do not resend a whole program to change part of it.
+
+Call kiln_list_primitives before writing code to get exact helper signatures, with capabilities: true for the runtime, source, export and camera contract. Read viewFidelity in any render result before judging materials: a geometry-flat CPU image is evidence about shape, not about material.
+
+Detailed workflows ship beside this server as Agent Skills, one directory each under ${packagedSkillsDir}:
+- kiln-setup-workspace: create a managed workspace for authoring, and verify its tools came up
+- kiln-author-asset: write a new asset and export a GLB
+- kiln-refine-asset: change a saved asset through revisions
+- kiln-qa-asset: verify geometry, export fidelity, and behaviour in the destination project
+- kiln-compose-scene: arrange several existing GLB assets into a scene
+- kiln-batch-dispatch: run comparable trials across harnesses or models
+
+Read the one matching the task before authoring; each names its own reference files.
+
+Most harnesses register skills only from their own directories, so these may not appear as registered skills where you are. If the user wants them registered, offer to copy the relevant directories into .claude/skills/ or .agents/skills/ in their project. Ask before writing, and say that registration takes effect in a new session.`;
 
 /** One MCP content block. Mirrors the SDK's `CallToolResult['content']` element. */
 type ContentBlock =
@@ -115,10 +155,13 @@ export async function runTool(def: KilnToolDef, args: unknown): Promise<KilnTool
 
 /** Build the server, registering every def from the registry. */
 export function createKilnMcpServer(context: KilnToolContext = {}): McpServer {
-  const server = new McpServer({
-    name: MCP_SERVER_NAME,
-    version: MCP_SERVER_VERSION,
-  });
+  const server = new McpServer(
+    {
+      name: MCP_SERVER_NAME,
+      version: MCP_SERVER_VERSION,
+    },
+    { instructions: MCP_SERVER_INSTRUCTIONS },
+  );
   server.registerResource(
     'kiln-asset-viewer',
     KILN_ASSET_WIDGET_URI,

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -18,6 +18,7 @@ import { createCachedEvaluatorPort, MemoryBuildCache, type BuildCache } from '..
 import * as THREE from 'three';
 
 import { validate } from '../validation';
+import { evaluatorOutcomeMessage } from '../evaluator/protocol';
 import { inspectSceneStructure, renderSceneToGLB, type RenderResult } from '../render';
 import { listPrimitives, type PrimitiveSpec } from '../list-primitives';
 import type { AssetCategory, AssetIntentV1 } from '../contracts';
@@ -845,7 +846,20 @@ export interface KilnRenderMetrics {
   ok: boolean;
   tris?: number;
   meshes?: number;
+  /**
+   * Material slots on the re-imported review scene, which is one per mesh. The
+   * scene measured here has been round-tripped through GLB, so authored sharing
+   * no longer survives as object identity and this can never disagree with
+   * `meshes`. Kept for output-shape stability; judge material sprawl from
+   * `distinctMaterials`.
+   */
   materials?: number;
+  /**
+   * Distinct materials in the exported GLB, measured post-dedup. This is the
+   * number that actually falls when parts share a material, and the one the
+   * instanceability grade is driven by.
+   */
+  distinctMaterials?: number;
   bbox?: { min: number[]; max: number[]; size: number[] };
   /** Mesh touching the lowest world point — ground-contact attribution. When
    *  bbox.min[1] dips below 0, this names the buried part so the agent can
@@ -918,6 +932,27 @@ function collectSceneMetrics(root: THREE.Object3D): SceneMetrics {
  * Execute Kiln code, render it to an in-memory GLB, and report metrics.
  * Never writes files; never throws — failures come back as { ok:false, error }.
  */
+/**
+ * The evaluator's rejection message is deliberately opaque, because nothing
+ * from a sandboxed exception may cross that boundary -- not a message, not a
+ * stack, not an identifier. A syntax error is the one exception worth making,
+ * and it costs nothing: acorn parses host-side before any generated code runs,
+ * which is exactly why `kiln_validate` can already report its line and column.
+ * Repeating that parse here leaks nothing new and turns an unactionable
+ * rejection into a position, without a second round-trip through validate.
+ */
+function withSyntaxDetail(message: string, code: string): string {
+  if (!message.startsWith(evaluatorOutcomeMessage('EXECUTION_REJECTED'))) return message;
+  let syntax: string | undefined;
+  try {
+    syntax = validate(code).errors.find((error) => error.startsWith('Syntax error:'));
+  } catch {
+    // A diagnostic must never turn a handled failure into an unhandled one.
+    return message;
+  }
+  return syntax ? `${message} ${syntax}` : message;
+}
+
 async function runRender(
   input: z.infer<typeof renderInput>,
   context: KilnToolContext,
@@ -945,6 +980,9 @@ async function runRender(
       tris: rendered.tris,
       meshes: metrics.meshes,
       materials: metrics.materials,
+      ...(rendered.meta.instanceability
+        ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials }
+        : {}),
       bbox: metrics.bbox,
       lowestPart: metrics.lowestPart,
       ...(instanceability
@@ -961,7 +999,7 @@ async function runRender(
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: [],
     };
   }
@@ -1015,7 +1053,7 @@ async function runScreenshot(
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: [],
     };
   }
@@ -1044,7 +1082,20 @@ export interface KilnRenderViewsResult {
   ok: boolean;
   tris?: number;
   meshes?: number;
+  /**
+   * Material slots on the re-imported review scene, which is one per mesh. The
+   * scene measured here has been round-tripped through GLB, so authored sharing
+   * no longer survives as object identity and this can never disagree with
+   * `meshes`. Kept for output-shape stability; judge material sprawl from
+   * `distinctMaterials`.
+   */
   materials?: number;
+  /**
+   * Distinct materials in the exported GLB, measured post-dedup. This is the
+   * number that actually falls when parts share a material, and the one the
+   * instanceability grade is driven by.
+   */
+  distinctMaterials?: number;
   bbox?: { min: number[]; max: number[]; size: number[] };
   lowestPart?: { name: string; y: number };
   /** Post-dedup instanceability grade (informational): how cheap to render at scale. */
@@ -1111,6 +1162,9 @@ async function runRenderViews(
         tris: rendered.tris,
         meshes: metrics.meshes,
         materials: metrics.materials,
+        ...(rendered.meta.instanceability
+          ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials }
+          : {}),
         bbox: metrics.bbox,
         lowestPart: metrics.lowestPart,
         views: grid.views,
@@ -1261,6 +1315,9 @@ async function runRenderViews(
       tris: rendered.tris,
       meshes: metrics.meshes,
       materials: metrics.materials,
+      ...(rendered.meta.instanceability
+        ? { distinctMaterials: rendered.meta.instanceability.metrics.uniqueMaterials }
+        : {}),
       bbox: metrics.bbox,
       lowestPart: metrics.lowestPart,
       ...(rendered.meta.instanceability
@@ -1286,7 +1343,7 @@ async function runRenderViews(
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: withSyntaxDetail(err instanceof Error ? err.message : String(err), input.code),
       warnings: [],
     };
   }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -24,6 +24,7 @@
 
 import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
+import { listPrimitives } from './list-primitives';
 
 // =============================================================================
 // Types
@@ -339,8 +340,130 @@ export function validate(code: string, _opts: { category?: string } = {}): Valid
     });
   }
 
+  warnings.push(...unknownHelperWarnings(ast));
+
   return toResult(issues, warnings, analysis.estimatedTris);
 }
+
+/**
+ * Identifiers that are called but neither declared in the program nor exposed
+ * by the sandbox. Calling one throws the moment the program runs, so reporting
+ * it before execution is strictly better than discovering it from a render.
+ *
+ * This is also the only place the name can be reported at all. The isolated
+ * evaluator deliberately lets no identifier, message or stack cross its
+ * boundary, so `kiln_render` can say that some variable was undeclared but
+ * never which one. This parse happens host-side, before anything executes.
+ *
+ * Reported as a warning rather than an error, and the declaration set below
+ * deliberately over-approximates: every binding anywhere in the program counts
+ * as in scope, so a shadowed or conditionally declared name is never falsely
+ * flagged. The cost is that some genuinely unbound names go unreported, which
+ * is the safe direction for a check that would otherwise reject valid source.
+ */
+function unknownHelperWarnings(ast: acorn.Program): ValidationIssue[] {
+  const declared = new Set<string>();
+  const bind = (node: unknown): void => {
+    const target = node as { type?: string; [key: string]: unknown } | null;
+    if (!target?.type) return;
+    if (target.type === 'Identifier') declared.add(target['name'] as string);
+    else if (target.type === 'ObjectPattern')
+      for (const prop of target['properties'] as { value?: unknown; argument?: unknown }[])
+        bind(prop.value ?? prop.argument);
+    else if (target.type === 'ArrayPattern')
+      for (const el of target['elements'] as unknown[]) bind(el);
+    else if (target.type === 'AssignmentPattern') bind(target['left']);
+    else if (target.type === 'RestElement') bind(target['argument']);
+  };
+  const params = (node: unknown): void => {
+    const fn = node as { id?: { name?: string }; params?: unknown[] };
+    if (fn.id?.name) declared.add(fn.id.name);
+    for (const param of fn.params ?? []) bind(param);
+  };
+  walk.simple(ast, {
+    VariableDeclarator(node) {
+      bind((node as unknown as { id: unknown }).id);
+    },
+    FunctionDeclaration(node) {
+      params(node);
+    },
+    FunctionExpression(node) {
+      params(node);
+    },
+    ArrowFunctionExpression(node) {
+      params(node);
+    },
+    ClassDeclaration(node) {
+      params(node);
+    },
+    CatchClause(node) {
+      bind((node as unknown as { param: unknown }).param);
+    },
+  });
+
+  const seen = new Map<string, number | undefined>();
+  walk.simple(ast, {
+    CallExpression(node) {
+      const callee = (node as unknown as { callee?: { type?: string; name?: string } }).callee;
+      if (callee?.type !== 'Identifier' || !callee.name) return;
+      const name = callee.name;
+      if (declared.has(name) || SANDBOX_CALLABLES.has(name) || seen.has(name)) return;
+      seen.set(name, (node as unknown as { loc?: { start?: { line?: number } } }).loc?.start?.line);
+    },
+  });
+
+  return [...seen].map(([name, line]) => ({
+    code: 'UNKNOWN_HELPER',
+    message: `${name}() is not declared in this program and is not a Kiln sandbox global; the build will fail when it runs.`,
+    fixHint:
+      'Call kiln_list_primitives to confirm the helper name and signature, or declare the function in this program.',
+    ...(line === undefined ? {} : { line }),
+  }));
+}
+
+/**
+ * Everything a program may legitimately call by bare name: the sandbox catalog,
+ * which a bidirectional test keeps in step with `buildSandboxGlobals()`, plus
+ * the JavaScript built-ins the sandbox does not remove. The catalog is imported
+ * rather than the sandbox itself so this module's dependency graph stays free of
+ * three.js.
+ */
+const SANDBOX_CALLABLES: ReadonlySet<string> = new Set([
+  ...listPrimitives().map((primitive) => primitive.name),
+  'Array',
+  'BigInt',
+  'Boolean',
+  'Error',
+  'Float32Array',
+  'Float64Array',
+  'Int16Array',
+  'Int32Array',
+  'Int8Array',
+  'Map',
+  'Number',
+  'Object',
+  'Promise',
+  'Proxy',
+  'RangeError',
+  'Reflect',
+  'RegExp',
+  'Set',
+  'String',
+  'Symbol',
+  'TypeError',
+  'Uint16Array',
+  'Uint32Array',
+  'Uint8Array',
+  'WeakMap',
+  'WeakSet',
+  'decodeURIComponent',
+  'encodeURIComponent',
+  'isFinite',
+  'isNaN',
+  'parseFloat',
+  'parseInt',
+  'structuredClone',
+]);
 
 // Backward-compat alias.
 export const validateKilnCode = validate;


### PR DESCRIPTION
A `git clone` of this repository opened onto a `kiln` MCP server that could not start, and skills registered for one harness out of five. This fixes both, plus the Phase 4 error-legibility and metric items.

## The first-contact bug

Root `.mcp.json` used `${PLUGIN_ROOT}` — which is **Antigravity's** variable — while its actual consumers are Claude Code project configuration and the Codex plugin, neither of which defines it. A fresh clone therefore showed a failing MCP server before the reader had done anything wrong: no tools, no skills.

It now uses `${CLAUDE_PROJECT_DIR:-.}`, the documented project-scoped idiom, verified to launch with the variable both set and unset. The Codex manifest carries its server inline with a plugin-root-relative `cwd` rather than sharing that file. `mcp_config.json` is deliberately untouched: its use of `${PLUGIN_ROOT}` is intentional and documented in `mcp-bundle.test.ts`.

## Cross-harness skills

Read from each vendor's own documentation:

| Harness | Project-local skill paths |
| --- | --- |
| claude | `.claude/skills/` only |
| codex | `.agents/skills/`, cwd up to repo root |
| opencode | `.opencode/`, `.claude/`, `.agents/skills/` |
| hermes | `.hermes/skills/`, `.agents/skills/` — git checkout required |
| agy | `.agents/skills/` |

The Agent Skills standard specifies the skill *format* and deliberately leaves discovery to implementations, which is why no single directory serves all five. So:

- A new repo-side `kiln-setup-workspace` skill, committed to both `.claude/skills/` and `.agents/skills/`, so a bare clone can learn that workspaces exist at all — `AGENTS.md` previously never mentioned them.
- Generated workspaces get the authoring skills in both directories.
- opencode's `skills.paths` is **kept**, and a hermes `skills.external_dirs` added, because both gate convention discovery on a git checkout and a clean room deliberately is not one.
- Copies, not symlinks: symlinks need developer mode or an administrator on Windows.
- `check:skills` enforces byte-identity against the maintained `skills/` and Agent Skills conformance, wired into CI and negative-tested against three failure modes.

Only the setup skill is registered at the root. Registering the authoring skills there would tell an agent sitting in the engine checkout to author assets in it, which their own guidance forbids.

## MCP `instructions`

Was empty. It is the only orientation channel that survives every install shape — including a hand-configured server opened in an empty folder, which has no `AGENTS.md`, no `CLAUDE.md`, and no registered skills. It now carries the tool surface, the `programRef` contract, and a skill index: ~354 tokens, an index and a pointer rather than the ~2,700 the bodies would cost at every session start. It offers to register the skills and asks before writing.

## Error legibility, bounded by the sandbox contract

`src/evaluator/authoring-diagnostic.ts` exists so that no identifier, path, message, or stack crosses out of the isolated evaluator, so two of these are deliberately partial:

- `kiln_render` now surfaces the acorn syntax position `kiln_validate` already reported. Safe because that parse is host-side, before generated code runs.
- The unknown-helper advice points at `kiln_list_primitives` but still does not name the identifier, because only the sandboxed exception carries it.
- `kiln_validate` names it instead, from the same host-side parse — **zero false positives across all 86 example programs**, and local functions and arrow consts are not flagged.

## `materials` could never disagree with `meshes`

Root cause proven, and not what was first suspected: `loadEvaluatedReviewScene` renders to GLB and re-imports the scene, so authored material sharing no longer survives as object identity. `materials` is unchanged and now documented for what it actually measures; `distinctMaterials` reports the post-dedup GLB figure that falls when parts share a material — 20 parts sharing one material now reports `distinctMaterials: 1`.

## Verification

1810 pass, 0 fail, 2 skip (baseline 1805, +5 tests here). `typecheck`, `lint`, `check:toolchain` and `check:skills` all exit 0, lint at its unchanged 14-warning / 11-info baseline. `build:runtime` byte-identical across consecutive runs.

## Known: CI may redden on `asset-cli.test.ts`

Pre-existing and unrelated to this change — it fails on a pristine `9b0c610` at roughly the same rate. Diagnosed while confirming CI readiness and recorded as Phase 8 in the plan: **`kiln save` exits 0 and prints nothing under Bun** (`node dist/cli.mjs` → 2,061 bytes; `bun dist/cli.mjs` → 0 bytes). The test spawns `process.execPath`, which under `bun test` is Bun, so it parses an empty string. Users are unaffected — every shipped launcher and manifest invokes `node` — but contributors are, since `AGENTS.md` documents Bun. Deliberately not fixed here: different subsystem, and mixing it in would obscure this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
