### PR TITLE
chore: the guide pinned a toolchain the gate rejects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Preserve that distinction and the provider usage fields when changing model rout
 
 ## Toolchain and validation
 
-Supported toolchain: Bun `1.3.14`; Node `22.23.1`; npm `12.0.1`. Do not use a Bun canary or implicit
+Supported toolchain: Bun `1.4.2`; Node `22.23.2`; npm `12.0.2`. Do not use a Bun canary or implicit
 latest for a release gate.
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## The guide was pinning a toolchain the gate rejects — 2026-09-11
+
+- `AGENTS.md`, `CONTRIBUTING.md`, `README.md`, `docs/google.md` and
+  `docs/install.md` still named Bun 1.3.14, Node 22.23.1 and npm 12.0.1 after the
+  bump to 1.4.2/22.23.2/12.0.2. `AGENTS.md` is the guide every harness reads, so
+  the first command a new contributor ran installed a Bun that
+  `bun run check:toolchain` — the next command in the same list — then rejected.
+- `scripts/check-toolchain.mjs` now asserts those five documents state the
+  supported triple, and that `pages.yml` pins the same Bun as `ci.yml`. The gate
+  had enforced `package.json` and `ci.yml` and nothing else, so both the prose and
+  the second workflow could drift silently; `pages.yml` was correct today only
+  because it was set by hand in the same change. Verified by injecting each of the
+  three defects and confirming a non-zero exit, rather than by observing a pass.
+- Dated receipts under `docs/evaluation/` are deliberately excluded from the
+  check. They record the toolchain a run actually used, and rewriting one to match
+  a new pin would falsify it.
+
 ## Skills are fetchable by URL — 2026-09-11
 
 - The six skills are published at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ used CPU or GPU. Remove credentials and private paths from shared logs.
 ## Work on the engine
 
 Read [AGENTS.md](AGENTS.md) and the [README](README.md). Contributor checks use Bun
-1.3.14, Node 22.23.1 and npm 12.0.1. End users only need Node/npm for a built package.
+1.4.2, Node 22.23.2 and npm 12.0.2. End users only need Node/npm for a built package.
 
 ```sh
 bun install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cd ../my-assets
 
 Choose `claude`, `codex`, `opencode`, `hermes`, or `agy` for `--harness`, then open that harness in the
 new directory using its generated START.md instructions and accept its project and MCP trust prompts. Sign in to your harness
-first. The MCP server and local CLI are tested on Node.js 22.23.1.
+first. The MCP server and local CLI are tested on Node.js 22.23.2.
 
 Try: “Read AGENTS.md, then make a wooden workbench with a lower shelf. Render it,
 review the result, and save the source and GLB.”

--- a/docs/google.md
+++ b/docs/google.md
@@ -20,7 +20,7 @@ cd ../my-assets
 node agy.mjs --model gemini-3.8-flash-high
 ```
 
