### PR TITLE
chore: lint the repository's own gates, which were never linted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## The repository's own gates are linted now — 2026-09-12
+
+- Adding a file to `scripts/` and running `biome check` on its path printed "No files
+  were processed." Biome's `files.includes` was `src/`, `site/src/` and `site/*.ts`, so
+  the directory holding this repository's gates — and which `test:coverage` already
+  measures — sat outside the lint surface. The zero-warning baseline 13.5 established
+  was zero across a subset.
+- Taken: `scripts/check-*.mjs` and `scripts/**/*.test.mjs` — the checks are now checked.
+  416 files where 405 were. Ten findings were behind the hole: seven format, and three
+  real ones. A dead `const` in `check-vision.mjs`, easy to miss because the identical
+  line two loops down is load-bearing. Two `useTemplate` on the
+  `JSON.stringify(…) + '\n'` idiom. `reliability.test.mjs` asserts both include
+  patterns, verified by dropping one and watching it fail.
+- Left, with the cost measured rather than guessed. The rest of `scripts/` is one-off
+  tools, several authored as dense single-expression lines. Taking the whole directory
+  is 26 lint findings, a 1,530-line reflow (3,078 lines to 4,608, pure formatting), and
+  **162 lines of coverage slack** — `test:coverage` measures `scripts`, those tools are
+  never executed, so the reflow lands in the uncovered denominator and lines fall
+  92.49% to 92.14% against a threshold of 92. Measured by taking the full pass and
+  running the gate.
+- Which says something about the ratchet worth recording: line coverage over manual
+  helper scripts is noise inside a number this repository treats as a contract.
+  Narrowing what `test:coverage` measures is the real fix, and a separate decision.
+- `render-service/` stays out for an unrelated reason: its sources are CRLF by
+  `.gitattributes`, and the formatter would rewrite the line endings.
+- One incidental finding: Biome prints at most 20 diagnostics by default, so a count
+  read off `bun run lint` is a floor, not a total. The gate still fails either way.
+
 ## The prompt-cache breakpoint is asserted on the wire — 2026-09-12
 
 - The two deferred rows in the queue were both deferred *with a reason*. Checking the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,14 @@ bun run test:coverage
 tolerated baseline to compare against, so any diagnostic your change produces is
 yours -- either fix it, or suppress it with a `biome-ignore` comment that says why.
 
+The surface is `src/`, `site/src/`, `site/*.ts`, and in `scripts/` the gates and
+their tests (`check-*.mjs`, `**/*.test.mjs`). The one-off tools beside them and
+`render-service/` are out -- see ledger 14.4 for what taking them costs. If you add
+a directory, add it to `files.includes` in `biome.json`: Biome silently processes
+nothing outside that list, which is how `scripts/` went unlinted while the coverage
+run measured it. Note that `biome` prints at most 20 diagnostics by default, so a
+count read off the output is a floor.
+
 For behavior changes, first add a focused failing test, then make the smallest fix
 and run the relevant checks. Keep the coverage thresholds. Ordinary tests use CPU
 rendering and make no model calls. Live provider tests are optional and can spend

--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,13 @@
   "$schema": "https://biomejs.dev/schemas/2.5.13/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
