### PR TITLE
fix: honor isolate on the GPU path, and steer sessions to the loop

### DIFF
--- a/.agents/skills/kiln-setup-workspace/SKILL.md
+++ b/.agents/skills/kiln-setup-workspace/SKILL.md
@@ -32,11 +32,31 @@ From an installed package, the equivalent is `kiln-init /absolute/empty-workspac
 
 Antigravity and Hermes get a generated launcher because each needs arguments or a separate profile that the bare command does not supply. Hermes authenticates in its own profile; setup copies no credentials.
 
+## Start the GPU render service
+
+Setup asks for render mode `auto`: a GPU service when one answers on port 8000, CPU views otherwise. CPU views are honest about silhouette, proportion and contact and say nothing about colour, metalness or roughness, so without the service no render can confirm a material.
+
+Offer to start it before launching the harness. It lives in the engine installation rather than the workspace, and it is a separate package with a native dependency, so its install is its own step and is not covered by installing the engine.
+
+```bash
+cd render-service && npm install && npm start
+```
+
+Leave it running in its own terminal. The CLI picks up a service started at any time on its next call, while an MCP session resolves the service once at startup -- so starting it first is what gets in-loop renders material-faithful without a restart. If the machine has no usable GPU, report that and continue on CPU views; it is a limit to state, not a setup failure.
+
 ## Verify the loadout before authoring
 
 Accept the project and MCP trust prompts, then confirm the server is actually live rather than assuming it from configuration. Call `kiln_list_primitives` on `kiln_workspace` with `capabilities: true`; it returns the runtime, source, export and camera contract and proves the tools resolved. A server named `kiln` from a global installation is a different thing. Do not substitute it silently; report the setup problem instead.
 
 Confirm the installed skills are readable at `skills/` in the workspace, and read the relevant one from there rather than a global copy. Whether the harness also registers them natively depends on the harness.
+
+Report the rest of the session's loadout at the same time. Skills and MCP servers from user-level configuration load here too, and an authoring session carrying a dozen unrelated skills spends context and invites the wrong tool. List whatever is registered that has nothing to do with this task and let the user decide whether to narrow it. Do not change their global configuration.
+
+## Wiring a workspace by hand
+
+`--harness` covers claude, codex, opencode, hermes and agy. For any other harness, or an engine installed as a package elsewhere, assemble the same loadout in an empty directory: register the installation's `dist/mcp-server.mjs` as a stdio MCP server named `kiln_workspace`, give it `KILN_PROGRAM_STORE` pointing at `.kiln/programs` inside that directory plus `KILN_RENDER=auto`, and copy the skills you need from `skills/` into both `.claude/skills/` and `.agents/skills/` there.
+
+A hand-wired directory carries no manifest, so it gets no runtime preflight and `--repair` cannot correct its paths later. Prefer the generated workspace wherever the harness is supported, and tell the user which of the two they have.
 
 ## Relocation and repair
 

--- a/.claude/skills/kiln-setup-workspace/SKILL.md
+++ b/.claude/skills/kiln-setup-workspace/SKILL.md
@@ -32,11 +32,31 @@ From an installed package, the equivalent is `kiln-init /absolute/empty-workspac
 
 Antigravity and Hermes get a generated launcher because each needs arguments or a separate profile that the bare command does not supply. Hermes authenticates in its own profile; setup copies no credentials.
 
+## Start the GPU render service
+
+Setup asks for render mode `auto`: a GPU service when one answers on port 8000, CPU views otherwise. CPU views are honest about silhouette, proportion and contact and say nothing about colour, metalness or roughness, so without the service no render can confirm a material.
+
+Offer to start it before launching the harness. It lives in the engine installation rather than the workspace, and it is a separate package with a native dependency, so its install is its own step and is not covered by installing the engine.
+
+```bash
+cd render-service && npm install && npm start
+```
+
+Leave it running in its own terminal. The CLI picks up a service started at any time on its next call, while an MCP session resolves the service once at startup -- so starting it first is what gets in-loop renders material-faithful without a restart. If the machine has no usable GPU, report that and continue on CPU views; it is a limit to state, not a setup failure.
+
 ## Verify the loadout before authoring
 
 Accept the project and MCP trust prompts, then confirm the server is actually live rather than assuming it from configuration. Call `kiln_list_primitives` on `kiln_workspace` with `capabilities: true`; it returns the runtime, source, export and camera contract and proves the tools resolved. A server named `kiln` from a global installation is a different thing. Do not substitute it silently; report the setup problem instead.
 
 Confirm the installed skills are readable at `skills/` in the workspace, and read the relevant one from there rather than a global copy. Whether the harness also registers them natively depends on the harness.
