### PR TITLE
fix(docs): regenerate the tool reference, and wire its drift check into the suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## The published tool reference is correct again — 2026-09-12
+
+- `docs/tools.md` is generated from the tool registry, and `docs/` is in the package's
+  `files` list — so a stale reference is not an internal note being wrong, it is shipped
+  to every install. It was stale: regenerating moved **128 lines**.
+- The cause was an in-range dependency bump. `zod` 4.4.3 → 4.6.2 changed
+  `z.toJSONSchema` to emit `items: false`, `minItems` and `maxItems` for fixed-length
+  tuples, so every tuple input in the published reference understated its own schema.
+- Nothing caught it because the generator's `--check` mode appeared in **no workflow and
+  no test** — the same shape as the render service's 37 tests running nowhere. An
+  offline gate that runs nowhere is worth exactly as much as no gate.
+- It is a test now rather than a workflow step: the generator exports
+  `toolReferenceMarkdown()` with its CLI behaviour behind a direct-entry guard, and
+  `scripts/tool-reference.test.mjs` compares the published file to the registry. `bun
+  test` already runs on Linux, Windows and both macOS architectures, so this needs no
+  new job — and cannot become a job somebody forgets to add, which is the failure mode
+  being fixed.
+- Compared whole rather than section by section: the drift that shipped was four added
+  lines inside one nested schema, which any summary comparison would have missed.
+  Verified by dropping a single `minItems` line and watching the test name the file and
+  the command that fixes it.
+
 ## Every directory that holds code is linted now — 2026-09-12
 
 - 14.4 left the one-off tools in `scripts/` out and priced the alternative at 26 lint

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -1679,6 +1679,7 @@ the installed tree.
 | 14.1 | Re-ground 7.12 / SEP-2640 against an authoritative source | **Done 2026-09-12.** Deferred still, for a stronger reason. See below |
 | 14.2 | Establish what actually blocks the `ai` 7 family, and gate it | **Done 2026-09-12.** `@strands-agents/sdk@1.17.0` is latest, declares peer `@ai-sdk/provider: ^3.0.0`, and its `VercelModel` is typed on `LanguageModelV3` in 21 places. `@openrouter/ai-sdk-provider@3.0.0` requires `ai: ^7.0.0`; `ai@7.0.99` depends on `@ai-sdk/provider@4.0.14`. The family cannot be taken until Strands ships a release accepting the v4 spec -- no budget changes that. `scripts/peer-ranges.test.mjs` now fails on a peer range the version beside it does not meet, verified by patching the installed `@openrouter/ai-sdk-provider` manifest to peer `ai: ^7.0.0` and watching it report `installed 6.0.282` |
 | 14.3 | Assert the prompt-cache breakpoint on the wire, offline | **Done 2026-09-12.** Both native transports captured in `src/agent/providers.test.ts`, both differential. See below |
+| 14.8 | Regenerate `docs/tools.md` and wire its drift check into the suite | **Done 2026-09-12.** 128 insertions of understated schema, published since 13.2. The check is a test now, verified by dropping one `minItems` line and watching it name the file |
 | 14.7 | The rest of `scripts/` under the formatter, now that 14.5 made it free | **Done 2026-09-12.** 480 files where 442 were; every directory holding code is in the surface. Turned up two findings nothing else would have: two `any` in the evaluation host, and a stale generated doc -- see 14.8 |
 | 14.6 | `render-service/` into the lint surface, which needed its line endings settled first | **Done 2026-09-12.** 442 files where 416 were. See below |
 | 14.5 | Give the coverage ratchet a scope, so repo-only code cannot move the engine's contract | **Done 2026-09-12.** Measured over `src/` alone; baseline re-measured at 95.39% functions / 92.59% lines; `lines` raised 92 to 92.1 so the narrowing does not quietly hand back slack. See below |
@@ -1944,3 +1945,20 @@ re-running the check.
 Not folded into 14.7: regenerating a shipped document and wiring its gate is its own
 change with its own reasoning, and burying it in a formatting pass is how a doc
 artifact changes without anyone reading why.
