### PR TITLE
ci: three jobs that reported and blocked nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## Three CI jobs reported and blocked nothing — 2026-09-12
+
+- `build portable Node package` and both `Node package · macOS` jobs run on every push
+  and every pull request, and were required by nothing. Measured before changing
+  anything: **24 of 24 green across the last 8 runs on main**, and a pull request that
+  broke macOS packaging would still have merged.
+- The test named `every CI job blocks; none of them merely reports` was green throughout,
+  because it checked only `continue-on-error` — the narrower of the two ways a job can
+  fail to block. Its own comment already described the gap it did not cover: *"the other
+  half is a GitHub setting."* For three jobs that setting had simply never been made.
+- 13.4 set the precedent that a context is required only once it has reported, since a
+  required context that never reports blocks every merge instead of guarding it. It
+  promoted the Windows job on nine runs with seven green; these three clear that bar.
+- The test now derives every context `ci.yml` can produce — expanding the macOS matrix
+  into its two legs, because GitHub requires the expanded name — and compares it against
+  the list that has to be required. Adding a job without deciding whether it gates a
+  merge now fails the suite. Verified three ways: a new job, a renamed job, and a dropped
+  matrix leg each fail, naming the exact context gained or lost.
+- **`build the gallery` is deliberately not required.** `pages.yml` is path-filtered, so
+  it stays silent on any pull request touching none of `examples/`, `site/`, `src/`,
+  `scripts/authorship.ts` or `README.md`. Requiring it would block every such merge —
+  the exact trap 13.4 named. The rule is now written down: unconditional workflow,
+  required; conditional workflow, unrequired.
+
 ## The documented way to convert an old clone did not work — 2026-09-12
 
 - The 2026-09-10 rewrite moved `refs/tags/oss-2026-09-05` as well as `main`, and a tag

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -2084,7 +2084,7 @@ re-measured since the day it was written.
 | ID | Task | State |
 | --- | --- | --- |
 | 15.1 | The README's remedy for converting a pre-rewrite clone does not work | **Done 2026-09-12.** See below |
-| 15.2 | Three CI jobs report on every PR and block nothing | Queued; the repository half and the GitHub setting |
+| 15.2 | Three CI jobs report on every PR and block nothing | **Done 2026-09-12.** Both halves. See below |
 | 15.3 | The documented offline gate does not run render-service's 37 tests, or `check:skills` | Queued |
 | 15.4 | `version` has been `0.6.0` for 21 shipped changes, and the tarball is named from it | Queued; owner chose to bump per shipped change |
 
@@ -2135,3 +2135,49 @@ byte-identical.
 to 26 MB when the runtime bundles were re-added after the rewrite, and the checkout is
 unchanged at 34 MB. The timing claims came out rather than being restated, because they
 are network-bound and cannot be honestly re-measured from a different link.
