### PR TITLE
fix: keep Bun-only APIs out of Node bundles and shipped source (10.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## Bun-only APIs cannot reach a Node bundle unnoticed — 2026-09-11
+
+- Audited the shipped bundles for the defect class behind the MCP server's
+  `import.meta.main` bug. The bundles were clean of all nine patterns checked —
+  but the audit found the identifier still live in
+  `src/experiments/geometry-acceptance.ts`, which **ships** (`files` carries
+  `src/**/*.ts`). Unbundled under plain `node`, `import.meta.main` is `undefined`,
+  so that guard was always *false* and running the script with node did nothing
+  at all, silently. The same defect as the MCP one with its sign flipped: there,
+  bundling made the guard always *true* and started a server nobody asked for.
+  Both now use `isDirectEntry`, which decides from `process.argv[1]`.
+- A new guard asserts both halves — no Bun-only API in any committed bundle, and
+  no `import.meta.main` deciding an entry point in shipped source. It was
+  verified by injecting a defect into each and watching it fail, rather than
+  trusted for passing green: the whole reason this class survived is that nothing
+  was looking.
+
 ## The GPU material check runs for the first time — 2026-09-11
 
 - `render-service/test/material-conformance.mjs` is the only automated evidence

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -1217,7 +1217,7 @@ the inertness guard `cli-entry.test.ts` always had.
 | --- | --- | --- |
 | 10.1 | `import.meta.main` does not survive bundling to Node; the MCP entry block ran on import and became a `ReferenceError` under Bun 1.4 | Done 2026-09-11 -- shared `isDirectEntry`, guarded by a new inertness test |
 | 10.2 | Re-record the coverage baseline measured under Bun 1.4.2 | Done 2026-09-11 |
-| 10.3 | Consider whether other Bun-only globals reach a `--target=node` bundle. `import.meta.main` was the one that mattered; nothing else is asserted | Pending; audit, no known defect |
+| 10.3 | Consider whether other Bun-only globals reach a `--target=node` bundle. `import.meta.main` was the one that mattered; nothing else is asserted | **Done 2026-09-11.** Audited, and it found one live instance -- `src/experiments/geometry-acceptance.ts` still guarded its entry with `import.meta.main`. That file **ships** (`files` carries `src/**/*.ts`), and unbundled under plain `node` the identifier is `undefined`, so the guard was always FALSE and running the script with node did nothing at all, silently. The same defect as 10.1 with its sign flipped: there, bundling made the guard always TRUE and started a server nobody asked for. Now `isDirectEntry`. The bundles themselves were already clean of all nine patterns checked. `src/__tests__/bun-only-globals.test.ts` now asserts both halves, and was verified to fail on an injected defect in each rather than trusted for passing |
 
 ## Phase 9 -- Review surfaces that misreport a correct asset
 

--- a/src/__tests__/bun-only-globals.test.ts
+++ b/src/__tests__/bun-only-globals.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Bun-only APIs must not reach a `--target=node` bundle, or the shipped source.
+ *
+ * Ledger 10.3, and it exists because 10.1 shipped undetected for as long as the
+ * bundle did. `src/mcp-server.ts` guarded its entry block with `import.meta.main`,
+ * which is Bun's. No Bun release lowers it correctly for a Node target: both
+ * lowerings observed emit `__require.main == __require.module`, and under Node ESM
+ * both sides are `undefined`, so the guard was **always true** and importing the
+ * bundle started a live stdio server. Bun 1.4 then stopped emitting the helper the
+ * expression referenced, turning it into a startup `ReferenceError` -- which is the
+ * only reason anyone found out.
+ *
+ * The same identifier fails the other way in unbundled shipped source. This
+ * package ships `src/**` and a user may run a script with `node` directly; there
+ * `import.meta.main` is plainly `undefined`, so an entry guard is always false and
+ * the script silently does nothing. `src/experiments/geometry-acceptance.ts` was
+ * doing exactly that.
+ *
+ * Both directions are decided by `isDirectEntry`, from `process.argv[1]` rather
+ * than from whatever a bundler makes of `import.meta`.
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+const REPO = resolve(import.meta.dir, '../..');
+
+/**
+ * Each pattern is written to survive the bundles' embedded base64. The base64
+ * alphabet contains `Bun` as an ordinary substring but can never contain `Bun.`,
+ * so the namespace check requires the dot and an identifier after it rather than
+ * matching the bare word.
+ */
+const BUN_ONLY: readonly { readonly name: string; readonly pattern: RegExp }[] = [
+  { name: 'import.meta.main', pattern: /import\.meta\.main\b/ },
+  { name: 'import.meta.dir', pattern: /import\.meta\.dir\b/ },
+  { name: 'import.meta.file', pattern: /import\.meta\.file\b/ },
+  { name: 'import.meta.path', pattern: /import\.meta\.path\b/ },
+  { name: 'import.meta.require', pattern: /import\.meta\.require\b/ },
+  { name: 'Bun namespace', pattern: /\bBun\.[A-Za-z_$]/ },
+  { name: 'process.isBun', pattern: /\bprocess\.isBun\b/ },
+  { name: 'HTMLRewriter', pattern: /\bHTMLRewriter\b/ },
+  // The helper Bun's `import.meta.main` lowering referenced. Its presence means
+  // some Bun-ism was lowered rather than rejected.
+  { name: "Bun's __require helper", pattern: /\b__require\b/ },
+];
+
+/** Every `.ts` under `src` that the package ships: tests are excluded by `files`. */
+async function shippedSources(directory = join(REPO, 'src')): Promise<string[]> {
+  const found: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') continue;
+      found.push(...(await shippedSources(path)));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) found.push(path);
+  }
+  return found;
+}
+
+describe('Bun-only APIs', () => {
+  it('do not appear in any committed runtime bundle', async () => {
+    const dist = join(REPO, 'dist');
+    const bundles = (await readdir(dist)).filter((file) => file.endsWith('.mjs'));
+    // A passing assertion over an empty list would be no assertion at all.
+    expect(bundles.length).toBeGreaterThan(0);
+
+    const offences: string[] = [];
+    for (const bundle of bundles) {
+      const text = await readFile(join(dist, bundle), 'utf8');
+      for (const { name, pattern } of BUN_ONLY)
+        if (pattern.test(text)) offences.push(`dist/${bundle}: ${name}`);
+    }
+    expect(offences).toEqual([]);
+  });
+
+  it('are not used to decide an entry point in shipped source', async () => {
+    const sources = await shippedSources();
+    expect(sources.length).toBeGreaterThan(0);
+
+    const offences: string[] = [];
+    for (const path of sources) {
+      const text = await readFile(path, 'utf8');
+      // `direct-entry.ts` names the identifier in prose to explain why it is not
+      // used; prose is fine, an expression is not.
+      for (const line of text.split('\n')) {
+        const code = line.replace(/^\s*(?:\/\/|\*|\/\*).*$/, '');
+        if (/import\.meta\.main\b/.test(code))
+          offences.push(`${relative(REPO, path)}: import.meta.main`);
+      }
+    }
+    expect(offences).toEqual([]);
+  });
+});