+
+**Fixed 2026-09-12.** `docs/` is in the package's `files` list, so this was not an
+internal note being wrong -- the understated schemas were published to every
+install. Regenerating moved 128 lines.
+
+The wiring is a test, not a workflow step. `generate-tool-reference.ts` now exports
+`toolReferenceMarkdown()` and `toolReferencePath`, with the CLI behaviour behind a
+direct-entry guard so importing the module neither writes the file nor sets an exit
+code, and `scripts/tool-reference.test.mjs` compares the published file to the
+registry. `bun test` already runs on Linux, Windows and both macOS architectures, so
+a test needs no new job and cannot be a job somebody forgets to add -- which is the
+failure mode being fixed, not a new instance of it.
+
+Compared whole rather than section by section, because the drift that shipped was
+four added lines inside one nested schema and any summary comparison would have
+missed it. Verified by dropping a single `minItems` line and watching the test name
+the file with the command that fixes it.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -219,7 +219,10 @@ Build a program and return geometry metrics, exact part paths and images. Omit c
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           },
                           "target": {
                             "type": "array",
@@ -233,7 +236,10 @@ Build a program and return geometry metrics, exact part paths and images. Omit c
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           },
                           "relativeTo": {
                             "type": "string",
@@ -259,7 +265,10 @@ Build a program and return geometry metrics, exact part paths and images. Omit c
                                   {
                                     "type": "number"
                                   }
-                                ]
+                                ],
+                                "items": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               },
                               "rotation": {
                                 "type": "array",
@@ -273,7 +282,10 @@ Build a program and return geometry metrics, exact part paths and images. Omit c
                                   {
                                     "type": "number"
                                   }
-                                ]
+                                ],
+                                "items": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             },
                             "additionalProperties": false
@@ -302,7 +314,10 @@ Build a program and return geometry metrics, exact part paths and images. Omit c
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           },
                           "up": {
                             "type": "array",
@@ -316,7 +331,10 @@ Build a program and return geometry metrics, exact part paths and images. Omit c
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           },
                           "halfHeight": {
                             "type": "number",
@@ -534,7 +552,10 @@ Render sampled animation frames to check motion and attachments. Use shot for th
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "items": false,
+                  "minItems": 3,
+                  "maxItems": 3
                 },
                 "target": {
                   "type": "array",
@@ -548,7 +569,10 @@ Render sampled animation frames to check motion and attachments. Use shot for th
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "items": false,
+                  "minItems": 3,
+                  "maxItems": 3
                 },
                 "relativeTo": {
                   "type": "string",
@@ -574,7 +598,10 @@ Render sampled animation frames to check motion and attachments. Use shot for th
                         {
                           "type": "number"
                         }
-                      ]
+                      ],
+                      "items": false,
+                      "minItems": 3,
+                      "maxItems": 3
                     },
                     "rotation": {
                       "type": "array",
@@ -588,7 +615,10 @@ Render sampled animation frames to check motion and attachments. Use shot for th
                         {
                           "type": "number"
                         }
-                      ]
+                      ],
+                      "items": false,
+                      "minItems": 3,
+                      "maxItems": 3
                     }
                   },
                   "additionalProperties": false
@@ -617,7 +647,10 @@ Render sampled animation frames to check motion and attachments. Use shot for th
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "items": false,
+                  "minItems": 3,
+                  "maxItems": 3
                 },
                 "up": {
                   "type": "array",
@@ -631,7 +664,10 @@ Render sampled animation frames to check motion and attachments. Use shot for th
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "items": false,
+                  "minItems": 3,
+                  "maxItems": 3
                 },
                 "halfHeight": {
                   "type": "number",
@@ -826,7 +862,10 @@ Render roof-off floor-plan, dollhouse, and eye-level cutaway views. Optional ver
                           {
                             "type": "number"
                           }
-                        ]
+                        ],
+                        "items": false,
+                        "minItems": 3,
+                        "maxItems": 3
                       },
                       "target": {
                         "type": "array",
@@ -840,7 +879,10 @@ Render roof-off floor-plan, dollhouse, and eye-level cutaway views. Optional ver
                           {
                             "type": "number"
                           }
-                        ]
+                        ],
+                        "items": false,
+                        "minItems": 3,
+                        "maxItems": 3
                       },
                       "relativeTo": {
                         "type": "string",
@@ -866,7 +908,10 @@ Render roof-off floor-plan, dollhouse, and eye-level cutaway views. Optional ver
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           },
                           "rotation": {
                             "type": "array",
@@ -880,7 +925,10 @@ Render roof-off floor-plan, dollhouse, and eye-level cutaway views. Optional ver
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           }
                         },
                         "additionalProperties": false