+
+Report the rest of the session's loadout at the same time. Skills and MCP servers from user-level configuration load here too, and an authoring session carrying a dozen unrelated skills spends context and invites the wrong tool. List whatever is registered that has nothing to do with this task and let the user decide whether to narrow it. Do not change their global configuration.
+
+## Wiring a workspace by hand
+
+`--harness` covers claude, codex, opencode, hermes and agy. For any other harness, or an engine installed as a package elsewhere, assemble the same loadout in an empty directory: register the installation's `dist/mcp-server.mjs` as a stdio MCP server named `kiln_workspace`, give it `KILN_PROGRAM_STORE` pointing at `.kiln/programs` inside that directory plus `KILN_RENDER=auto`, and copy the skills you need from `skills/` into both `.claude/skills/` and `.agents/skills/` there.
+
+A hand-wired directory carries no manifest, so it gets no runtime preflight and `--repair` cannot correct its paths later. Prefer the generated workspace wherever the harness is supported, and tell the user which of the two they have.
 
 ## Relocation and repair
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## Usable from a bare clone by any harness; isolate honored on GPU — 2026-09-10
+
+- A bare clone is now usable by claude, codex, opencode, hermes and agy. The root
+  `.mcp.json` pointed at `${PLUGIN_ROOT}`, which only Antigravity defines, so the
+  server failed to start with MODULE_NOT_FOUND in every other host; it now uses
+  `${CLAUDE_PROJECT_DIR:-.}`, which resolves whether or not the variable is set.
+  `CLAUDE.md` imports `AGENTS.md` rather than duplicating it, and the
+  `kiln-setup-workspace` skill is registered at `.claude/skills/` and
+  `.agents/skills/` so a clone opened for an asset task is told to build a
+  workspace instead of authoring in the engine checkout.
+- `visibility: 'isolate'` and the legacy `isolate: true` were silently ignored
+  whenever a GPU service was attached. Both hide geometry by clearing
+  `mesh.visible`; the CPU rasterizer culls on that flag, but glTF carries no
+  per-mesh visibility, so the derivative GLB shipped the hidden meshes and the
+  service drew them. `kiln_inspect` was reporting "nothing in this image occludes
+  it" about images where everything still did. The derivative serialization now
+  prunes hidden meshes from a copy, leaving the caller's scene untouched. The
+  only previous test framed a single-mesh scene, where isolation cannot change
+  the image.
+- The generated workspace guide is organised around the authoring loop rather
+  than a flat tool list, and presents the MCP server and `node kiln.mjs` as equal
+  surfaces that may be mixed, naming the two things that actually differ: where
+  the rendered image lands, and that a CPU view is not material evidence. It also
+  names the GPU render service, resolving the engine path through
+  `.kiln/workspace.json` so `--repair` keeps it accurate, and asks the session to
+  report skills and MCP servers it inherited from user-level configuration.
+- `START.md` printed a literal `/current/kiln/` in its repair command; it now
+  prints the recorded installation path plus how to recover if that moved.
+
 ## Smaller clone; gallery images served from R2 — 2026-09-10
 
 - Gallery renders and launch video are no longer carried in git history. A clone

--- a/dist/agent-run.mjs
+++ b/dist/agent-run.mjs
@@ -28661,6 +28661,24 @@ async function renderDerivativeCell(input, context) {
       mesh.material = Array.isArray(mesh.material) ? mesh.material.map(prepare) : prepare(mesh.material);
     });
   }
+  let hasHidden = false;
+  derivativeRoot.traverse((node) => {
+    const mesh = node;
+    if (mesh.isMesh && mesh.visible === false)
+      hasHidden = true;
+  });
+  if (hasHidden) {
+    if (derivativeRoot === input.root)
+      derivativeRoot = derivativeRoot.clone(true);
+    const drop = [];
+    derivativeRoot.traverse((node) => {
+      const mesh = node;
+      if (mesh.isMesh && mesh.visible === false)
+        drop.push(node);
+    });
+    for (const node of drop)
+      node.removeFromParent();
+  }
   const rendered = await renderSceneToGLB(derivativeRoot, {
     derivative: true,
     ...trustedCategory(context) ? { category: trustedCategory(context) } : {},

--- a/dist/build.json
+++ b/dist/build.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "entries": {
     "mcp": {
-      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
+      "identity": "sha256:eb5d210afab12a40858499e43f506e45de70a30cbd3ad6359c2719f9984e9d96",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
+      "sourceHash": "01118f4cc332bae8b434ad341e5b779c269924c9915e4681b833159cfa757f2b",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",
@@ -27,13 +27,13 @@
       },
       "target": "node",
       "file": "mcp-server.mjs",
-      "bundleHash": "sha256:addada60e499bc4394c047ec3c04065c3c9d068539ecdc9b2007c177baac350f"
+      "bundleHash": "sha256:d3e0c45fdf10b553dbef69024deb044f9c08ba45b517aec784dc8c4a2f1c386b"
     },
     "cli": {
-      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
+      "identity": "sha256:eb5d210afab12a40858499e43f506e45de70a30cbd3ad6359c2719f9984e9d96",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
+      "sourceHash": "01118f4cc332bae8b434ad341e5b779c269924c9915e4681b833159cfa757f2b",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",
@@ -55,13 +55,13 @@
       },
       "target": "node",
       "file": "cli.mjs",
-      "bundleHash": "sha256:9b152ea485159e4feee717a3d860f5f962cd108018dc215466f68d506702bbd1"
+      "bundleHash": "sha256:c13978dd2923e85c847bb4cd904075a82affcfbb9669f5c61eeb22844677ae23"
     },
     "worker": {
-      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
+      "identity": "sha256:eb5d210afab12a40858499e43f506e45de70a30cbd3ad6359c2719f9984e9d96",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
+      "sourceHash": "01118f4cc332bae8b434ad341e5b779c269924c9915e4681b833159cfa757f2b",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",
@@ -86,10 +86,10 @@
       "bundleHash": "sha256:bb463f3b33b7474ed8f2c0626fa4bde8c64101182b11aac042491f7077e6cbdd"
     },
     "agent-run": {
-      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
+      "identity": "sha256:eb5d210afab12a40858499e43f506e45de70a30cbd3ad6359c2719f9984e9d96",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
+      "sourceHash": "01118f4cc332bae8b434ad341e5b779c269924c9915e4681b833159cfa757f2b",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",
@@ -111,13 +111,13 @@
       },
       "target": "node",
       "file": "agent-run.mjs",
-      "bundleHash": "sha256:4966a3d3fff0ca42fc8b77e2c0d5bf07af5966adb5fe80a67b3d0285325badf7"
+      "bundleHash": "sha256:2fcd14c02e8a8b168396623ca851f206529b2e5559eb87162ed4de3c699d73ee"
     },
     "agent-providers": {
-      "identity": "sha256:70c6c949f1dd2a9dbd878e97d7ed45530200f2f9d08ed7dc9d03ac8eb3547bbb",
+      "identity": "sha256:eb5d210afab12a40858499e43f506e45de70a30cbd3ad6359c2719f9984e9d96",
       "engineVersion": "0.6.0",
       "toolchain": "bun@1.3.14",
-      "sourceHash": "0ca9c934aa03b96edece8ad4b89e63828df404309d23f8da9d8de25e51a2950f",
+      "sourceHash": "01118f4cc332bae8b434ad341e5b779c269924c9915e4681b833159cfa757f2b",
       "dependencyHash": "50096a04c37058e201c3d5234a0babeae5531f941f07f5dbf11ee733f04ce2e8",
       "dependencies": {
         "@gltf-transform/core": "^4.4.1",

--- a/dist/cli.mjs
+++ b/dist/cli.mjs
@@ -28561,6 +28561,24 @@ async function renderDerivativeCell(input, context) {
       mesh.material = Array.isArray(mesh.material) ? mesh.material.map(prepare) : prepare(mesh.material);
     });
   }
