### PR TITLE
build: the documented gate did not run two of the repository's checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,11 @@ latest for a release gate.
 ```bash
 bun install --frozen-lockfile
 bun run check:toolchain
+bun run check:skills
 bun run typecheck
 bun run lint
 bun run test
+bun run test:render-service
 bun run test:coverage
 ```
 
@@ -86,6 +88,13 @@ test`. Full offline gate: also run `bun run test:coverage`; it emits text plus `
 and enforces the checked-in line/function ratchet in `bunfig.toml`. Raise thresholds when practical;
 do not lower them without an explicit measured rationale. Live model tests are opt-in only via
 `bun run test:live` and may spend money.
+
+`bun run test` is `bun test src scripts`, so it does **not** reach `render-service/`, which is a
+separate npm project. `bun run test:render-service` does; it needs `npm --prefix render-service ci
+--ignore-scripts` once. All 37 of those tests are pure -- framing arithmetic, PNG readback packing,
+cache identity, contract and preset validation -- so none of them needs a GPU or the native Dawn
+build, which is why `--ignore-scripts` is enough. Run it whenever you change `render-service/`; CI
+requires it.
 
 Tests and CI pin `KILN_RENDER=cpu`. The coverage ratchet must not vary by whether the runner has a
 GPU. It is measured over `src/` alone -- the shipped engine -- so nothing you change under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## The documented offline gate did not run two of the repository's checks — 2026-09-12
+
+- `bun run test` is `bun test src scripts`, so it never reached `render-service/`. Its 37
+  tests ran only in CI, in the job 13.7 added — so a contributor editing that subsystem
+  got **no local signal at all** and found out from a red pull request. `check:skills`
+  was the same shape in the other direction: a step in CI's `checks` job that the
+  documented gate never named.
+- The subsystem cannot fold into `bun test src scripts`: it is a separate npm project
+  with its own lockfile and a native dependency. It gets `bun run test:render-service`
+  instead, which needs `npm --prefix render-service ci --ignore-scripts` once. All 37
+  tests are pure — framing arithmetic, PNG readback packing, cache identity, contract and
+  preset validation — so none needs a GPU or the Dawn build, which is the CI job's own
+  recorded reason `--ignore-scripts` suffices.
+- Both are now in the gate in `AGENTS.md` and `CONTRIBUTING.md`, and a test asserts the
+  general defect rather than the instance: **every `bun run` command the agent guide
+  names must exist as a script**, and the two that were missing must appear in the gate
+  block itself.
+- Reading the fenced block rather than the whole file is what makes that discriminate.
+  The first version checked "named anywhere in `AGENTS.md`" and stayed green when the
+  line was deleted from the gate — because the prose underneath mentions the same
+  command. Verified three ways after narrowing: a guide naming a script that does not
+  exist, the line dropped from the block, and the script removed from `package.json` all
+  fail.
+
 ## Three CI jobs reported and blocked nothing — 2026-09-12
 
 - `build portable Node package` and both `Node package · macOS` jobs run on every push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,20 @@ Read [AGENTS.md](AGENTS.md) and the [README](README.md). Contributor checks use 
 ```sh
 bun install --frozen-lockfile
 bun run check:toolchain
+bun run check:skills
 bun run typecheck
 bun run lint
 bun run test
+bun run test:render-service
 bun run test:coverage
 ```
+
+`bun run test` is `bun test src scripts`, so it never reaches `render-service/` -- a
+separate npm project with its own lockfile and a native dependency.
+`bun run test:render-service` does, after `npm --prefix render-service ci
+--ignore-scripts` once. All 37 of those tests are pure, so none of them needs a GPU or
+the Dawn build; CI requires the job, and before this the only way to find a break in it
+was a red pull request.
 
 `lint` reports **nothing** on a clean tree, and a warning fails it. There is no
 tolerated baseline to compare against, so any diagnostic your change produces is

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -2085,7 +2085,7 @@ re-measured since the day it was written.
 | --- | --- | --- |
 | 15.1 | The README's remedy for converting a pre-rewrite clone does not work | **Done 2026-09-12.** See below |
 | 15.2 | Three CI jobs report on every PR and block nothing | **Done 2026-09-12.** Both halves. See below |