+
+
+### 15.2 -- the other half of "every CI job blocks"
+
+`ci.yml` has five jobs producing six check contexts, because `macos-package` is a
+matrix. Three of the six were required by main's branch protection. The other three
+-- `build portable Node package`, `Node package . macOS arm64` and `Node package .
+macOS x64` -- ran on every push and every pull request, reported **24 of 24 green
+across the last 8 runs on main**, and gated nothing. A change that broke macOS
+packaging failed the workflow and still permitted the merge.
+
+This is the sibling of the defect class Phase 14 named. That one was a gate that
+existed but ran nowhere; this is a gate that runs, reports, and does not bite.
+
+What makes it worth recording is that the repository already knew. The test
+`every CI job blocks; none of them merely reports` carries the comment *"This asserts
+the repository's half. The other half is a GitHub setting: the job's check context has
+to be listed in main's branch protection."* The comment was right, the name was
+broader than the assertion, and for three jobs the setting had never been made. A test
+name is a claim; this one outran its `continue-on-error` check by three contexts.
+
+13.4's precedent decides the promotion rather than green runs alone: a context is
+required only once it has reported, because one that never reports blocks every merge
+instead of guarding it. It promoted the Windows job on nine runs, seven green. These
+three have reported on every run since they were added.
+
+The test now derives the context list from the workflow -- expanding the matrix into
+one context per leg, since GitHub requires the expanded name and not the job key --
+and compares it against the list that must be required. Verified by three separate
+mutations, each failing and naming the exact context gained or lost: a job added, a
+job renamed, and one matrix leg dropped. The first derivation attempt was wrong in a
+way worth noting, because it still produced a plausible list: slicing each job with
+`search()` from the job's own offset matched that job's header at position 0, so every
+job sliced to a single newline and the matrix never expanded. It failed loudly only
+because the expected list was written out independently.
+
+**`build the gallery` stays unrequired, and that is the interesting half.** It is a
+seventh context, from `pages.yml`, and it appeared on this phase's own first pull
+request. Requiring it would be the obvious way to "complete the set" and would be
+wrong: `pages.yml` is path-filtered to `examples/`, `site/`, `src/`,
+`scripts/authorship.ts` and `README.md`, so it is silent on any pull request touching
+none of those -- and a required context that never reports blocks the merge. `ci.yml`
+carries no path filter, which is exactly why all six of its contexts can be required.
+The rule, so nobody completes the set later: unconditional workflow, required;
+conditional workflow, unrequired. `deploy to Pages` is a third case and needs nothing,
+since it reports `skipping` rather than staying absent.