+  let hasHidden = false;
+  derivativeRoot.traverse((node) => {
+    const mesh = node;
+    if (mesh.isMesh && mesh.visible === false)
+      hasHidden = true;
+  });
+  if (hasHidden) {
+    if (derivativeRoot === input.root)
+      derivativeRoot = derivativeRoot.clone(true);
+    const drop = [];
+    derivativeRoot.traverse((node) => {
+      const mesh = node;
+      if (mesh.isMesh && mesh.visible === false)
+        drop.push(node);
+    });
+    for (const node of drop)
+      node.removeFromParent();
+  }
   const rendered = await renderSceneToGLB(derivativeRoot, {
     derivative: true,
     ...trustedCategory(context) ? { category: trustedCategory(context) } : {},

--- a/dist/mcp-server.mjs
+++ b/dist/mcp-server.mjs
@@ -28260,6 +28260,24 @@ async function renderDerivativeCell(input, context) {
       mesh.material = Array.isArray(mesh.material) ? mesh.material.map(prepare) : prepare(mesh.material);
     });
   }
+  let hasHidden = false;
+  derivativeRoot.traverse((node) => {
+    const mesh = node;
+    if (mesh.isMesh && mesh.visible === false)
+      hasHidden = true;
+  });
+  if (hasHidden) {
+    if (derivativeRoot === input.root)
+      derivativeRoot = derivativeRoot.clone(true);
+    const drop = [];
+    derivativeRoot.traverse((node) => {
+      const mesh = node;
+      if (mesh.isMesh && mesh.visible === false)
+        drop.push(node);
+    });
+    for (const node of drop)
+      node.removeFromParent();
+  }
   const rendered = await renderSceneToGLB(derivativeRoot, {
     derivative: true,
     ...trustedCategory(context) ? { category: trustedCategory(context) } : {},
@@ -30227,7 +30245,7 @@ var MCP_SERVER_INSTRUCTIONS = `Kiln turns JavaScript you write into GLB 3D asset
 
 Work by reference. Send a program once to kiln_validate or kiln_render; the result carries a programRef. Keep it exactly as returned, including a short p_ handle, and use it for every later view and edit. kiln_source with that ref and a literal query returns exact edit anchors, and kiln_edit with that ref plus edits returns a new ref and renders by default. Do not resend a whole program to change part of it.
 
-Call kiln_list_primitives before writing code to get exact helper signatures, with capabilities: true for the runtime, source, export and camera contract. Read viewFidelity in any render result before judging materials: a geometry-flat CPU image is evidence about shape, not about material.
+Call kiln_list_primitives before writing code to get exact helper signatures, with capabilities: true for the runtime, source, export and camera contract. Read viewFidelity in any render result before judging materials: a geometry-flat CPU image is evidence about shape, not about material. When materialFaithful is false and the task concerns appearance, say so rather than concluding from a CPU view: material-faithful views come from the GPU render service that ships as render-service/ in this installation, which has its own npm install and is resolved once at server startup.
 
 Detailed workflows ship beside this server as Agent Skills, one directory each under ${packagedSkillsDir}:
 - kiln-setup-workspace: create a managed workspace for authoring, and verify its tools came up

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -1024,3 +1024,38 @@ documents Bun as the toolchain.
 | 8.2 | Decide whether the CLI should refuse to exit 0 having produced no output at all, independent of the Bun cause. A silent success is the part that made this look like flakiness for so long | Pending |
 | 8.3 | Point `src/asset-cli.test.ts` at an interpreter that reflects how the CLI actually ships, or assert non-empty stdout before parsing so the failure names the real cause | Pending |
 | 8.4 | Re-check the other two intermittent tests against this finding; a shared `spawnSync` under Bun may explain more than one of them | Pending |
+
+## Phase 9 -- Review surfaces that misreport a correct asset
+
+Found 2026-09-10 into 2026-09-11 by a blind clone-and-author run: an agent given
+no context beyond the repository itself, asked to clone it, set it up, and make
+two assets, then to report what confused it. It followed the intended document
+chain (`README.md`, engine `AGENTS.md`, `kiln-setup-workspace`, the workspace
+`START.md` and `AGENTS.md`, the author skill and its references), never authored
+in the checkout, never opened `src/`, `examples/` or `docs/`, mixed the MCP and
+CLI surfaces without confusion, carried `programRef` lineage through anchored
+edits three and four refs deep, and reported its inherited session loadout
+unprompted -- including a rival `kiln-setup-workspace` registered from another
+installation's plugin cache, which it declined in favour of the clone's copy.
+Phase 7's guide and audit work is therefore validated end to end for the CLI
+path. What the run could not exercise is the in-loop MCP surface, because only a
+harness session started inside the workspace registers `kiln_workspace`.
+
+The findings below share a shape worth naming: the asset was correct every time,
+and the surface used to *review* it was what lied. That is the most expensive
+class of defect here, because the review step is the whole loop's evidence, and a
+model has no independent way to catch it.
+
+9.1 is fixed. Everything else is recorded from the run's report and is not yet
+independently verified; 9.2 is the one that looks like the same bug class as 9.1.
+
+| Task | Detail |
+| --- | --- |
+| 9.1 | `visibility: 'isolate'` and legacy `isolate: true` were silently ignored whenever a GPU service was attached. Both hide by clearing `mesh.visible`; `views/raster.ts` culls on it, but glTF has no per-mesh visibility and Kiln writes its own GLB rather than three's `GLTFExporter`, whose `onlyVisible` defaults true. `kiln_inspect` asserted "nothing in this image occludes it" about images where everything still did. **Done 2026-09-11**: `renderDerivativeCell` prunes hidden meshes from a copy. Escaped because the only prior test framed a single-mesh scene, where isolation cannot change the image |
+| 9.2 | `kiln_screenshot_animation` renders the entire asset rotating where the clip drives one joint. The run parsed the exported GLB's JSON chunk and found the `Spin` animation holds exactly one channel, targeting the spindle node, and that the node's subtree excludes the bench and seat that were visibly turning. Camera receipts were byte-identical across frames, so it is not a framing artefact. Pending; verify before trusting the report, then look for the 9.1 pattern -- a review path that re-poses or re-serializes more than the clip does |
+| 9.3 | `viewFidelity.exactArtifact` reported `false` on every render, including ones where the run independently hashed `inputGlbSha256` equal to both the exported GLB and the saved `asset.glb`. Either the flag means something narrower than its name, or it is wrong. Pending; whichever it is, a model cannot use a fidelity flag whose false value carries no meaning |
+| 9.4 | `kiln_screenshot_animation` requires a `clip` name and `frameTimes` normalized to 0..1, and neither is stated in the author skill or the camera recipes. The run guessed the clip name from its own `createClip` call and hit a validation error on seconds-valued frame times. Pending; a documentation gap, not a defect |
+| 9.5 | `arrayRadial` count semantics are not inferable from the signature plus the example: whether the source mesh survives as the copy at index 0 had to be deduced from a mesh count. Pending; documentation |
+| 9.6 | CLI `--out` does not create parent directories, failing with a bare `ENOENT` *after* the build succeeded and printed a `programRef`. Invisible from the README, whose example writes into the cwd. Pending; decide between `mkdir -p` and an error that names the directory |
+| 9.7 | The MCP server resolves the render service once before its first connection, so a service started afterwards is invisible until the session restarts, while the CLI picks it up on the next call. Re-probe lazily when a render needs PBR and no port is attached, with a short negative cache -- the probe's `absent` path is a refused localhost connection. Pending; collapses the guidance to "start it whenever" and deletes the restart caveat from the workspace guide and the setup skill. Not folded into the Phase 7 documentation commit because `captureViewsViaPort` owns the deadline and degrade policy and the change deserves its own TDD |
+| 9.8 | Narrow the generated per-harness configuration to suppress user-level skills and MCP servers where each harness supports it. The blind run inherited roughly twenty unrelated skills and four unrelated servers. This is the only option that reduces inherited context rather than reporting it, and it needs vendor documentation per harness first: configuration that validates and silently does nothing is the `${PLUGIN_ROOT}` failure class. Pending |

--- a/scripts/create-workspace.mjs
+++ b/scripts/create-workspace.mjs
@@ -62,21 +62,35 @@ function managedFiles(root, runtime, harness, nodeExecutable) {
 
 const guide = `# Kiln asset workspace
 
-Use the kiln_workspace MCP server configured in this project to author and refine assets in this directory. Another server named kiln may use a different installation; do not substitute it silently. The engine is installed separately. Do not read its implementation or example collection to solve an asset task.
+Author and refine assets in this directory. The engine is installed separately. Do not read its implementation or example collection to solve an asset task.
 
-- This project's own skills are installed and registered for your harness; read the relevant one from here, never a global plugin copy. The maintained copies are in skills/, mirrored to .claude/skills/ and .agents/skills/ because harnesses scan different directories. Use kiln_list_primitives on kiln_workspace for API signatures. If that server is unavailable, report the setup problem instead of using another installation.
-- Import an existing file with node kiln.mjs source asset.kiln.js. It returns a programRef, normally a short immutable p_ handle. Copy it exactly; do not expand or shorten it.
-- For a new draft, pass code once to kiln_validate or kiln_render. Keep its programRef even if validation fails.
-- Use kiln_source with programRef and a literal query to read exact edit anchors. Follow nextOffset for more context.
-- Use kiln_edit with programRef and edits. It returns a new programRef and renders by default. Use that reference for later views and edits; do not resend the program.
-- Review the image and diff. Check viewFidelity before judging materials.
-- Save completed assets with kiln_save, browse configured collections with kiln_assets, and open node kiln.mjs view to inspect saved GLBs. Keep the exact asset and revision IDs for export or restore. Save refinements as child revisions rather than replacing their parent.
-- Save with node kiln.mjs source PROGRAM_REF --out revised.kiln.js. Export refuses to overwrite a file.
-- Export geometry with node kiln.mjs render PROGRAM_REF --out asset.glb --views sheet.png.
+Two surfaces drive the same engine and share .kiln/programs, so either is fine and you can mix them freely. The kiln_workspace MCP server returns each render as an image in your context. The node kiln.mjs CLI writes renders to disk, so read the PNG back before judging anything visual. A server named kiln may be a different installation; do not substitute it silently, and report the setup problem instead.
 
-Replace PROGRAM_REF above with the exact returned reference. Full sha256 references remain valid.
+Read the skill for your task from skills/ in this directory, never a global plugin copy. The maintained copies are there, mirrored into .claude/skills/ and .agents/skills/ because harnesses scan different directories. Use kiln_list_primitives for API signatures.
 
-The CLI and MCP share .kiln/programs. Keep that directory while working. Source files are portable; references resolve only in a store containing their source.
+## The loop
+
+1. Draft. Pass code once to kiln_render or kiln_validate, or import a file with node kiln.mjs source asset.kiln.js. Either returns a programRef, normally a short immutable p_ handle. Keep it even when validation fails. Copy it exactly; never construct, expand or shorten one, and do not retransmit the program.
+2. Render. kiln_render, or node kiln.mjs render PROGRAM_REF --views sheet.png.
+3. Review. Look at the image. Check viewFidelity before judging materials: a CPU view is honest about silhouette, proportion and contact, and says nothing about colour, metalness or roughness.
+4. Edit. Read exact anchors with kiln_source and a literal query, following nextOffset for more context, then call kiln_edit with programRef and edits. Each edit returns a new programRef; use that one from then on. Rewriting the whole file through the CLI works, but it loses the anchored diff and the revision lineage.
+5. Save. kiln_save, or node kiln.mjs save. Keep the exact asset and revision IDs. Save refinements as child revisions rather than replacing their parent. Browse collections with kiln_assets and inspect saved GLBs with node kiln.mjs view.
+
+Export at any point. Source is node kiln.mjs source PROGRAM_REF --out revised.kiln.js; geometry is node kiln.mjs render PROGRAM_REF --out asset.glb --views sheet.png. Export refuses to overwrite a file. Replace PROGRAM_REF with the exact returned reference; full sha256 references also remain valid.
+
+## Material-faithful views
+
+This workspace asks for render mode auto: a GPU service when one answers on port 8000, CPU views otherwise. Without that service every render reports viewFidelity.materialFaithful false, and nothing rendered here can confirm a material.
+
+To start it, read runtime from .kiln/workspace.json and run npm install && npm start in render-service/ under that path. It is a separate package with a native dependency, so the install is its own step and can take a while. Start it at any time; the CLI picks it up on the next call. If MCP renders still report CPU afterwards, restart this session, because the MCP server resolves the service once at startup.
+
+For a task about appearance, say so rather than silently accepting CPU views.
+
+## Keep this context clean
+
+Skills and MCP servers from user-level configuration still load here: a workspace separates task context, not operating-system permissions. When you verify the server, report anything registered that is unrelated to this task so the user can decide whether to narrow it.
+
+Keep .kiln/programs while working. Source files are portable; references resolve only in a store containing their source.
 `;
 
 async function readManifest(root) {
@@ -170,7 +184,7 @@ export async function createWorkspace(directory, harness = 'claude', options = {
     await writeFile(join(stage, '.kiln/workspace.json'), quote(manifest));
     const command = harness === 'hermes' ? 'node hermes.mjs --ignore-rules' : harness === 'agy' ? 'node agy.mjs' : harness;
     const launch = harness === 'hermes' ? 'Hermes uses a separate profile; authenticate in that profile or supply provider credentials through the environment.' : harness === 'agy' ? 'The launcher supplies the absolute project directory. For headless runs, use node agy.mjs --model MODEL --print \"Read AGENTS.md and the project skills. Use only kiln_workspace MCP tools. YOUR TASK.\". Print mode disables automatic slash-command/skill expansion to avoid automatic expansion of a global skill. Use absolute task-file paths in headless prompts and verify that tool calls use kiln_workspace; global configuration and authentication remain unchanged.' : `This directory is configured for ${harness}.`;
-    await writeFile(join(stage, 'START.md'), `# Start making assets\n\n\`\`\`bash\ncd ${root}\n${command}\n\`\`\`\n\n${launch} Accept the project/MCP trust prompts. Ask the agent to read AGENTS.md and create an asset. Kiln needs no separate model key.\n\nCore author/refine/QA skills are installed and registered for this harness. Optional compose/batch skills are selected at setup with --skills compose,batch.\n\nKeep assets here and engine source outside. This separates task context, not operating-system permissions. User instructions and authentication can still apply.\n\nRun repair after anything that invalidates the generated absolute paths: moving this workspace, moving or reinstalling the runtime, or replacing the Node that setup recorded -- an nvm switch or uninstall does that, because the manifest pins the exact interpreter the preflight check validated.\n\n\`\`\`bash\nnode /current/kiln/scripts/create-workspace.mjs ${root} --repair\n\`\`\`\n\nRepair updates generated runtime paths only and refuses edited configuration; it preserves skills, assets, and saved revisions.\n`);
+    await writeFile(join(stage, 'START.md'), `# Start making assets\n\n\`\`\`bash\ncd ${root}\n${command}\n\`\`\`\n\n${launch} Accept the project/MCP trust prompts. Ask the agent to read AGENTS.md and create an asset. Kiln needs no separate model key.\n\nCore author/refine/QA skills are installed and registered for this harness. Optional compose/batch skills are selected at setup with --skills compose,batch.\n\nKeep assets here and engine source outside. This separates task context, not operating-system permissions. User instructions and authentication can still apply.\n\nRun repair after anything that invalidates the generated absolute paths: moving this workspace, moving or reinstalling the runtime, or replacing the Node that setup recorded -- an nvm switch or uninstall does that, because the manifest pins the exact interpreter the preflight check validated.\n\n\`\`\`bash\nnode ${join(runtime, 'scripts/create-workspace.mjs')} ${root} --repair\n\`\`\`\n\nThat path is where the installation was at setup. If the installation itself moved, run the same command from its current location; \`runtime\` in .kiln/workspace.json records where this workspace last expected it.\n\nRepair updates generated runtime paths only and refuses edited configuration; it preserves skills, assets, and saved revisions.\n`);
     if (exists) {
       // Windows cannot remove the caller's current directory, even when empty.
       // Move only staged entries and track them so a failed install rolls back.

--- a/skills/kiln-setup-workspace/SKILL.md
+++ b/skills/kiln-setup-workspace/SKILL.md
@@ -32,11 +32,31 @@ From an installed package, the equivalent is `kiln-init /absolute/empty-workspac
 
 Antigravity and Hermes get a generated launcher because each needs arguments or a separate profile that the bare command does not supply. Hermes authenticates in its own profile; setup copies no credentials.
 
+## Start the GPU render service
+
+Setup asks for render mode `auto`: a GPU service when one answers on port 8000, CPU views otherwise. CPU views are honest about silhouette, proportion and contact and say nothing about colour, metalness or roughness, so without the service no render can confirm a material.
+
+Offer to start it before launching the harness. It lives in the engine installation rather than the workspace, and it is a separate package with a native dependency, so its install is its own step and is not covered by installing the engine.
+
+```bash
+cd render-service && npm install && npm start
+```
+
+Leave it running in its own terminal. The CLI picks up a service started at any time on its next call, while an MCP session resolves the service once at startup -- so starting it first is what gets in-loop renders material-faithful without a restart. If the machine has no usable GPU, report that and continue on CPU views; it is a limit to state, not a setup failure.
+
 ## Verify the loadout before authoring
 
 Accept the project and MCP trust prompts, then confirm the server is actually live rather than assuming it from configuration. Call `kiln_list_primitives` on `kiln_workspace` with `capabilities: true`; it returns the runtime, source, export and camera contract and proves the tools resolved. A server named `kiln` from a global installation is a different thing. Do not substitute it silently; report the setup problem instead.
 
 Confirm the installed skills are readable at `skills/` in the workspace, and read the relevant one from there rather than a global copy. Whether the harness also registers them natively depends on the harness.
+
+Report the rest of the session's loadout at the same time. Skills and MCP servers from user-level configuration load here too, and an authoring session carrying a dozen unrelated skills spends context and invites the wrong tool. List whatever is registered that has nothing to do with this task and let the user decide whether to narrow it. Do not change their global configuration.
+
+## Wiring a workspace by hand
+
+`--harness` covers claude, codex, opencode, hermes and agy. For any other harness, or an engine installed as a package elsewhere, assemble the same loadout in an empty directory: register the installation's `dist/mcp-server.mjs` as a stdio MCP server named `kiln_workspace`, give it `KILN_PROGRAM_STORE` pointing at `.kiln/programs` inside that directory plus `KILN_RENDER=auto`, and copy the skills you need from `skills/` into both `.claude/skills/` and `.agents/skills/` there.
+
+A hand-wired directory carries no manifest, so it gets no runtime preflight and `--repair` cannot correct its paths later. Prefer the generated workspace wherever the harness is supported, and tell the user which of the two they have.
 
 ## Relocation and repair
 

--- a/src/__tests__/mcp-instructions.test.ts
+++ b/src/__tests__/mcp-instructions.test.ts
@@ -33,6 +33,8 @@ describe('MCP server instructions', () => {
     expect(MCP_SERVER_INSTRUCTIONS).toContain('programRef');
     expect(MCP_SERVER_INSTRUCTIONS).toContain('viewFidelity');
     expect(MCP_SERVER_INSTRUCTIONS).toContain('kiln_list_primitives');
+    // The only channel a hand-wired directory has: no workspace guide exists there.
+    expect(MCP_SERVER_INSTRUCTIONS).toContain('render-service/');
   });
 
   it('offers registration without instructing an unrequested write', () => {

--- a/src/__tests__/workspace-bootstrap.test.ts
+++ b/src/__tests__/workspace-bootstrap.test.ts
@@ -182,3 +182,29 @@ it('adds a new managed launcher during repair but refuses an existing user file'
     await rm(root, { recursive: true, force: true });
   }
 }, 30000);
+
+it('steers the session to the loop, the render service and its own inherited context', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'kiln-guide-'));
+  try {
+    const task = join(root, 'w');
+    expect(run([task, '--harness', 'claude'], root).status).toBe(0);
+    const guide = await readFile(join(task, 'AGENTS.md'), 'utf8');
+    // Both surfaces are legitimate, so the guide has to name the two things that
+    // actually differ rather than express a preference: where the image lands, and
+    // that the CPU fallback is not material evidence.
+    expect(guide).toContain('read the PNG back');
+    expect(guide).toContain('materialFaithful');
+    expect(guide).toContain('render-service');
+    // `--repair` regenerates only the managedFiles set, never this guide, so an
+    // absolute engine path baked in here would rot silently the first time the
+    // installation moved. The manifest is the indirection that repair does keep.
+    expect(guide).toContain('.kiln/workspace.json');
+    expect(guide).not.toContain(repo);
+    // Inherited user-level skills and servers are the measured context leak; the
+    // workspace cannot prevent them, so it must at least ask for them to be reported.
+    expect(guide).toContain('user-level configuration');
+    expect(await readFile(join(task, 'CLAUDE.md'), 'utf8')).toBe(guide);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}, 30000);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -50,7 +50,7 @@ export const MCP_SERVER_INSTRUCTIONS = `Kiln turns JavaScript you write into GLB
 
 Work by reference. Send a program once to kiln_validate or kiln_render; the result carries a programRef. Keep it exactly as returned, including a short p_ handle, and use it for every later view and edit. kiln_source with that ref and a literal query returns exact edit anchors, and kiln_edit with that ref plus edits returns a new ref and renders by default. Do not resend a whole program to change part of it.
 
-Call kiln_list_primitives before writing code to get exact helper signatures, with capabilities: true for the runtime, source, export and camera contract. Read viewFidelity in any render result before judging materials: a geometry-flat CPU image is evidence about shape, not about material.
+Call kiln_list_primitives before writing code to get exact helper signatures, with capabilities: true for the runtime, source, export and camera contract. Read viewFidelity in any render result before judging materials: a geometry-flat CPU image is evidence about shape, not about material. When materialFaithful is false and the task concerns appearance, say so rather than concluding from a CPU view: material-faithful views come from the GPU render service that ships as render-service/ in this installation, which has its own npm install and is resolved once at server startup.
 
 Detailed workflows ship beside this server as Agent Skills, one directory each under ${packagedSkillsDir}:
 - kiln-setup-workspace: create a managed workspace for authoring, and verify its tools came up

--- a/src/tools/__tests__/camera-integration.test.ts
+++ b/src/tools/__tests__/camera-integration.test.ts
@@ -164,3 +164,116 @@ test('inspect exposes subject frames and measures exact part-local anchors', asy
   expect(out.measurement).toMatchObject({ distance: 2, units: 'asset units', frame: 'world' });
   expect(out.subjectFrame.worldMatrix).toHaveLength(16);
 });
+
+/** Count meshes in the JSON chunk of a GLB, without decoding buffers. */
+function glbMeshCount(glb: Uint8Array): number {
+  const view = new DataView(glb.buffer, glb.byteOffset, glb.byteLength);
+  const jsonLength = view.getUint32(12, true);
+  const json = JSON.parse(new TextDecoder().decode(glb.subarray(20, 20 + jsonLength)));
+  return (json.meshes ?? []).length;
+}
+
+test('isolate hides surrounding geometry on the GPU path, not only the CPU rasterizer', async () => {
+  // Two meshes far enough apart that context framing keeps both in view, so the
+  // only thing that can remove one from the GPU request is isolation itself.
+  const twoPart =
+    "const meta={name:'pair',category:'prop'};function build(){const r=createRoot('Root');" +
+    "createPart('Near',boxGeo(1,1,1),gameMaterial('#888888'),{parent:r});" +
+    "createPart('Far',boxGeo(1,1,1),gameMaterial('#333333'),{parent:r,position:[3,0,0]});return r;}";
+  const requests: PbrRenderRequest[] = [];
+  const defs = createKilnProgramToolRegistry({
+    viewRenderPort: async (req) => {
+      requests.push(req);
+      return {
+        ok: true,
+        rendererId: 'gpu:test',
+        cameras: req.cameras,
+        width: req.width,
+        height: req.height,
+        viewsPng: (req.cameras ?? [null]).map(() =>
+          encodePng(new Uint8Array(256 * 256 * 3), 256, 256),
+        ),
+        derivativeFidelity: {
+          materialFaithful: true,
+          inputGlbSha256: `sha256:${createHash('sha256').update(req.glb).digest('hex')}`,
+        },
+      };
+    },
+  });
+  const render = defs.find((d) => d.name === 'kiln_render')!;
+  const shot = (visibility: 'context' | 'isolate') => ({
+    subject: { name: 'Mesh_Near' },
+    visibility,
+    camera: {
+      type: 'explicit' as const,
+      projection: 'perspective' as const,
+      position: [6, 4, 6],
+      target: [0, 0, 0],
+    },
+  });
+  const run = async (visibility: 'context' | 'isolate') => {
+    requests.length = 0;
+    const out = (await render.run({
+      code: twoPart,
+      capture: { version: 'kiln.capture.v1', shots: [shot(visibility)], size: 256 },
+    })) as Record<string, unknown>;
+    expect(out.ok).toBe(true);
+    expect(requests).toHaveLength(1);
+    return glbMeshCount(requests[0]!.glb);
+  };
+  // Isolation is per shot, so one isolate shot must not strip geometry from a
+  // later context shot in the same capture. Both mechanisms mutate shared
+  // `.visible` state, which is what makes the ordering worth pinning.
+  requests.length = 0;
+  const mixed = (await render.run({
+    code: twoPart,
+    capture: {
+      version: 'kiln.capture.v1',
+      shots: [shot('isolate'), shot('context')],
+      size: 256,
+      output: 'separate',
+    },
+  })) as Record<string, unknown>;
+  expect(mixed.ok).toBe(true);
+  expect(requests.map((r) => glbMeshCount(r.glb))).toEqual([1, 2]);
+  expect(await run('context')).toBe(2);
+  // The CPU rasterizer culls on `mesh.visible` (views/raster.ts), but a GLB has no
+  // per-mesh visibility, so an unfiltered serialization makes isolate a silent
+  // no-op on exactly the material-faithful path it is most useful on.
+  expect(await run('isolate')).toBe(1);
+});
+
+test('legacy kiln_inspect isolate keeps its occlusion promise on the GPU path', async () => {
+  const twoPart =
+    "const meta={name:'pair',category:'prop'};function build(){const r=createRoot('Root');" +
+    "createPart('Near',boxGeo(1,1,1),gameMaterial('#888888'),{parent:r});" +
+    "createPart('Far',boxGeo(1,1,1),gameMaterial('#333333'),{parent:r,position:[3,0,0]});return r;}";
+  const requests: PbrRenderRequest[] = [];
+  const defs = createKilnProgramToolRegistry({
+    viewRenderPort: async (req) => {
+      requests.push(req);
+      return {
+        ok: true,
+        rendererId: 'gpu:test',
+        cameras: req.cameras,
+        width: req.width,
+        height: req.height,
+        viewsPng: (req.cameras ?? [null]).map(() =>
+          encodePng(new Uint8Array(512 * 512 * 3), 512, 512),
+        ),
+        derivativeFidelity: {
+          materialFaithful: true,
+          inputGlbSha256: `sha256:${createHash('sha256').update(req.glb).digest('hex')}`,
+        },
+      };
+    },
+  });
+  const inspect = defs.find((d) => d.name === 'kiln_inspect')!;
+  const seen = await inspect.run({ code: twoPart, part: 'Near', isolate: true });
+  expect((seen as Record<string, unknown>).ok).toBe(true);
+  // The result text promises "nothing in this image occludes it". Before the
+  // derivative GLB was filtered that sentence was false whenever a GPU service
+  // was attached, which is the one case where the close-up is worth taking.
+  expect(requests).toHaveLength(1);
+  expect(glbMeshCount(requests[0]!.glb)).toBe(1);
+});

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -403,6 +403,27 @@ async function renderDerivativeCell(
         : prepare(mesh.material);
     });
   }