-Use the supported Bun 1.3.14 and Node 22.23.1 toolchain. A built package avoids the
+Use the supported Bun 1.4.2 and Node 22.23.2 toolchain. A built package avoids the
 Bun/build steps: run `npm exec --offline -- kiln-init ../my-assets --harness agy`
 from its installation directory instead. Check [release compatibility](install.md#release-compatibility)
 before following saved-asset examples with an older package.

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,7 +43,7 @@ release. Do not substitute an unverified npm registry package.
 ## Start on a Mac with a local package
 
 Install Node.js from the [official download page](https://nodejs.org/en/download).
-The pinned package-test runtime is Node **22.23.1**. Use native ARM64 Node on Apple
+The pinned package-test runtime is Node **22.23.2**. Use native ARM64 Node on Apple
 Silicon, or x64 Node on an Intel Mac. Check what this terminal is running:
 
 ```sh
@@ -53,7 +53,7 @@ node -p "process.platform + ' ' + process.arch"
 ```
 
 The last line should say `darwin arm64` or `darwin x64`. The npm supplied with Node
-can install the package; contributor CI pins npm 12.0.1 for reproducible receipts.
+can install the package; contributor CI pins npm 12.0.2 for reproducible receipts.
 You do not need to change global npm or install Homebrew for this workflow.
 
 Choose a permanent installation directory and use the real tarball filename:
@@ -279,7 +279,7 @@ with Docker running. See the [recorded Linux package check](evaluation/platform-
 for the pinned image, exact candidate hash, coverage, and limitations.
 
 CI builds one tarball on Linux, then runs the same npm package smoke natively on
-`macos-15` (ARM64) and `macos-15-intel` (x64), with Node 22.23.1 and npm 12.0.1.
+`macos-15` (ARM64) and `macos-15-intel` (x64), with Node 22.23.2 and npm 12.0.2.
 The Mac jobs install no contributor dependencies and do not set up Bun. Their
 retained receipts include the tarball hash, native architecture and completed
 checks. These versioned runner labels follow [GitHub's runner catalog](https://docs.github.com/en/actions/reference/runners/github-hosted-runners);

--- a/scripts/check-toolchain.mjs
+++ b/scripts/check-toolchain.mjs
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 const filesOnly = process.argv.includes('--files-only');
 const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
 const workflow = await readFile(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8');
+const pages = await readFile(new URL('../.github/workflows/pages.yml', import.meta.url), 'utf8');
 
 const expectedPackageManager = 'bun@1.4.2';
 const expectedEngines = { bun: '1.4.2', node: '22.23.2', npm: '12.0.2' };
@@ -29,6 +30,35 @@ if (!/^\s*node-version:\s*22\.23\.2\s*$/mu.test(workflow)) {
 }
 if (!workflow.includes('npm install --global npm@12.0.2')) {
   errors.push('CI npm version must be 12.0.2');
+}
+if (!new RegExp(`^\\s*bun-version:\\s*${expectedEngines.bun}\\s*$`, 'mu').test(pages)) {
+  errors.push(`Pages bun-version must be ${expectedEngines.bun}`);
+}
+// The gate enforced package.json and ci.yml but never the prose, so the guide
+// went on telling every harness to install Bun 1.3.14 for a day after the bump --
+// the first command a new contributor runs, failing against the checker below it.
+// Dated receipts under docs/evaluation/ are deliberately absent: they record the
+// toolchain a run actually used, and rewriting one to match a new pin would
+// falsify it.
+const guidance = [
+  ['AGENTS.md', [`Bun \`${expectedEngines.bun}\`; Node \`${expectedEngines.node}\`; npm \`${expectedEngines.npm}\``]],
+  ['CONTRIBUTING.md', [`${expectedEngines.bun}, Node ${expectedEngines.node} and npm ${expectedEngines.npm}`]],
+  ['README.md', [`Node.js ${expectedEngines.node}`]],
+  ['docs/google.md', [`Bun ${expectedEngines.bun} and Node ${expectedEngines.node}`]],
+  [
+    'docs/install.md',
+    [
+      `Node **${expectedEngines.node}**`,
+      `npm ${expectedEngines.npm} for reproducible receipts`,
+      `Node ${expectedEngines.node} and npm ${expectedEngines.npm}`,
+    ],
+  ],
+];
+for (const [name, phrases] of guidance) {
+  const body = await readFile(new URL(`../${name}`, import.meta.url), 'utf8');
+  for (const phrase of phrases) {
+    if (!body.includes(phrase)) errors.push(`${name} must state the supported toolchain: ${phrase}`);
+  }
 }
 if (!workflow.includes('run: bun run check:toolchain')) {
   errors.push('CI must run the toolchain metadata check');


### PR DESCRIPTION
## What was wrong

Five current-guidance documents still named **Bun 1.3.14, Node 22.23.1, npm 12.0.1** after the bump to 1.4.2 / 22.23.2 / 12.0.2.

`AGENTS.md` is the guide every harness reads. Its toolchain line sits directly above the command list, so the first thing a new contributor did was install a Bun that `bun run check:toolchain` — the *next* command in that same list — then rejected.

Corrected in `AGENTS.md`, `CONTRIBUTING.md`, `README.md`, `docs/google.md` and `docs/install.md`.

## Why it could happen at all

`check-toolchain.mjs` enforced `package.json` and `ci.yml`. Nothing else. So the prose could drift, and so could the second workflow — `pages.yml` has its own `bun-version` and was never checked; it is correct today only because it was set by hand in the same change that bumped `ci.yml`.

The checker now asserts both.

## Verified by failing, not by passing

Each of the three defects was injected and the exit code confirmed non-zero:

| Injected defect | Result |
| --- | --- |
| `AGENTS.md` reverted to the stale triple | `AGENTS.md must state the supported toolchain: Bun ...` — exit 1 |
| `pages.yml` left behind on a bump | `Pages bun-version must be 1.4.2` — exit 1 |
| `docs/install.md` npm line stale | `docs/install.md must state the supported toolchain: npm 12.0.2 ...` — exit 1 |

## What is deliberately not checked

Dated receipts under `docs/evaluation/` keep the versions they were produced on — twenty-odd files naming 1.3.14 / 22.23.1. They are evidence of what a run actually used, and rewriting one to match a new pin would falsify it. The check covers current guidance only.

## Gate

`check:toolchain` pass · `typecheck` clean · `lint` 14 warnings / 11 infos (unchanged baseline) · `test` 1831 pass, 2 skip, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)