--- a/scripts/reliability.test.mjs
+++ b/scripts/reliability.test.mjs
@@ -136,9 +136,16 @@ describe('repository reliability contracts', () => {
   // intermittent native fault was ruled out. Demoting it again is a decision, not a
   // detail, so it cannot happen by dropping one line back into the file unnoticed.
   //
-  // This asserts the repository's half. The other half is a GitHub setting: the job's
-  // check context has to be listed in main's branch protection, or a red Windows run
-  // fails the workflow and still permits the merge.
+  // The other half is a GitHub setting, and for three jobs it had simply never been
+  // made: `build portable Node package` and both macOS package jobs ran on every pull
+  // request, reported green 24 times out of 24, and were required by nothing -- so a
+  // change that broke macOS packaging still merged. This test's name claimed otherwise
+  // while checking only `continue-on-error`, which is the narrower of the two ways a
+  // job can fail to block.
+  //
+  // `REQUIRED_CHECKS` cannot verify the GitHub setting from here. What it does is turn
+  // the omission from silent into loud: adding a job to this workflow without deciding
+  // whether it gates a merge now fails the suite.
   test('every CI job blocks; none of them merely reports', async () => {
     const workflow = await readText('.github/workflows/ci.yml');
 
@@ -152,6 +159,43 @@ describe('repository reliability contracts', () => {
     // It must never be why Windows reports red, so it is failure-tolerant by design.
     expect(workflow.match(/^ {8}continue-on-error:/gmu)).toHaveLength(1);
     expect(workflow).toContain('Report the native dependency inventory');
+
+    // Every check context this workflow can produce, and therefore every context that
+    // has to be listed in main's branch protection. A matrix job contributes one per
+    // leg, which is why the two macOS legs appear separately: GitHub requires the
+    // expanded name, not the job key.
+    //
+    // Scoped to this workflow on purpose. `pages.yml` also reports a context -- `build
+    // the gallery` -- and it must NOT be required, because that workflow is
+    // path-filtered: it stays silent on a pull request touching none of `examples/`,
+    // `site/`, `src/`, `scripts/authorship.ts` or `README.md`, and a required context
+    // that never reports blocks every such merge instead of guarding it. `ci.yml` has
+    // no path filter, so all six of its contexts always report and can all be
+    // required. Conditional workflow, unrequired; unconditional workflow, required.
+    const REQUIRED_CHECKS = [
+      'build portable Node package',
+      'Node package \u00b7 macOS arm64',
+      'Node package \u00b7 macOS x64',
+      'render service tests',
+      'typecheck \u00b7 lint \u00b7 test',
+      'typecheck \u00b7 lint \u00b7 test (Windows)',
+    ];
+
+    // Derived from the workflow rather than restated, so a renamed or added job is a
+    // failure here instead of a context that silently stops being required. The job
+    // key is the context when a job declares no `name`.
+    const body = workflow.slice(workflow.indexOf('\njobs:'));
+    const heads = [...body.matchAll(/^ {2}([a-z][\w-]*):$/gmu)];
+    const produced = heads.flatMap((head, index) => {
+      const job = body.slice(head.index, heads[index + 1]?.index ?? body.length);
+      const declared = job.match(/^ {4}name: (.+)$/mu)?.[1] ?? head[1];
+      const legs = [...job.matchAll(/^ {12}arch: (\S+)$/gmu)].map(([, arch]) => arch);
+      return legs.length > 0
+        ? legs.map((arch) => declared.replace(/\$\{\{ matrix\.arch \}\}/u, arch))
+        : [declared];
+    });
+
+    expect(produced.sort()).toEqual([...REQUIRED_CHECKS].sort());
   });
 
   // The 2026-09-10 rewrite moved `refs/tags/oss-2026-09-05` as well as `main`, and a


### PR DESCRIPTION
## The gap

`ci.yml` has five jobs producing **six** check contexts (`macos-package` is a matrix).
Three were required by main's branch protection. The other three ran on every push and
every pull request, reported green, and gated nothing:

| Context | Reported | Required before |
| --- | --- | --- |
| `typecheck · lint · test` | always | ✅ |
| `typecheck · lint · test (Windows)` | always | ✅ |
| `render service tests` | always | ✅ |
| `build portable Node package` | always | ❌ |
| `Node package · macOS arm64` | always | ❌ |
| `Node package · macOS x64` | always | ❌ |

**24 of 24 green across the last 8 runs on main**, measured before changing anything. A
pull request that broke macOS packaging failed the workflow and still permitted the
merge.

This is the sibling of the class Phase 14 named. That one was a gate that existed but
ran nowhere; this is a gate that runs, reports, and does not bite.

## The repository already knew

The test `every CI job blocks; none of them merely reports` was green throughout, because
it checked only `continue-on-error` — the narrower of the two ways a job can fail to
block. Its own comment described the gap it did not cover:

> This asserts the repository's half. The other half is a GitHub setting: the job's check
> context has to be listed in main's branch protection.

The comment was right; the name was broader than the assertion by three contexts.

## Why these three, now

13.4 set the precedent, and it is not "green runs alone": a context is required only once
it has **reported**, because one that never reports blocks every merge instead of
guarding it. It promoted the Windows job on nine runs with seven green. These three have
reported on every run since they were added.

## `build the gallery` stays unrequired — the half worth reading

A **seventh** context exists, from `pages.yml`, and it showed up on this phase's own
first PR. Requiring it would be the obvious way to complete the set, and would be wrong:
`pages.yml` is path-filtered to `examples/`, `site/`, `src/`, `scripts/authorship.ts` and
`README.md`, so it is silent on any PR touching none of those — and a required context
that never reports blocks the merge. That is exactly 13.4's trap.

`ci.yml` carries no path filter, which is precisely why all six of its contexts can be
required. The rule is now written down so nobody completes the set later:
**unconditional workflow, required; conditional workflow, unrequired.** (`deploy to
Pages` is a third case needing nothing — it reports `skipping` rather than staying
absent.)

## Verification

The test now derives the context list from the workflow, expanding the matrix into one
context per leg, and compares it against the list that must be required. Adding a job
without deciding whether it gates a merge now fails the suite. Proven by three mutations,
each failing and naming the exact context gained or lost:

- a job added → `+ "a job nobody required"`
- one matrix leg dropped → `- "Node package · macOS x64"`
- a job renamed → same shape

The first derivation attempt was wrong in a way worth naming, since it still produced a
plausible list: slicing each job with `search()` from the job's own offset matched that
job's own header at position 0, so every job sliced to a single newline and the matrix
never expanded. It failed loudly only because the expected list is written out
independently rather than derived twice.

`lint` nothing over 481 files · `typecheck` clean · reliability suite 6 pass.

The branch-protection contexts are updated alongside this PR, so this PR's own merge is
gated by the new requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