-| 15.3 | The documented offline gate does not run render-service's 37 tests, or `check:skills` | Queued |
+| 15.3 | The documented offline gate does not run render-service's 37 tests, or `check:skills` | **Done 2026-09-12.** See below |
 | 15.4 | `version` has been `0.6.0` for 21 shipped changes, and the tarball is named from it | Queued; owner chose to bump per shipped change |
 
 ### 15.1 -- the tag is the whole rewrite, on the clone side too
@@ -2181,3 +2181,39 @@ carries no path filter, which is exactly why all six of its contexts can be requ
 The rule, so nobody completes the set later: unconditional workflow, required;
 conditional workflow, unrequired. `deploy to Pages` is a third case and needs nothing,
 since it reports `skipping` rather than staying absent.
+
+
+### 15.2, confirmed by its own pull request
+
+Worth adding because the claim stopped being a deduction. `build the gallery` is
+**absent** from PR #99's checks entirely -- that PR touched `CHANGELOG.md`, this file
+and `reliability.test.mjs`, none of which match `pages.yml`'s path filter. Had the
+context been required to "complete the set", PR #99 could not have merged. The rule is
+not a precaution against something that might happen; it is a description of what did.
+
+### 15.3 -- the gate that was documented and the gate that was run
+
+`bun run test` is `bun test src scripts`. It never reached `render-service/`, whose 37
+tests ran only in the CI job 13.7 added -- so a contributor editing that subsystem got
+no local signal at all and learned about a break from a red pull request. `check:skills`
+was the same mismatch pointing the other way: a step in CI's `checks` job that the
+documented gate never named. Neither was broken. Both were invisible from the
+instructions.
+
+The subsystem genuinely cannot fold into `bun test src scripts` -- separate npm project,
+own lockfile, native dependency -- so it gets its own script. What makes that cheap is
+already recorded in the CI job's comment: all 37 tests are pure, none acquires a device,
+and `--ignore-scripts` skips the Dawn build. Nothing had to change but the wiring.
+
+The test asserts the general defect instead of the instance: every `bun run` command
+`AGENTS.md` names must exist as a script, in both directions. **Reading the fenced gate
+block rather than the whole file is what makes it discriminate**, and that was found by
+trying to break it rather than by reasoning. The first version checked "named anywhere in
+`AGENTS.md`" and stayed green when the gate line was deleted -- because the explanatory
+prose that the same commit added mentions the same command. An assertion written against
+a file is only as narrow as the region it reads.
+
+That is three for three in this phase: every fix wired the check into `bun test` rather
+than adding a CI job, for the reason Phase 14 gave -- a job is the thing somebody forgets
+to add. 15.2 is the exception that proves it, since half of it could only ever be a
+GitHub setting, and the repository half is what makes that half's absence loud.

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "test:coverage": "KILN_SPIKE_LIVE=0 KILN_RENDER=cpu bun test src scripts --coverage && bun scripts/check-coverage.mjs",
     "test:live": "KILN_SPIKE_LIVE=1 bun test",
     "test:package": "node scripts/test-plugin-package.mjs && node scripts/smoke-package.mjs",
+    "test:render-service": "npm --prefix render-service test",
     "lint": "biome check --error-on-warnings .",
     "verify:posters": "bun scripts/verify-posters.mjs",
     "site:assets": "cd site && bun scripts/build-assets.mjs",

--- a/scripts/reliability.test.mjs
+++ b/scripts/reliability.test.mjs
@@ -219,6 +219,39 @@ describe('repository reliability contracts', () => {
     expect(readme).toContain('git gc --prune=now');
   });
 
