### PR TITLE
fix: the r186 bump missed the site, and now a gate catches that

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## The r186 bump missed the site, and now a gate catches that — 2026-09-12
+
+- `site/` was still on three 0.185.1 while the engine and `render-service` moved to
+  0.186.0. Substantive rather than untidy: kiln emits `EXT_mesh_gpu_instancing`, and
+  r186 fixed that extension's custom instance attribute sharing in `GLTFLoader`, so
+  the site was rendering the gallery with an unfixed loader for an extension the
+  engine writes.
+- `check:toolchain` now asserts `three` is byte-identical in every manifest that pins
+  it, and that `@types/three` tracks its minor. Verified by injecting three defects —
+  the exact drift that shipped, a `render-service` drift, and a stale `@types/three` —
+  and confirming each is caught and names the offending manifest.
+- The reason this is a gate and not a note: the same class of defect, a value that
+  must agree across files with nothing enforcing it, had been caught in the prose that
+  same morning by a person. Twice in one day is an argument for a check.
+
 ## Finishing the CommonJS removal the r186 bump started — 2026-09-12
 
 - The previous entry's fix was incomplete, and looked complete.

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -1549,3 +1549,43 @@ documented split -- validate covers syntax and sandbox rules, not semantics -- a
 Lane B's sandbox rejection did carry its specific diagnostic
 (`generated code used an undeclared variable`), so the generic message is what a
 caller sees only when no diagnostic maps to the failure.
+
+## Phase 13 -- Parity, gates, and the remaining polish queue
+
+Opened 2026-09-12. Phases 6, 9, 10, 11 and 12 are closed; 7.12 is the only older
+row still open and it is blocked upstream. This phase is the agreed queue for
+getting the repository to a state a stranger can build on, decided with the owner
+on 2026-09-12.
+
+### The lesson this phase starts from
+
+The r186 bump moved `three` in the engine and in `render-service` and **missed
+`site/`**. That is not tidiness: kiln emits `EXT_mesh_gpu_instancing`, and r186
+fixed that extension's custom instance attribute sharing in `GLTFLoader`, so a
+site one minor behind renders the gallery with an unfixed loader for an extension
+the engine writes. The same class of defect -- a value that must agree across
+files with nothing enforcing it -- had been caught in the prose that same morning,
+by a person, hours earlier. Twice in one day is the argument for a gate rather
+than for more care.
+
+| ID | Task | State |
+| --- | --- | --- |
+| 13.1 | `site/` to three 0.186.0, and `check:toolchain` gains a cross-manifest guard: `three` must be byte-identical in every manifest that pins it, and `@types/three` must track its minor | **Done 2026-09-12.** Verified by injecting three separate defects -- the exact site drift that shipped, a `render-service` drift, and a `@types/three` left a minor behind -- and confirming each is caught and names the offending manifest |
+| 13.2 | Safe in-range dependency refresh, kept strictly separate from the deferred majors: `ai` 6.0.222 to 6.0.282, `openai` 6.46.0 to 6.49.0, `@ai-sdk/provider` 3.0.14 to 3.0.16, `@aws-sdk/client-bedrock-runtime` 3.1083.0 to 3.1131.0, and in `site/` react/react-dom 19.3.0 and vite 8.3.0 | Approved, not started |
+| 13.3 | Raise the coverage ratchet from 92/91 to 94/92. Measured 95.27% functions / 92.49% lines, so this keeps roughly 1.3 and 0.5 points for normal churn | Approved, not started |
+| 13.4 | Promote the Windows job from `continue-on-error` to blocking | Approved, not started. The suite itself has never failed there; both red runs were new code of this session's own -- a `sharp/package.json` require and a `URL.pathname` that yields `/D:/...` -- which is the job doing its job |
+| 13.5 | Clear the one substantive lint finding: an unused import in `src/__tests__/optimize.test.ts`. Everything else in the 14/11 baseline is `useTemplate` and `useOptionalChain` style | Approved, not started |
+| 13.6 | Decide shadows by comparison, not assumption. r186 deleted the `PCFSoftShadowMap` implementation; `render-service` now names `PCFShadowMap`, and `VSMShadowMap` is the soft filter that survives. Render gallery presets under both and choose by eye, because this is the only user-visible regression in the r186 upgrade and it lands on marketing surface | Approved, not started |
+
+### Explicitly not in this phase
+
+- **7.12 / SEP-2640.** Still `In Review` on the Skills Over MCP working group's own
+  board, with the reference implementation also in review. Nothing to build against.
+  Re-checked 2026-09-11; the first summary read claimed it had gone Final, and that
+  was wrong -- the charter is the authority, not a page summary.
+- **The `ai` 7 / `@ai-sdk/provider` 4 / `@openrouter/ai-sdk-provider` 3 family.**
+  Deferred by decision. Only `test:live` exercises those paths, it spends money, and
+  the deliberate prompt-cache transport asymmetry is exactly what a provider major
+  breaks silently. 13.2 deliberately takes the in-range updates and leaves these.
+- **11.4.** Answered: the CLI already joins a running service, and auto-spawn would
+  make a one-shot command pay a GPU startup it cannot amortize.