--- a/src/experiments/geometry-acceptance.ts
+++ b/src/experiments/geometry-acceptance.ts
@@ -1,5 +1,6 @@
 /** Bounded offline acceptance probes, not public geometry APIs. */
 import * as THREE from 'three';
+import { isDirectEntry } from '../direct-entry';
 import { meshGeo, parametricSurface, geometryDiagnostics } from '../geometry';
 import { getManifoldModule, manifoldToGeometry } from '../solids';
 import { implicitSurface } from '../implicit';
@@ -269,4 +270,9 @@ async function run(id: string) {
     for (const m of owned) m.delete();
   }
 }
-if (import.meta.main) await run(process.argv[2]!);
+// `import.meta.main` is Bun's, and this file ships in the package. Under plain
+// `node` it is `undefined`, so the guard was always false and running this
+// script with node did nothing at all, silently. That is the same defect as 10.1
+// with its sign flipped: there, bundling made the guard always TRUE and started
+// a server nobody asked for.
+if (isDirectEntry(import.meta.url)) await run(process.argv[2]!);


### PR DESCRIPTION
10.3 asked whether other Bun-only globals reach a `--target=node` bundle, with no known defect behind it. The bundles were clean of all nine patterns checked. **The audit found a live instance elsewhere.**

`src/experiments/geometry-acceptance.ts` still guarded its entry block with `import.meta.main`, and that file **ships** — `files` carries `src/**/*.ts`. Unbundled under plain `node` the identifier is simply `undefined`, so the guard was always **false** and running the script with node did nothing at all, silently.

That is 10.1's defect with its sign flipped. There, Bun's lowering emitted `__require.main == __require.module` — both `undefined` under Node ESM — so the guard was always **true** and importing the bundle started a live stdio server.

Same identifier, opposite failures, both invisible. It now uses `isDirectEntry`, which decides from `process.argv[1]` rather than from whatever a bundler makes of `import.meta`.

## The guard

`src/__tests__/bun-only-globals.test.ts` asserts both halves:

- no Bun-only API in any committed runtime bundle
- no `import.meta.main` deciding an entry point anywhere in shipped source

The patterns are written to survive the bundles' embedded base64. The base64 alphabet contains `Bun` as an ordinary substring and there *are* real occurrences inside encoded payloads — but it can never contain `Bun.`, so the namespace check requires the dot and an identifier after it rather than matching the bare word.

**Verified by injecting a defect into each half and watching it fail with the offence named**, rather than trusted for passing green:

```
+   "dist/cli.mjs: import.meta.main",
+   "dist/cli.mjs: Bun namespace",
(fail) Bun-only APIs > do not appear in any committed runtime bundle
+   "src/experiments/geometry-acceptance.ts: import.meta.main",
(fail) Bun-only APIs > are not used to decide an entry point in shipped source
```

The entire reason this class survived as long as it did is that nothing was looking, and a guard that cannot fail would have reproduced that exactly.

## Gates

`typecheck` clean, `lint` exit 0 at the unchanged 14/11 baseline, **1828 pass / 2 skip / 0 fail** across 210 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)