-    "includes": ["src/**/*.ts", "site/src/**/*.{ts,tsx}", "site/*.ts"],
+    "includes": [
+      "src/**/*.ts",
+      "site/src/**/*.{ts,tsx}",
+      "site/*.ts",
+      "scripts/check-*.mjs",
+      "scripts/**/*.test.mjs"
+    ],
     "maxSize": 4194304
   },
   "formatter": {

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -1668,6 +1668,7 @@ the installed tree.
 | 14.1 | Re-ground 7.12 / SEP-2640 against an authoritative source | **Done 2026-09-12.** Deferred still, for a stronger reason. See below |
 | 14.2 | Establish what actually blocks the `ai` 7 family, and gate it | **Done 2026-09-12.** `@strands-agents/sdk@1.17.0` is latest, declares peer `@ai-sdk/provider: ^3.0.0`, and its `VercelModel` is typed on `LanguageModelV3` in 21 places. `@openrouter/ai-sdk-provider@3.0.0` requires `ai: ^7.0.0`; `ai@7.0.99` depends on `@ai-sdk/provider@4.0.14`. The family cannot be taken until Strands ships a release accepting the v4 spec -- no budget changes that. `scripts/peer-ranges.test.mjs` now fails on a peer range the version beside it does not meet, verified by patching the installed `@openrouter/ai-sdk-provider` manifest to peer `ai: ^7.0.0` and watching it report `installed 6.0.282` |
 | 14.3 | Assert the prompt-cache breakpoint on the wire, offline | **Done 2026-09-12.** Both native transports captured in `src/agent/providers.test.ts`, both differential. See below |
+| 14.4 | Bring the repository's own gates under the lint gate, which they were never under | **Done 2026-09-12** for the gates and their tests: 416 files checked where 405 were, and the tree reports nothing. The one-off tools beside them are measured and deliberately left, below |
 
 ### 14.1 -- the decisive fact is not the SEP's status
 
@@ -1741,3 +1742,51 @@ Verified the way the rest of this queue was -- by patching the installed Strands
 adapters to drop `cache_control` and the converse `cachePoint`. Each injection fails
 exactly the new test while **every pre-existing test stays green**, including the one
 named "the adapter emits `cache_control`", which never checked that it did.
+
+### 14.4 -- the lint baseline covered a subset of the repository
+
+13.5 took the lint baseline to zero and `CONTRIBUTING.md` said so. Biome's
+`files.includes` was `src/**/*.ts`, `site/src/**/*.{ts,tsx}` and `site/*.ts`, so
+`scripts/` -- which holds this repository's own gates, and which `test:coverage`
+already measures -- was outside the surface entirely. Found by adding
+`scripts/peer-ranges.test.mjs` and watching `biome check` on its own path report
+"No files were processed."
+
+**Taken: the gates and their tests.** `scripts/check-*.mjs` and
+`scripts/**/*.test.mjs`, which is a category rather than a subset -- the checks are
+now checked. 416 files where 405 were. Ten findings were behind the hole: seven
+format, reflowing seven files by 116 lines in total, and three real ones. A dead
+`const` in `check-vision.mjs`, easy to miss because the identical line two loops
+down is load-bearing, which is also what made the fix need a block-scoped anchor.
+And two `useTemplate` on the `JSON.stringify(...) + '\n'` idiom. `reliability.test.mjs`
+asserts both include patterns, verified by dropping `scripts/check-*.mjs` and
+watching it fail: a directory silently leaving the lint surface is how this started.
+
+**Left, with the cost measured rather than guessed.** The rest of `scripts/` is
+one-off tools -- dispatch, promotion, poster upload, geometry experiments -- and
+several are authored as dense single-expression lines; `observe-shipping.test.mjs`
+was one 1,300-character line before this pass. Taking the whole directory costs:
+
+- **26 lint findings**, 22 of them the same `+ '\n'` idiom, several inside minified
+  lines where the fix is unreviewable and the file is no more readable after.
+- **A 1,530-line reflow.** `scripts/` goes from 3,078 lines to 4,608, a 50% growth
+  that is entirely formatting.
+- **162 lines of coverage slack.** `test:coverage` measures `src scripts`, the
+  one-off tools are never executed by a test, so the reflow lands almost entirely
+  in the uncovered denominator: lines fall 92.49% to 92.14% against a threshold of
+  92, leaving 62 lines of room where there were 224. Measured by taking the full
+  pass and running the gate, not estimated.
+
+That third cost is the interesting one, because it says something the ratchet has
+been quietly absorbing all along: line coverage over manual helper scripts is
+noise in a number the repository treats as a contract. Narrowing what
+`test:coverage` measures is the real fix and it is a separate decision, so it is
+recorded here rather than folded in.
+
+`render-service/` stays out for an unrelated reason: its `src/**` is CRLF by
+`.gitattributes` and Biome's formatter would rewrite the line endings.
+
+One incidental finding worth keeping. Biome caps output at 20 diagnostics by
+default, so `bun run lint` reported 20 findings in `scripts/` when there were 26.
+`--error-on-warnings` still fails the gate, so nothing escapes -- but a count read
+off that output is a floor, not a total.

--- a/scripts/check-coverage.test.mjs
+++ b/scripts/check-coverage.test.mjs
@@ -31,7 +31,10 @@ async function fixture(thresholds, measuredBaseline = { functions: 100, lines: 1
       '',
     ].join('\n'),
   );
-  await writeFile(join(directory, 'thresholds.json'), JSON.stringify({ measuredBaseline, thresholds }));
+  await writeFile(
+    join(directory, 'thresholds.json'),
+    JSON.stringify({ measuredBaseline, thresholds }),
+  );
   return directory;
 }
 