+  // `withCameraVisibility` and `isolateSubtree` express isolation by clearing
+  // `mesh.visible`. The CPU rasterizer culls on that flag (see views/raster.ts),
+  // but glTF carries no per-mesh visibility, so serializing unfiltered ships the
+  // hidden geometry to the GPU service and makes isolate a silent no-op on exactly
+  // the material-faithful path it is most useful on. Prune on a copy: the caller
+  // restores `.visible` afterwards and must not observe a mutated scene.
+  let hasHidden = false;
+  derivativeRoot.traverse((node) => {
+    const mesh = node as THREE.Mesh;
+    if (mesh.isMesh && mesh.visible === false) hasHidden = true;
+  });
+  if (hasHidden) {
+    if (derivativeRoot === (input.root as THREE.Object3D))
+      derivativeRoot = derivativeRoot.clone(true);
+    const drop: THREE.Object3D[] = [];
+    derivativeRoot.traverse((node) => {
+      const mesh = node as THREE.Mesh;
+      if (mesh.isMesh && mesh.visible === false) drop.push(node);
+    });
+    for (const node of drop) node.removeFromParent();
+  }
   const rendered = await renderSceneToGLB(derivativeRoot, {
     // The scene here was loaded back from a GLB this engine already produced
     // and adjudicated. Submitting it for judgement a second time fails on the


### PR DESCRIPTION
## The bug worth reading first

`visibility: 'isolate'` and the legacy `isolate: true` were **silently ignored whenever a GPU render service was attached.**

Both mechanisms hide geometry by clearing `mesh.visible`. The CPU rasterizer culls on that flag ([src/views/raster.ts:199](../blob/main/src/views/raster.ts#L199)), but glTF carries no per-mesh visibility, and Kiln writes its own GLB rather than using three's `GLTFExporter` — whose `onlyVisible` defaults to `true`. So `renderDerivativeCell` serialized the hidden meshes and the service drew them.

Isolation worked on CPU and was a no-op on exactly the material-faithful path where a close-up is worth taking. Worse, `kiln_inspect` reports `"Everything else is hidden, so nothing in this image occludes it"` off the mutation rather than the render, so on GPU it was asserting something false to the model with no way for it to tell.

**Fix:** `renderDerivativeCell` prunes hidden meshes from a copy, leaving the caller's scene untouched so `withCameraVisibility`'s restore still sees what it expects.

**Why it escaped:** the only prior `isolate` test asserted `cameraShots` length and `ok: true` on a **single-mesh** scene, where isolation cannot change the image. Three new tests, each verified to fail without the fix: the capture path (`context` → 2 meshes, `isolate` → 1), per-shot independence within one capture (`[isolate, context]` → `[1, 2]`, so one shot cannot poison the next through shared `.visible` state), and the legacy `kiln_inspect` entry point.

## How it was found

A blind clone-and-author run: an agent given no context beyond the repository, asked to clone it, set it up, make two assets, and report what confused it.

It also validated the workspace work end to end. It followed the intended document chain, never authored in the checkout, never opened `src/`, `examples/` or `docs/`, mixed both surfaces without confusion, carried `programRef` lineage through anchored edits three and four refs deep, and reported its inherited session loadout unprompted — including a rival `kiln-setup-workspace` registered from another installation's plugin cache, which it declined in favour of the clone's copy.

## Workspace context changes

- **The guide is organised around the loop**, not a flat tool list. MCP and `node kiln.mjs` are presented as equal surfaces that may be mixed, naming only the two real differences: where the rendered image lands, and that a CPU view is not material evidence. The earlier run used the CLI exclusively, which was a fair reading of the old bullet ordering rather than a mistake.
- **The GPU render service is discoverable from all three places a session can start**: the setup skill offers it before the harness launches (the only moment an MCP session gets it without a restart), the workspace guide explains it mid-session, and `MCP_SERVER_INSTRUCTIONS` names it for a hand-wired directory that has no workspace guide at all.
- The guide resolves the engine path through `.kiln/workspace.json` rather than baking one, because `--repair` regenerates only the managed file set and would leave an absolute path to rot silently.
- `START.md` printed a literal `/current/kiln/` in its repair command; it now prints the recorded installation path plus how to recover if that moved.
- The setup skill asks a session to report skills and MCP servers inherited from user-level configuration, and documents wiring a workspace by hand for harnesses `--harness` does not cover.

## Verification

- `bun run test` — **1813 pass / 0 fail / 2 skip**
- `bun run typecheck` — clean
- `bun run lint` — exit 0, unchanged 14-warning / 11-info baseline
- `bun run check:skills` — 6 skills conform, both registration copies byte-identical
- `bun run build:runtime` — byte-identical across consecutive runs

## Not in this PR

Phase 9 of the plan records the blind run's remaining findings, which share a shape: **the asset was correct and the surface used to review it was not.** Chief among them, `kiln_screenshot_animation` renders the whole asset rotating where the clip drives one joint — the run proved the GLB holds a single channel targeting the spindle by parsing its JSON chunk. That looks like the same bug class as the fix here and is not yet independently verified.

Also recorded: `exactArtifact: false` where hashes match exactly, undocumented `clip` and `frameTimes` semantics, `arrayRadial` count semantics, CLI `--out` not creating parent directories, the MCP lazy re-probe that would delete the "start it first" caveat, and per-harness loadout narrowing pending vendor docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)