### PR TITLE
fix: the Pages upload was stripping the well-known index

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -104,10 +104,19 @@ jobs:
 
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         if: github.event_name != 'pull_request'
+      # `include-hidden-files` is required, not optional. v5 of this action archives
+      # with `--exclude=.[^/]*` unless it is set, which silently strips EVERY
+      # hidden path. The well-known skills index is at `.well-known/`, so the first
+      # deployment built it correctly, vite copied it correctly, and the upload
+      # deleted it: 465 entries in the artifact and not one of them a dotfile,
+      # while the same build locally produced all seven. Nothing reproducible on a
+      # workstation would have found this, because the exclusion is in the action
+      # rather than in the build.
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         if: github.event_name != 'pull_request'
         with:
           path: site/dist
+          include-hidden-files: true
 
   deploy:
     name: deploy to Pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ GitHub. The package is not published on the npm registry.
 - **This path carries skills and no MCP server**, so a client that loads them has
   the workflows and none of the tools they describe. `docs/install.md` says so
   where it offers the URL.
+- **Follow-up:** the first deployment served a 404, and neither the build nor
+  Pages was at fault. `actions/upload-pages-artifact` v5 archives with
+  `--exclude=.[^/]*` unless `include-hidden-files` is set, so it strips *every*
+  hidden path — and a well-known URI is under a dotted directory by definition.
+  The artifact had 465 entries and not one dot-entry, while the same build
+  locally produced all seven files. Fixed by setting the flag, verified to add
+  exactly `.well-known` and nothing else.
 
 ## Bun-only APIs cannot reach a Node bundle unnoticed — 2026-09-11
 

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -1455,3 +1455,37 @@ stops mattering as much.
 Until one of those exists, reporting the inherited loadout -- which the setup skill
 already does, and which the blind run did unprompted -- is the whole of what can
 be done. That is a weaker outcome than the row wanted and it is the honest one.
+
+### 7.13's first deployment served a 404, and the build was not at fault
+
+Worth recording because the diagnosis ran the wrong way round for a while, and
+because the cause is the failure class this document keeps naming.
+
+The index was generated in CI -- the step logged all six skills with digests
+byte-identical to a local build, which incidentally proved the archives
+deterministic across machines as well as across runs. `vite build` copied
+`public/` to `dist/` as it does locally. And
+`https://kilnstudio.tools/.well-known/agent-skills/index.json` returned 404.
+
+Downloading the Pages artifact settled it: 465 entries, `assets/`, `thumbs/`,
+`build/` and the loose files, and **not one dot-entry**. So the files never
+reached the deployment, which ruled out Pages' serving layer and Jekyll, the two
+usual suspects. Reproducing CI's exact step order locally produced all seven
+files, which ruled out the build.
+
+The cause is in the action. `actions/upload-pages-artifact` v5 archives with:
+
+```
+--exclude=.git --exclude=.github ${{ inputs.include-hidden-files != 'true' && '--exclude=.[^/]*' || '' }} .
+```
+
+`--exclude=.[^/]*` strips **every** hidden path unless `include-hidden-files` is
+set. A well-known URI is by definition under a dotted directory, so the default
+silently deletes exactly what RFC 8615 requires. Nothing on a workstation could
+have reproduced it: the exclusion lives in the upload, not the build.
+
+Two things generalize. Reading the pinned action's own `action.yml` at its pinned
+SHA answered in one request what several rounds of deduction had not -- the
+dependency was right there and pinned, so there was nothing to guess about. And
+`.well-known` is the only dot-entry in `site/dist`, so the flag was verified to
+add exactly that and nothing else before being set.


### PR DESCRIPTION
7.13's first deployment served a 404, and **neither the build nor Pages was at fault.**

- The index was generated in CI — the step logged all six skills with digests **byte-identical to a local build**, which incidentally proves the archives deterministic across machines as well as across runs.
- `vite build` copied `public/` into `dist/` exactly as it does locally.
- Reproducing CI's step order on a workstation produced all seven files.

Downloading the Pages artifact settled it: **465 entries, and not one dot-entry.** The files never reached the deployment, which rules out Pages' serving layer and Jekyll — the two usual suspects for this symptom.

## The cause is in the action

`actions/upload-pages-artifact` v5 archives with:

```
--exclude=.git --exclude=.github ${{ inputs.include-hidden-files != 'true' && '--exclude=.[^/]*' || '' }} .
```

That third pattern strips **every** hidden path unless `include-hidden-files` is set. A well-known URI is under a dotted directory by definition, so the default silently deletes exactly what RFC 8615 requires.

Nothing reproducible locally would have found this, because the exclusion lives in the upload rather than in the build.

## Two things that generalise

Reading the pinned action's own `action.yml` **at its pinned SHA** answered in one request what several rounds of deduction had not — the dependency was right there and pinned, so there was nothing to guess about.

And `.well-known` is the only dot-entry in `site/dist`, so the flag was verified to add exactly that and nothing else before being set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)