--- a/scripts/check-skills.mjs
+++ b/scripts/check-skills.mjs
@@ -74,7 +74,9 @@ async function validate(label, dir, name) {
   const declared = fields.get('name');
   const description = fields.get('description');
   if (declared !== name) {
-    errors.push(`${label}: name is ${declared ?? '(absent)'} but must match the directory, ${name}`);
+    errors.push(
+      `${label}: name is ${declared ?? '(absent)'} but must match the directory, ${name}`,
+    );
   }
   if (!/^[a-z0-9]+(-[a-z0-9]+)*$/u.test(name) || name.length > 64) {
     errors.push(`${label}: name must be 1-64 lowercase alphanumerics with single hyphens`);
@@ -84,7 +86,8 @@ async function validate(label, dir, name) {
     errors.push(`${label}: description is ${description.length} characters, over the 1024 maximum`);
   }
   for (const key of fields.keys()) {
-    if (!SPEC_KEYS.has(key)) errors.push(`${label}: ${key} is not an Agent Skills frontmatter field`);
+    if (!SPEC_KEYS.has(key))
+      errors.push(`${label}: ${key} is not an Agent Skills frontmatter field`);
   }
   const lines = text.split(/\r?\n/u).length;
   if (lines > 500) errors.push(`${label}: SKILL.md is ${lines} lines, over the recommended 500`);
@@ -113,7 +116,9 @@ for (const registry of REGISTRIES) {
     .sort();
   const expected = [...REGISTERED].sort();
   if (present.join(',') !== expected.join(',')) {
-    errors.push(`${registry}/ holds [${present.join(', ')}] but must hold exactly [${expected.join(', ')}]`);
+    errors.push(
+      `${registry}/ holds [${present.join(', ')}] but must hold exactly [${expected.join(', ')}]`,
+    );
   }
   for (const name of expected) {
     if (!present.includes(name)) continue;

--- a/scripts/check-toolchain.mjs
+++ b/scripts/check-toolchain.mjs
@@ -98,8 +98,16 @@ for (const name of manifests) {
   }
 }
 const guidance = [
-  ['AGENTS.md', [`Bun \`${expectedEngines.bun}\`; Node \`${expectedEngines.node}\`; npm \`${expectedEngines.npm}\``]],
-  ['CONTRIBUTING.md', [`${expectedEngines.bun}, Node ${expectedEngines.node} and npm ${expectedEngines.npm}`]],
+  [
+    'AGENTS.md',
+    [
+      `Bun \`${expectedEngines.bun}\`; Node \`${expectedEngines.node}\`; npm \`${expectedEngines.npm}\``,
+    ],
+  ],
+  [
+    'CONTRIBUTING.md',
+    [`${expectedEngines.bun}, Node ${expectedEngines.node} and npm ${expectedEngines.npm}`],
+  ],
   ['README.md', [`Node.js ${expectedEngines.node}`]],
   ['docs/google.md', [`Bun ${expectedEngines.bun} and Node ${expectedEngines.node}`]],
   [
@@ -114,17 +122,21 @@ const guidance = [
 for (const [name, phrases] of guidance) {
   const body = await readFile(at(name), 'utf8');
   for (const phrase of phrases) {
-    if (!body.includes(phrase)) errors.push(`${name} must state the supported toolchain: ${phrase}`);
+    if (!body.includes(phrase))
+      errors.push(`${name} must state the supported toolchain: ${phrase}`);
   }
 }
 if (!workflow.includes('run: bun run check:toolchain')) {
   errors.push('CI must run the toolchain metadata check');
 }
 for (const ref of workflow.matchAll(/uses:\s*([^\s#]+)/g)) {
-  if (!ref[1].startsWith('./') && !/@[0-9a-f]{40}$/i.test(ref[1])) errors.push(`CI Action ref must use an immutable commit SHA: ${ref[1]}`);
+  if (!ref[1].startsWith('./') && !/@[0-9a-f]{40}$/i.test(ref[1]))
+    errors.push(`CI Action ref must use an immutable commit SHA: ${ref[1]}`);
 }
 if (!filesOnly && process.versions.bun !== expectedEngines.bun) {
-  errors.push(`runtime Bun must be ${expectedEngines.bun} (found ${process.versions.bun ?? 'Node'})`);
+  errors.push(
+    `runtime Bun must be ${expectedEngines.bun} (found ${process.versions.bun ?? 'Node'})`,
+  );
 }
 if (!filesOnly) {
   const revision = spawnSync('bun', ['--revision'], { encoding: 'utf8', shell: false });
@@ -139,4 +151,6 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log(`Toolchain metadata: Bun ${expectedEngines.bun}, Node ${expectedEngines.node}, npm ${expectedEngines.npm}`);
+console.log(
+  `Toolchain metadata: Bun ${expectedEngines.bun}, Node ${expectedEngines.node}, npm ${expectedEngines.npm}`,
+);

--- a/scripts/check-vision.mjs
+++ b/scripts/check-vision.mjs
@@ -64,7 +64,6 @@ const byProvider = new Map();
 for (const m of models) {
   const slash = m.indexOf('/');
   const provider = slash > 0 ? m.slice(0, slash) : 'opencode';
-  const id = slash > 0 ? m.slice(slash + 1) : m;
   if (!byProvider.has(provider)) byProvider.set(provider, capabilities(provider));
 }
 
@@ -77,13 +76,18 @@ for (const m of models) {
   const caps = byProvider.get(provider)?.get(id);
   if (!caps) unknown.push(m);
   else if (caps.attachment !== true) blind.push(m);
-  const state = !caps ? 'not listed by this provider' : caps.attachment === true ? 'sees images' : 'TEXT ONLY';
+  const state = !caps
+    ? 'not listed by this provider'
+    : caps.attachment === true
+      ? 'sees images'
+      : 'TEXT ONLY';
   console.log(`  ${m.padEnd(44)} ${state}`);
 }
 
 if (blind.length || unknown.length) {
   console.error('');
-  if (blind.length) console.error(`refusing to dispatch ${blind.length} text-only model(s): ${blind.join(', ')}`);
+  if (blind.length)
+    console.error(`refusing to dispatch ${blind.length} text-only model(s): ${blind.join(', ')}`);
   if (unknown.length) console.error(`could not verify: ${unknown.join(', ')}`);
   process.exit(1);
 }

--- a/scripts/evaluation/observe-shipping.test.mjs
+++ b/scripts/evaluation/observe-shipping.test.mjs
@@ -1,4 +1,79 @@
-import {test} from 'node:test';import assert from 'node:assert/strict';import {EvaluationBudget,plannedCells} from './observe-shipping.mjs';
-test('parallel reservations cannot exceed image allowance and failed calls release reservations',()=>{const budget=new EvaluationBudget({maxCalls:30,maxImages:7});assert.equal(budget.reserve('one',6),null);assert.match(budget.reserve('two',2),/image/);budget.settle('one',0);assert.equal(budget.reserve('two',2),null);budget.settle('two',2);assert.equal(budget.stats().images,2);});
-test('call cap and shipping grid/separate counts are bounded before dispatch',()=>{const budget=new EvaluationBudget({maxCalls:1,maxImages:48});assert.equal(budget.reserve(1,0),null);assert.match(budget.reserve(2,0),/call/);assert.equal(plannedCells('kiln_render',{}),6);assert.equal(plannedCells('kiln_render',{capture:{version:'kiln.capture.v1',shots:[{},{}],output:'separate'}}),2);assert.equal(plannedCells('kiln_edit',{render:false}),0);});
-test('shipping proxy forwards actual PNGs while retaining source args/text and blocking excess calls',async()=>{const {mkdtempSync,writeFileSync,readFileSync,readdirSync}=await import('node:fs');const {tmpdir}=await import('node:os');const {join}=await import('node:path');const {spawn}=await import('node:child_process');const root=mkdtempSync(join(tmpdir(),'kiln-observer-proof-'));const fixture=join(root,'server.mjs');writeFileSync(fixture,`import {createInterface} from 'node:readline';createInterface({input:process.stdin}).on('line',line=>{const q=JSON.parse(line);console.log(JSON.stringify({jsonrpc:'2.0',id:q.id,result:{content:[{type:'text',text:'{"ok":true}'},{type:'image',mimeType:'image/png',data:'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aKk8AAAAASUVORK5CYII='}]}}));});`);const child=spawn(process.execPath,[new URL('./observe-shipping.mjs',import.meta.url).pathname.replace(/^\/([A-Za-z]:)/,'$1'),'--server',fixture,'--out',join(root,'out'),'--max-calls','1'],{stdio:['pipe','pipe','pipe'],windowsHide:true});let stdout='';child.stdout.on('data',chunk=>stdout+=chunk);const done=new Promise(resolve=>child.on('close',resolve));child.stdin.write(JSON.stringify({jsonrpc:'2.0',id:1,method:'tools/call',params:{name:'kiln_render',arguments:{code:'model-authored'}}})+'\n');child.stdin.end(JSON.stringify({jsonrpc:'2.0',id:2,method:'tools/call',params:{name:'kiln_render',arguments:{}}})+'\n');assert.equal(await done,0);const responses=stdout.trim().split('\n').map(JSON.parse);assert.ok(responses.find(r=>r.id===2).result.isError);assert.equal(responses.find(r=>r.id===1).result.content[1].data,'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aKk8AAAAASUVORK5CYII=');const trace=readFileSync(join(root,'out','transcript.jsonl'),'utf8');assert.match(trace,/model-authored/);assert.equal(readdirSync(join(root,'out','images')).length,1);});
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EvaluationBudget, plannedCells } from './observe-shipping.mjs';
+test('parallel reservations cannot exceed image allowance and failed calls release reservations', () => {
+  const budget = new EvaluationBudget({ maxCalls: 30, maxImages: 7 });
+  assert.equal(budget.reserve('one', 6), null);
+  assert.match(budget.reserve('two', 2), /image/);
+  budget.settle('one', 0);
+  assert.equal(budget.reserve('two', 2), null);
+  budget.settle('two', 2);
+  assert.equal(budget.stats().images, 2);
+});
+test('call cap and shipping grid/separate counts are bounded before dispatch', () => {
+  const budget = new EvaluationBudget({ maxCalls: 1, maxImages: 48 });
+  assert.equal(budget.reserve(1, 0), null);
+  assert.match(budget.reserve(2, 0), /call/);
+  assert.equal(plannedCells('kiln_render', {}), 6);
+  assert.equal(
+    plannedCells('kiln_render', {
+      capture: { version: 'kiln.capture.v1', shots: [{}, {}], output: 'separate' },
+    }),
+    2,
+  );
+  assert.equal(plannedCells('kiln_edit', { render: false }), 0);
+});
+test('shipping proxy forwards actual PNGs while retaining source args/text and blocking excess calls', async () => {
+  const { mkdtempSync, writeFileSync, readFileSync, readdirSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const { spawn } = await import('node:child_process');
+  const root = mkdtempSync(join(tmpdir(), 'kiln-observer-proof-'));
+  const fixture = join(root, 'server.mjs');
+  writeFileSync(
+    fixture,
+    `import {createInterface} from 'node:readline';createInterface({input:process.stdin}).on('line',line=>{const q=JSON.parse(line);console.log(JSON.stringify({jsonrpc:'2.0',id:q.id,result:{content:[{type:'text',text:'{"ok":true}'},{type:'image',mimeType:'image/png',data:'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aKk8AAAAASUVORK5CYII='}]}}));});`,
+  );
+  const child = spawn(
+    process.execPath,
+    [
+      new URL('./observe-shipping.mjs', import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1'),
+      '--server',
+      fixture,
+      '--out',
+      join(root, 'out'),
+      '--max-calls',
+      '1',
+    ],
+    { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true },
+  );
+  let stdout = '';
+  child.stdout.on('data', (chunk) => (stdout += chunk));
+  const done = new Promise((resolve) => child.on('close', resolve));
+  child.stdin.write(
+    `${JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'kiln_render', arguments: { code: 'model-authored' } },
+    })}\n`,
+  );
+  child.stdin.end(
+    `${JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'kiln_render', arguments: {} },
+    })}\n`,
+  );
+  assert.equal(await done, 0);
+  const responses = stdout.trim().split('\n').map(JSON.parse);
+  assert.ok(responses.find((r) => r.id === 2).result.isError);
+  assert.equal(
+    responses.find((r) => r.id === 1).result.content[1].data,
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aKk8AAAAASUVORK5CYII=',
+  );
+  const trace = readFileSync(join(root, 'out', 'transcript.jsonl'), 'utf8');
+  assert.match(trace, /model-authored/);
+  assert.equal(readdirSync(join(root, 'out', 'images')).length, 1);
+});

--- a/scripts/reliability.test.mjs
+++ b/scripts/reliability.test.mjs
@@ -60,7 +60,10 @@ describe('repository reliability contracts', () => {
     // finding, and a rule quietly lowered to keep a build green is indistinguishable from
     // a rule nobody wanted.
     const biome = JSON.parse(await readText('biome.json'));
-    const severities = Object.assign({}, ...Object.values(biome.linter.rules).filter((group) => typeof group === 'object'));
+    const severities = Object.assign(
+      {},
+      ...Object.values(biome.linter.rules).filter((group) => typeof group === 'object'),
+    );
     for (const rule of [
       'useTemplate',
       'useOptionalChain',
@@ -72,6 +75,16 @@ describe('repository reliability contracts', () => {
     ]) {
       expect(severities[rule], `${rule} must stay at error`).toBe('error');
     }
+    // The gates have to be inside the lint surface. `scripts/` sat outside
+    // `files.includes` while `test:coverage` measured it, so every check in this
+    // directory -- including the file you are reading -- was coverage-counted and
+    // never linted. Found by adding a file here and watching `biome check` on its
+    // own path report "No files were processed". The surface is the gates and their
+    // tests; the one-off tools beside them are a separate decision, recorded in
+    // ledger 14.4 with what taking them costs.
+    expect(biome.files.includes).toContain('scripts/check-*.mjs');
+    expect(biome.files.includes).toContain('scripts/**/*.test.mjs');
+
     // Views must be byte-reproducible: a runner that happens to reach a GPU render
     // service must not be able to change what the golden-image tests compare.
     expect(pkg.scripts['test']).toContain('KILN_RENDER=cpu');
@@ -91,10 +104,14 @@ describe('repository reliability contracts', () => {
     const { functions, lines } = thresholds.measuredBaseline;
     expect(functions).toBeGreaterThanOrEqual(thresholds.thresholds.functions);
     expect(lines).toBeGreaterThanOrEqual(thresholds.thresholds.lines);
-    expect(readme).toContain("docs/architecture.md");
-    expect(await readText('docs/architecture.md')).toContain('Threshold decreases require an explicit measured rationale.');
+    expect(readme).toContain('docs/architecture.md');
+    expect(await readText('docs/architecture.md')).toContain(
+      'Threshold decreases require an explicit measured rationale.',
+    );
     expect(workflow).toContain('run: bun run test:coverage');
-    expect(workflow).toContain('uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02');
+    expect(workflow).toContain(
+      'uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02',
+    );
     expect(workflow).toContain('path: coverage/lcov.info');
   });
 

--- a/scripts/site-indexing.test.mjs
+++ b/scripts/site-indexing.test.mjs
@@ -7,9 +7,16 @@ test('crawler discovery points only to the canonical document, without hash rout
   const robots = await readFile(new URL('../site/public/robots.txt', import.meta.url), 'utf8');
   expect(html.match(/rel="canonical"/g)).toHaveLength(1);
   expect(html).toContain('<link rel="canonical" href="https://kilnstudio.tools/"');
-  expect([...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1])).toEqual(['https://kilnstudio.tools/']);
+  expect([...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1])).toEqual([
+    'https://kilnstudio.tools/',
+  ]);
   expect(robots).toContain('Sitemap: https://kilnstudio.tools/sitemap.xml');
   expect(robots).not.toMatch(/Disallow:\s*\//);
-  const index = await readFile(new URL('../site/public/sitemap-index.xml', import.meta.url), 'utf8');
-  expect([...index.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1])).toEqual(['https://kilnstudio.tools/sitemap.xml']);
+  const index = await readFile(
+    new URL('../site/public/sitemap-index.xml', import.meta.url),
+    'utf8',
+  );
+  expect([...index.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1])).toEqual([
+    'https://kilnstudio.tools/sitemap.xml',
+  ]);
 });


### PR DESCRIPTION
Stacked on #90. Retarget to `main` once that merges.

## The hole

Adding a file to `scripts/` and running `biome check` on its path printed **"No files were processed."** Biome's `files.includes` was `src/**/*.ts`, `site/src/**/*.{ts,tsx}` and `site/*.ts`, so the directory holding this repository's own gates — and which `test:coverage` already measures — sat outside the lint surface entirely. The zero-warning baseline 13.5 established was zero across a subset.

## Taken: the gates and their tests

`scripts/check-*.mjs` and `scripts/**/*.test.mjs` — a category rather than an arbitrary subset. The checks are now checked. **416 files where 405 were.**

Ten findings were behind the hole. Seven format, reflowing seven files by 116 lines in total. Three real:

- A dead `const` in `check-vision.mjs`, easy to miss because the identical line two loops down is load-bearing — which is also why the fix needs a block-scoped anchor rather than a line match.
- Two `useTemplate` on the `JSON.stringify(…) + '\n'` idiom.

`reliability.test.mjs` asserts both include patterns, verified by dropping `scripts/check-*.mjs` and watching it fail. A directory silently leaving the lint surface is how this started.

## Left, with the cost measured rather than guessed

The rest of `scripts/` is one-off tools — dispatch, promotion, poster upload, geometry experiments — and several are authored as dense single-expression lines. Taking the whole directory costs:

| | |
|---|---|
| **26 lint findings** | 22 the same `+ '\n'` idiom, several inside minified lines where the fix is unreviewable and the file is no more readable after |
| **A 1,530-line reflow** | `scripts/` goes from 3,078 to 4,608 lines — 50% growth that is entirely formatting |
| **162 lines of coverage slack** | `test:coverage` measures `src scripts`, those tools are never executed, so the reflow lands in the uncovered denominator: lines fall 92.49% → **92.14%** against a threshold of 92, leaving 62 lines of room where there were 224 |

Measured by taking the full pass and running the gate, not estimated.

That third cost says something the ratchet has been quietly absorbing: **line coverage over manual helper scripts is noise inside a number this repository treats as a contract.** Narrowing what `test:coverage` measures is the real fix and a separate decision, so ledger 14.4 records it rather than folding it in here.

`render-service/` stays out for an unrelated reason: its `src/**` is CRLF by `.gitattributes` and Biome's formatter would rewrite the line endings.

## One incidental finding

Biome prints at most **20** diagnostics by default, so `bun run lint` reported 20 findings in `scripts/` when there were 26. `--error-on-warnings` still fails the gate either way — but a count read off that output is a floor, not a total. Noted in `CONTRIBUTING.md`.

## Verification

`check:toolchain` · `check:skills` · `typecheck` · `lint` (416 files, reports nothing) · **1856 pass / 2 skip / 0 fail** across 214 files · coverage **95.27% / 92.49%**, 224 lines of slack — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)