@@ -909,7 +957,10 @@ Render roof-off floor-plan, dollhouse, and eye-level cutaway views. Optional ver
                           {
                             "type": "number"
                           }
-                        ]
+                        ],
+                        "items": false,
+                        "minItems": 3,
+                        "maxItems": 3
                       },
                       "up": {
                         "type": "array",
@@ -923,7 +974,10 @@ Render roof-off floor-plan, dollhouse, and eye-level cutaway views. Optional ver
                           {
                             "type": "number"
                           }
-                        ]
+                        ],
+                        "items": false,
+                        "minItems": 3,
+                        "maxItems": 3
                       },
                       "halfHeight": {
                         "type": "number",
@@ -1044,7 +1098,10 @@ Inspect a part with context or isolation. Use legacy part/orbit controls or shot
                 {
                   "type": "number"
                 }
-              ]
+              ],
+              "items": false,
+              "minItems": 3,
+              "maxItems": 3
             }
           },
           "required": [
@@ -1079,7 +1136,10 @@ Inspect a part with context or isolation. Use legacy part/orbit controls or shot
                 {
                   "type": "number"
                 }
-              ]
+              ],
+              "items": false,
+              "minItems": 3,
+              "maxItems": 3
             }
           },
           "required": [
@@ -1180,7 +1240,10 @@ Inspect a part with context or isolation. Use legacy part/orbit controls or shot
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "items": false,
+                  "minItems": 3,
+                  "maxItems": 3
                 },
                 "target": {
                   "type": "array",
@@ -1194,7 +1257,10 @@ Inspect a part with context or isolation. Use legacy part/orbit controls or shot
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "items": false,
+                  "minItems": 3,
+                  "maxItems": 3
                 },
                 "relativeTo": {
                   "type": "string",
@@ -1220,7 +1286,10 @@ Inspect a part with context or isolation. Use legacy part/orbit controls or shot
                         {
                           "type": "number"
                         }
-                      ]
+                      ],
+                      "items": false,
+                      "minItems": 3,
+                      "maxItems": 3
                     },
                     "rotation": {
                       "type": "array",
@@ -1234,7 +1303,10 @@ Inspect a part with context or isolation. Use legacy part/orbit controls or shot
                         {
                           "type": "number"
                         }
-                      ]
+                      ],
+                      "items": false,
+                      "minItems": 3,
+                      "maxItems": 3
                     }
                   },
                   "additionalProperties": false
@@ -1263,7 +1335,10 @@ Inspect a part with context or isolation. Use legacy part/orbit controls or shot
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "items": false,
+                  "minItems": 3,
+                  "maxItems": 3
                 },
                 "up": {
                   "type": "array",
@@ -1277,7 +1352,10 @@ Inspect a part with context or isolation. Use legacy part/orbit controls or shot
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "items": false,
+                  "minItems": 3,
+                  "maxItems": 3
                 },
                 "halfHeight": {
                   "type": "number",
@@ -1497,7 +1575,10 @@ Apply exact-string replacements to a program revision and render the result (ren
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           },
                           "target": {
                             "type": "array",
@@ -1511,7 +1592,10 @@ Apply exact-string replacements to a program revision and render the result (ren
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           },
                           "relativeTo": {
                             "type": "string",
@@ -1537,7 +1621,10 @@ Apply exact-string replacements to a program revision and render the result (ren
                                   {
                                     "type": "number"
                                   }
-                                ]
+                                ],
+                                "items": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               },
                               "rotation": {
                                 "type": "array",
@@ -1551,7 +1638,10 @@ Apply exact-string replacements to a program revision and render the result (ren
                                   {
                                     "type": "number"
                                   }
-                                ]
+                                ],
+                                "items": false,
+                                "minItems": 3,
+                                "maxItems": 3
                               }
                             },
                             "additionalProperties": false