+  // The documented offline gate ran neither `check:skills` nor render-service's 37
+  // tests. CI ran both -- the first as a step in `checks`, the second as its own job
+  // added by 13.7 -- so a contributor editing `render-service/` got no local signal at
+  // all and found out from a red pull request. The subsystem cannot fold into
+  // `bun test src scripts`: it is a separate npm project with its own lockfile and a
+  // native dependency, so it gets its own script instead.
+  //
+  // The general defect is a documented command that does not exist, or exists and is
+  // never named. Both directions are checked here rather than the one that prompted it.
+  test('every command the agent guide tells you to run exists', async () => {
+    const agents = await readText('AGENTS.md');
+    const scripts = (await readJson('package.json')).scripts ?? {};
+
+    const named = [...agents.matchAll(/`?bun run ([\w:-]+)/gu)].map(([, name]) => name);
+    expect(named.length).toBeGreaterThan(0);
+    for (const name of new Set(named)) expect(Object.keys(scripts)).toContain(name);
+
+    // The other direction, and it has to read the gate BLOCK rather than the whole
+    // file: the prose below the block names these scripts too, so "mentioned in
+    // AGENTS.md" stays true after someone deletes the line that actually tells you to
+    // run them. Checking the fenced block was the difference between this assertion
+    // discriminating and not -- deleting the line passed until it was narrowed.
+    const gate = agents.match(/```(?:sh|bash)?\n(bun install --frozen-lockfile\n[\s\S]*?)```/u);
+    expect(gate).not.toBeNull();
+    const gated = [...gate[1].matchAll(/^bun run ([\w:-]+)$/gmu)].map(([, name]) => name);
+    expect(gated).toContain('check:skills');
+    expect(gated).toContain('test:render-service');
+    expect(gated).toContain('test:coverage');
+    // `bun test src scripts` cannot reach render-service; the script is what does.
+    expect(scripts['test:render-service']).toContain('render-service');
+    expect(scripts.test).not.toContain('render-service');
+  });
+
   test('standalone agent context stays concise and names the safety-critical paths', async () => {
     const agents = await readText('AGENTS.md');
 


### PR DESCRIPTION
## Two checks CI ran that the instructions never mentioned

`bun run test` is `bun test src scripts`. It never reached `render-service/`, whose **37
tests ran only in CI** — in the job 13.7 added. So a contributor editing that subsystem
got no local signal at all and learned about a break from a red pull request.
`check:skills` was the same mismatch pointing the other way: a step in CI's `checks` job
that the documented gate never named.

Neither check was broken. Both were invisible from the instructions.

## Why a separate script rather than folding it in

`render-service/` is a separate npm project with its own lockfile and a native
dependency, so it cannot join `bun test src scripts`. It gets `bun run
test:render-service`, which needs `npm --prefix render-service ci --ignore-scripts` once.

What makes that cheap was already recorded — in the CI job's own comment: all 37 tests
are pure (framing arithmetic, PNG readback packing, cache identity, contract and preset
validation), none acquires a device, and `--ignore-scripts` skips the Dawn build. Nothing
had to change but the wiring.

## The gate is the general defect, not the instance

**Every `bun run` command `AGENTS.md` names must exist as a script**, checked in both
directions.

Reading the *fenced gate block* rather than the whole file is what makes it discriminate,
and that came out of trying to break it rather than from reasoning. The first version
checked "named anywhere in `AGENTS.md`" and **stayed green when I deleted the line from
the gate** — because the explanatory prose this same commit adds mentions the same
command. An assertion is only as narrow as the region it reads.

After narrowing, all three mutations fail:

| Mutation | Result |
| --- | --- |
| guide names `check:skills-typo` | `Expected to contain: "check:skills-typo"` |
| `bun run test:render-service` dropped from the block | `Expected to contain: "test:render-service"` |
| script removed from `package.json` | `Expected to contain: "test:render-service"` |

## Verification

Ran the gate exactly as it is now documented: `check:toolchain` · `check:skills` (6
conform) · `typecheck` clean · `lint` nothing over 481 files · `test:render-service` 37
pass · **full suite 1860 pass / 2 skip / 0 fail**.

Third of four in Phase 15, and the third to wire its check into `bun test` rather than
add a CI job — for the reason Phase 14 gave: a job is the thing somebody forgets to add.
15.2 is the exception that proves it, since half of that one could only ever be a GitHub
setting.

Also records that PR #99 confirmed its own claim: `build the gallery` was **absent** from
that PR's checks, because it touched no path in `pages.yml`'s filter. Had the context
been required to "complete the set", #99 could not have merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