--- a/scripts/check-toolchain.mjs
+++ b/scripts/check-toolchain.mjs
@@ -40,6 +40,36 @@ if (!new RegExp(`^\\s*bun-version:\\s*${expectedEngines.bun}\\s*$`, 'mu').test(p
 // Dated receipts under docs/evaluation/ are deliberately absent: they record the
 // toolchain a run actually used, and rewriting one to match a new pin would
 // falsify it.
+// three ships in three manifests -- the engine, the GPU render service, and the
+// site's viewer -- and they must agree. Not tidiness: kiln EMITS
+// EXT_mesh_gpu_instancing, and r186 fixed that extension's custom instance
+// attribute sharing in GLTFLoader, so a site one minor behind renders the gallery
+// with an unfixed loader for an extension the engine writes. The r186 bump moved
+// the engine and the service and missed the site, which is why this is a gate and
+// not a note: the same class of drift had already been caught in the prose that
+// morning, by a person, hours earlier.
+const threeManifests = ['package.json', 'render-service/package.json', 'site/package.json'];
+const threePins = new Map();
+for (const name of threeManifests) {
+  const manifest = JSON.parse(await readFile(new URL(`../${name}`, import.meta.url), 'utf8'));
+  const deps = { ...manifest.dependencies, ...manifest.devDependencies };
+  if (deps.three !== undefined) threePins.set(name, deps.three);
+  // `@types/three` tracks three's minor. A caret range is fine; a DIFFERENT minor is
+  // the bug, because the types then describe a release the runtime is not running.
+  if (deps['@types/three'] !== undefined) {
+    const wanted = String(deps.three ?? threePins.get('package.json') ?? '').split('.').slice(0, 2).join('.');
+    if (wanted && !String(deps['@types/three']).replace(/^[\^~]/u, '').startsWith(`${wanted}.`)) {
+      errors.push(`${name}: @types/three ${deps['@types/three']} does not track three ${wanted}.x`);
+    }
+  }
+}
+{
+  const distinct = new Set(threePins.values());
+  if (distinct.size > 1) {
+    const shown = [...threePins].map(([name, pin]) => `${name}=${pin}`).join(', ');
+    errors.push(`three must be identical in every manifest that pins it: ${shown}`);
+  }
+}
 const guidance = [
   ['AGENTS.md', [`Bun \`${expectedEngines.bun}\`; Node \`${expectedEngines.node}\`; npm \`${expectedEngines.npm}\``]],
   ['CONTRIBUTING.md', [`${expectedEngines.bun}, Node ${expectedEngines.node} and npm ${expectedEngines.npm}`]],

--- a/site/bun.lock
+++ b/site/bun.lock
@@ -9,12 +9,12 @@
         "@react-three/fiber": "^9.7.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "three": "0.185.1",
+        "three": "0.186.0",
       },
       "devDependencies": {
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.7",
-        "@types/three": "^0.185.4",
+        "@types/three": "^0.186.0",
         "@vitejs/plugin-react": "^6.1.1",
         "typescript": "^7.0.2",
         "vite": "^8.2.2",
@@ -82,7 +82,7 @@
 
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
 
-    "@types/three": ["@types/three@0.185.4", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA=="],
+    "@types/three": ["@types/three@0.186.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.3", "meshoptimizer": "~1.1.1" } }, "sha512-mxYSBpDC+D0pLfSP6sW4WZTcT+nrtmZcimMqnVmy36Hte3XpeYSrvgg4TRdaM1GemGog1AWzI5qL2VoIfMXbJQ=="],
 
     "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
@@ -242,7 +242,7 @@
 
     "suspend-react": ["suspend-react@0.1.3", "", { "peerDependencies": { "react": ">=17.0" } }, "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ=="],
 
-    "three": ["three@0.185.1", "", {}, "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg=="],
+    "three": ["three@0.186.0", "", {}, "sha512-cr/fIM2ddMSVbYVgkfD4jLJv7Fh/8ZTjvo+7gQeSVGUZHxpx9FDwoL5iC7hUz/LiRA8wMbqfnb90xKfm1/HHkQ=="],
 
     "three-mesh-bvh": ["three-mesh-bvh@0.8.3", "", { "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg=="],
 

--- a/site/package.json
+++ b/site/package.json
@@ -14,12 +14,12 @@
     "@react-three/fiber": "^9.7.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "three": "0.185.1"
+    "three": "0.186.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.7",
-    "@types/three": "^0.185.4",
+    "@types/three": "^0.186.0",
     "@vitejs/plugin-react": "^6.1.1",
     "typescript": "^7.0.2",
     "vite": "^8.2.2"


### PR DESCRIPTION
## The gap

`site/` was still on **three 0.185.1** while the engine and `render-service` moved to 0.186.0 in [#79](https://github.com/matthew-kissinger/kiln/pull/79).

Substantive rather than untidy: kiln **emits** `EXT_mesh_gpu_instancing` ([src/render.ts:121](src/render.ts:121)), and r186 fixed that extension's custom instance attribute sharing *in `GLTFLoader`*. So the site was rendering the gallery with an unfixed loader for an extension the engine writes.

## Why a gate and not a note

The same class of defect — a value that must agree across files, with nothing enforcing it — had been caught in the *prose* that same morning ([#77](https://github.com/matthew-kissinger/kiln/pull/77), the guide pinning a toolchain the gate rejected). By a person, hours earlier. Twice in one day is the argument for a check rather than for more care.

`check:toolchain` now asserts:
- `three` is byte-identical in every manifest that pins it (root, `render-service`, `site`)
- `@types/three` tracks three's minor wherever it appears

## Verified by failing, three ways

| Injected defect | Caught as |
| --- | --- |
| **The exact drift that shipped** — site left on 0.185.1 | `three must be identical in every manifest that pins it: package.json=0.186.0, render-service/package.json=0.186.0, site/package.json=0.185.1` |
| `render-service` drifts instead | same rule, naming `render-service/package.json=0.185.1` |
| `@types/three` left a minor behind | `package.json: @types/three ^0.185.4 does not track three 0.186.x` |

Each names the offending manifest rather than just failing.

## Also: Phase 13 recorded on the ledger

The agreed remaining queue, so it survives a context reset — in-range dependency refresh (kept strictly separate from the deferred `ai` 7 majors), coverage ratchet 92/91 → 94/92, promoting the Windows job to blocking, the one substantive lint finding, and deciding shadows by comparing PCF against VSM on real gallery presets.

## Gate

`check:toolchain` pass · `typecheck` clean · `lint` 14/11 unchanged · `test` **1835 pass, 0 fail** · site `tsc --noEmit` clean, `vite build` clean, site scripts 8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)