@@ -1580,7 +1670,10 @@ Apply exact-string replacements to a program revision and render the result (ren
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           },
                           "up": {
                             "type": "array",
@@ -1594,7 +1687,10 @@ Apply exact-string replacements to a program revision and render the result (ren
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "items": false,
+                            "minItems": 3,
+                            "maxItems": 3
                           },
                           "halfHeight": {
                             "type": "number",

--- a/scripts/generate-tool-reference.ts
+++ b/scripts/generate-tool-reference.ts
@@ -1,31 +1,53 @@
 import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import { createKilnProgramToolRegistry } from '../src/tools/registry';
 
-const tools = createKilnProgramToolRegistry();
-const content = `${[
-  '# Tool reference',
-  'Generated from the public registry with `bun run docs:tools`. Change the registry to update names, descriptions or schemas; use `bun run docs:tools --check` to check for drift.',
-  'Use these tools through your connected agent. Supply `code` once, then pass the returned `programRef` to later calls. References identify exact source revisions. [Source workflow](programs.md) · [Camera recipes](cameras.md) · [Geometry guide](geometry.md).',
-  'Call `kiln_list_primitives({capabilities:true})` for the current host limits and export/camera support. The schema below describes inputs; actual image replies include fidelity and capture metadata. Source reads return exact text, edits return a new revision, and failed builds return their errors.',
-  ...tools.flatMap((tool) => {
-    const schema = z.toJSONSchema(tool.inputSchema);
-    return [
-      `## ${tool.name}`,
-      tool.description,
-      '<details>\n<summary>Input JSON Schema</summary>\n',
-      `\`\`\`json\n${JSON.stringify(schema, null, 2)}\n\`\`\`\n\n</details>`,
-    ];
-  }),
-].join('\n\n')}\n`;
-const path = fileURLToPath(new URL('../docs/tools.md', import.meta.url));
-if (process.argv.includes('--check')) {
-  if ((await readFile(path, 'utf8').catch(() => '')) !== content) {
-    console.error('Tool reference differs from the registry. Run bun run docs:tools.');
-    process.exitCode = 1;
+export const toolReferencePath = fileURLToPath(new URL('../docs/tools.md', import.meta.url));
+
+/**
+ * The published tool reference, derived from the registry.
+ *
+ * Exported so the drift check can be a test rather than a command nobody runs.
+ * `--check` existed from the start and appeared in no workflow and no test, which
+ * is how `docs/tools.md` came to understate every tuple schema for a week: zod
+ * 4.6.2 changed `z.toJSONSchema` to emit `items: false`, `minItems` and
+ * `maxItems` for fixed-length tuples, the in-range bump took it, and the only
+ * thing that would have noticed was opt-in.
+ */
+export function toolReferenceMarkdown(): string {
+  const tools = createKilnProgramToolRegistry();
+  return `${[
+    '# Tool reference',
+    'Generated from the public registry with `bun run docs:tools`. Change the registry to update names, descriptions or schemas; use `bun run docs:tools --check` to check for drift.',
+    'Use these tools through your connected agent. Supply `code` once, then pass the returned `programRef` to later calls. References identify exact source revisions. [Source workflow](programs.md) · [Camera recipes](cameras.md) · [Geometry guide](geometry.md).',
+    'Call `kiln_list_primitives({capabilities:true})` for the current host limits and export/camera support. The schema below describes inputs; actual image replies include fidelity and capture metadata. Source reads return exact text, edits return a new revision, and failed builds return their errors.',
+    ...tools.flatMap((tool) => {
+      const schema = z.toJSONSchema(tool.inputSchema);
+      return [
+        `## ${tool.name}`,
+        tool.description,
+        '<details>\n<summary>Input JSON Schema</summary>\n',
+        `\`\`\`json\n${JSON.stringify(schema, null, 2)}\n\`\`\`\n\n</details>`,
+      ];
+    }),
+  ].join('\n\n')}\n`;
+}
+
+// Only when run as a command. Importing this module must not write a file or set
+// an exit code -- the test below it imports the builder.
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  const content = toolReferenceMarkdown();
+  if (process.argv.includes('--check')) {
+    if ((await readFile(toolReferencePath, 'utf8').catch(() => '')) !== content) {
+      console.error('Tool reference differs from the registry. Run bun run docs:tools.');
+      process.exitCode = 1;
+    }
+  } else {
+    await writeFile(toolReferencePath, content);
+    console.log(
+      `Wrote ${createKilnProgramToolRegistry().length} public tool definitions to docs/tools.md.`,
+    );
   }
-} else {
-  await writeFile(path, content);
-  console.log(`Wrote ${tools.length} public tool definitions to docs/tools.md.`);
 }

--- a/scripts/tool-reference.test.mjs
+++ b/scripts/tool-reference.test.mjs
@@ -1,0 +1,25 @@
+/**
+ * `docs/tools.md` is generated, and `docs/` is in the package's `files` list, so a
+ * stale reference is published to every install. The generator has had a `--check`
+ * mode from the start; it appeared in no workflow and no test, which is the same
+ * shape as the render service's 37 tests running nowhere (13.7).
+ *
+ * What slipped through it: 13.2's in-range `zod` 4.4.3 -> 4.6.2 bump changed
+ * `z.toJSONSchema` to emit `items: false`, `minItems` and `maxItems` for
+ * fixed-length tuples, so every tuple input in the published reference understated
+ * its own schema. An offline gate that exists but runs nowhere is worth exactly as
+ * much as no gate.
+ */
+import { expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { toolReferenceMarkdown, toolReferencePath } from './generate-tool-reference.ts';
+
+test('docs/tools.md matches the registry it is generated from', async () => {
+  const published = await readFile(toolReferencePath, 'utf8');
+  // Compared whole rather than by section: the drift that shipped was four added
+  // lines inside one nested schema, which any summary comparison would have missed.
+  expect(
+    published === toolReferenceMarkdown(),
+    'docs/tools.md is stale — run `bun run docs:tools`',
+  ).toBe(true);
+});


### PR DESCRIPTION
Found while the lint pass in #95 touched `generate-tool-reference.ts`.

`bun run docs:tools --check` has existed from the start — it reports drift and exits non-zero — and it appears in **no workflow and no test.** The same shape as 13.7, where a shipped subsystem's 37 tests ran on nobody's machine.

## It was drifting, and the drift shipped

`docs/` is in the package's `files` list. This is not an internal note being wrong: the understated schemas were published to every install. Regenerating moved **128 lines**.

The cause was an in-range dependency bump. 13.2 took `zod` 4.4.3 → 4.6.2, which changed `z.toJSONSchema` to emit `"items": false`, `"minItems"` and `"maxItems"` for fixed-length tuples — so every tuple input in the published reference understated its own schema. Verified to predate this phase by stashing the lint rewrite and re-running the check against HEAD's generator.

## The wiring is a test, not a workflow step

`generate-tool-reference.ts` exports `toolReferenceMarkdown()` and `toolReferencePath`, with the CLI behaviour behind a direct-entry guard so importing the module neither writes the file nor sets an exit code. `scripts/tool-reference.test.mjs` compares the published file to the registry.

`bun test` already runs on Linux, Windows and both macOS architectures, so this needs no new job — and cannot become a job somebody forgets to add, which is the failure mode being fixed rather than a fresh instance of it.

Compared whole rather than section by section: the drift that shipped was four added lines inside one nested schema, which any summary comparison would have missed. Verified by dropping a single `minItems` line and watching the test name the file and the command that fixes it.

## Verification

`check:toolchain` - `typecheck` - `lint` (481 files, reports nothing) - **1858 pass / 2 skip / 0 fail** across 215 files - coverage **95.39% / 92.59%** unchanged.

Generated with [Claude Code](https://claude.com/claude-code)
