### PR TITLE
ci: all four platform receipts come from one run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,15 +234,92 @@ jobs:
           test "$#" -eq 1
           npm run --silent test:package -- --tarball "$1" | tee package-smoke.json
       - name: Verify the retained smoke receipt
-        env:
-          EXPECTED_ARCH: ${{ matrix.arch }}
-        run: >-
-          node -e "const fs=require('node:fs'),assert=require('node:assert/strict'),crypto=require('node:crypto');const r=JSON.parse(fs.readFileSync('package-smoke.json','utf8'));assert.equal(r.status,'passed');assert.equal(r.platform,'darwin');assert.equal(r.arch,process.env.EXPECTED_ARCH);assert.equal(r.node,'v22.23.2');assert.equal(r.npm,'12.0.2');assert.equal(r.tarballSha256,crypto.createHash('sha256').update(fs.readFileSync(r.tarball)).digest('hex'));for(const check of ['packaged-node-worker','source-reference-edit-images','server-restart-persistence','exact-source-export'])assert(r.checks.includes(check));"
+        run: node scripts/verify-package-receipt.mjs --platform darwin --arch ${{ matrix.arch }}
       - name: Retain macOS package receipt
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-package-${{ matrix.arch }}
+          path: package-smoke.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  # Linux and Windows package receipts existed in the 2026-09-05 release and were made by
+  # hand: `test:package` ran only in the macOS job, so two of the four platforms a release
+  # attests to had no reproducible source. These two jobs close that, and deliberately
+  # mirror `macos-package` step for step rather than sharing a composite action -- the
+  # differences that matter (host assertion, receipt platform, artifact name) are exactly
+  # the ones a shared action would hide behind inputs.
+  linux-package:
+    name: Node package · Linux
+    needs: package-candidate
+    timeout-minutes: 20
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      # Consumers install only Node/npm. Bun builds the tarball in the separate producer job.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.23.2
+      - run: npm install --global npm@12.0.2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: node-package-candidate
+          path: candidate
+      - name: Verify native host
+        run: node -e "if(process.platform!=='linux')process.exit(1);console.log(process.platform,process.arch,process.version)"
+      - name: Install and exercise the end-user distribution
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -- "$PWD"/candidate/*.tgz
+          test "$#" -eq 1
+          npm run --silent test:package -- --tarball "$1" | tee package-smoke.json
+      - name: Verify the retained smoke receipt
+        run: node scripts/verify-package-receipt.mjs --platform linux --arch x64
+      - name: Retain Linux package receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: linux-package
+          path: package-smoke.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  windows-package:
+    name: Node package · Windows
+    needs: package-candidate
+    timeout-minutes: 30
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.23.2
+      - run: npm install --global npm@12.0.2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: node-package-candidate
+          path: candidate
+      - name: Verify native host
+        run: node -e "if(process.platform!=='win32')process.exit(1);console.log(process.platform,process.arch,process.version)"
+      # bash, not pwsh: the glob expansion and the single-tarball assertion below are the
+      # same on every platform, and Windows runners ship Git bash. 13.4's Windows reds
+      # were real defects, so this job gets the same 30-minute bound that one does.
+      - name: Install and exercise the end-user distribution
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -- "$PWD"/candidate/*.tgz
+          test "$#" -eq 1
+          npm run --silent test:package -- --tarball "$1" | tee package-smoke.json
+      - name: Verify the retained smoke receipt
+        run: node scripts/verify-package-receipt.mjs --platform win32 --arch x64
+      - name: Retain Windows package receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: windows-package
           path: package-smoke.json
           if-no-files-found: warn
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## All four platform receipts come from CI now — 2026-09-12
+
+- The 2026-09-05 release attached `linux-package.json` and `windows-package.json`, but
+  `test:package` ran only in the macOS job — so two of the four platforms a release
+  attests to had **no reproducible source** and were produced by hand. `linux-package`
+  and `windows-package` jobs close that; CI now emits the tarball and all four receipts
+  from one run.
+- The receipt check left the workflow. It was a ~400-character `node -e` one-liner inside
+  the macOS job, which is tolerable at one platform and not at four: the expected platform
+  differs per job, so copying it is three chances to assert `darwin` on a Linux runner and
+  have the receipt pass anyway. **A receipt that cannot fail is not evidence.** It is now
+  `scripts/verify-package-receipt.mjs`, one line in each of the four jobs.
+- Extracting it bought two things beyond deduplication. Expected Node and npm versions
+  come from `engines` rather than being written a second time, so `check-toolchain.mjs`
+  stays the single source; and because the receipt records `engineVersion`, each platform
+  receipt is now checked against `package.json` — so a release's receipts are tied to its
+  version rather than merely sitting beside it.
+- `--tarball` overrides the path the receipt recorded, which is what makes one verifier
+  serve both uses. In the job the receipt names a tarball sitting right there. At
+  release-assembly time the receipts are downloaded artifacts whose absolute paths belong
+  to a runner that no longer exists — but their `tarballSha256` is exactly what must be
+  checked against the file about to be published.
+- Verified against a real receipt rather than only fixtures: the Linux smoke was run on a
+  Linux host first (16 checks, `engineVersion 0.7.0`), then that receipt was accepted,
+  **rejected when asked to assert `darwin`** — the precise bug copying the one-liner would
+  have caused — and rejected again after one byte was appended to the tarball, naming both
+  hashes.
+- `REQUIRED_CHECKS` goes to eight, and the gate added two changes ago is what forced that
+  edit: adding a job without deciding whether it gates a merge fails the suite. First time
+  one of this phase's gates caught the next change instead of a past one.
+
 ## 0.7.0 — the version moves with what ships — 2026-09-12
 
 - `version` sat at `0.6.0` from the OSS release through **21 shipped changes**, while CI

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -2087,6 +2087,7 @@ re-measured since the day it was written.
 | 15.2 | Three CI jobs report on every PR and block nothing | **Done 2026-09-12.** Both halves. See below |
 | 15.3 | The documented offline gate does not run render-service's 37 tests, or `check:skills` | **Done 2026-09-12.** See below |
 | 15.4 | `version` has been `0.6.0` for 21 shipped changes, and the tarball is named from it | **Done 2026-09-12.** 0.7.0, gated. See below |
+| 15.5 | Linux and Windows package receipts had no reproducible source | **Done 2026-09-12.** Four receipts from one CI run; the check extracted. See below |
 
 ### 15.1 -- the tag is the whole rewrite, on the clone side too
 
@@ -2246,3 +2247,52 @@ So the sequence was the repository's own TDD rule applied to a release step: bum
 1860 tests pass on a mismatch, add the assertion, watch it name `mcp 0.6.0` against
 `mcp 0.7.0`, rebuild, watch it pass. A byte comparison is not a version check, and the
 difference only shows up when the version is the one thing that moved.
+
+
+### 15.5 -- a receipt that could not fail
+
+The 2026-09-05 release attached four platform receipts. Only two of them had a
+reproducible source: `test:package` ran in the macOS job and nowhere else, so
+`linux-package.json` and `windows-package.json` were made by hand. Wiring the other two
+platforms in is what the owner chose over hand-making them again, on the grounds that it
+is what makes the *next* release cheap rather than this one.
+
+That turned a copy-paste job into an extraction, and the reason is worth stating because
+it is not deduplication. The receipt check was a ~400-character `node -e` one-liner
+living inside the macOS job, and it hard-codes `assert.equal(r.platform,'darwin')`.
+Copied to Linux and Windows, the line that has to change is buried mid-string among six
+other assertions -- so the natural failure is a Linux job that asserts `darwin`, passes,
+and attests nothing. **A receipt that cannot fail is not evidence**, and four near-copies
+of one assertion is four chances to produce one.
+
+`scripts/verify-package-receipt.mjs` is now one line in each of the four package jobs,
+and extracting it bought two things nobody was looking for:
+
+- Expected Node and npm versions are read from `engines` instead of written a second
+  time, so `check-toolchain.mjs` stays their single source. The one-liner carried
+  `'v22.23.2'` and `'12.0.2'` as literals, which would have silently outlived a
+  toolchain bump.
+- The receipt already records `engineVersion`, so it is now checked against
+  `package.json`. Combined with 15.4 that closes the loop: the tarball's name, the
+  committed bundle's `identity`, and every platform receipt now have to agree on one
+  version.
+
+`--tarball` overrides the path the receipt recorded, which is what lets one verifier
+serve both uses. In the job the receipt names a tarball sitting right there and the
+default is correct. At release-assembly time the receipts are downloaded artifacts whose
+absolute paths belong to runners that no longer exist -- but their `tarballSha256` is
+exactly what has to be checked against the file about to be published. Without the
+override, verifying a release's own receipts would fail on a missing file, which is the
+kind of thing found by thinking about the last step before writing the first.
+
+Verified against a real receipt rather than fixtures alone. The Linux smoke was run on a
+Linux host before the job was written -- 16 checks, `status: passed`,
+`engineVersion: 0.7.0` -- so the job landed with evidence instead of hope. That receipt
+is accepted; asking the verifier to assert `darwin` against it is rejected with
+`platform: expected darwin, receipt says linux`; and appending one byte to the tarball is
+rejected naming both hashes.
+
+`REQUIRED_CHECKS` moves to eight, and **15.2's gate is what forced that edit** -- the
+suite fails on a job whose context nobody decided about. First time a gate from this
+phase caught the next change rather than a past one, which is the only real evidence that
+any of them will keep working.

--- a/scripts/reliability.test.mjs
+++ b/scripts/reliability.test.mjs
@@ -174,6 +174,8 @@ describe('repository reliability contracts', () => {
     // required. Conditional workflow, unrequired; unconditional workflow, required.
     const REQUIRED_CHECKS = [
       'build portable Node package',
+      'Node package \u00b7 Linux',
+      'Node package \u00b7 Windows',
       'Node package \u00b7 macOS arm64',
       'Node package \u00b7 macOS x64',
       'render service tests',

--- a/scripts/verify-package-receipt.mjs
+++ b/scripts/verify-package-receipt.mjs
@@ -1,0 +1,115 @@
+/**
+ * Check one platform's package-smoke receipt against what the release claims.
+ *
+ * This lived as a ~400 character `node -e` one-liner inside the macOS job, which was
+ * tolerable at one platform and is not at four: the expected platform differs per job,
+ * so triplicating it means three chances to assert `darwin` on a Linux runner and have
+ * the receipt pass anyway. A receipt that cannot fail is not evidence.
+ *
+ * The expected Node and npm versions are read from `engines` rather than written here,
+ * so `check-toolchain.mjs` stays the single source for them. `engineVersion` is checked
+ * against `package.json` for the same reason a release attaches these files at all --
+ * a receipt that does not name the version it exercised cannot be matched to a tarball.
+ *
+ * Usage:
+ *   node scripts/verify-package-receipt.mjs --platform linux --arch x64
+ *   node scripts/verify-package-receipt.mjs --platform win32 --arch x64 --receipt r.json
+ */
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Checks the smoke run must report, named individually so a silent drop is a failure. */
+const REQUIRED_CHECKS = [
+  'packaged-node-worker',
+  'source-reference-edit-images',
+  'server-restart-persistence',
+  'exact-source-export',
+];
+
+const PLATFORMS = new Set(['darwin', 'linux', 'win32']);
+
+function option(argv, name) {
+  const at = argv.indexOf(`--${name}`);
+  return at === -1 ? undefined : argv[at + 1];
+}
+
+export function receiptProblems(receipt, { platform, arch, manifest }) {
+  const problems = [];
+  const mustBe = (actual, wanted, label) => {
+    if (actual !== wanted) problems.push(`${label}: expected ${wanted}, receipt says ${actual}`);
+  };
+
+  mustBe(receipt.status, 'passed', 'status');
+  mustBe(receipt.platform, platform, 'platform');
+  mustBe(receipt.arch, arch, 'arch');
+  // `engines.node` is bare; the receipt records what `node --version` prints.
+  mustBe(receipt.node, `v${manifest.engines.node}`, 'node');
+  mustBe(receipt.npm, manifest.engines.npm, 'npm');
+  mustBe(receipt.engineVersion, manifest.version, 'engineVersion');
+
+  for (const check of REQUIRED_CHECKS) {
+    if (!receipt.checks?.includes(check)) problems.push(`missing check: ${check}`);
+  }
+  return problems;
+}
+
+export async function verifyReceipt(argv, root) {
+  const platform = option(argv, 'platform');
+  const arch = option(argv, 'arch');
+  if (!PLATFORMS.has(platform)) {
+    throw new Error(`--platform must be one of ${[...PLATFORMS].join(', ')}; got ${platform}`);
+  }
+  if (!arch) throw new Error('--arch is required');
+
+  const receiptPath = option(argv, 'receipt') ?? 'package-smoke.json';
+  const resolved = isAbsolute(receiptPath) ? receiptPath : join(root, receiptPath);
+  const receipt = JSON.parse(await readFile(resolved, 'utf8'));
+  const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+
+  const problems = receiptProblems(receipt, { platform, arch, manifest });
+
+  // Hashed last: it is the only check that reads a second file, and a receipt naming a
+  // tarball that is gone should say so rather than crash before the cheap checks run.
+  //
+  // `--tarball` overrides the path the receipt recorded, which is what makes this usable
+  // twice. In the job, the receipt names a tarball sitting right there and the default is
+  // right. At release-assembly time the receipts are downloaded artifacts whose recorded
+  // absolute paths belong to a runner that no longer exists -- but their `tarballSha256`
+  // is exactly what has to be checked against the file about to be published.
+  const tarball = option(argv, 'tarball') ?? receipt.tarball;
+  if (typeof receipt.tarballSha256 !== 'string' || receipt.tarballSha256.length === 0) {
+    problems.push('tarballSha256: missing');
+  } else {
+    try {
+      const actual = createHash('sha256')
+        .update(await readFile(tarball))
+        .digest('hex');
+      if (actual !== receipt.tarballSha256) {
+        problems.push(
+          `tarballSha256: ${tarball} hashes to ${actual}, receipt says ${receipt.tarballSha256}`,
+        );
+      }
+    } catch (error) {
+      problems.push(`tarball: ${tarball} unreadable (${error.code ?? error.message})`);
+    }
+  }
+  return problems;
+}
+
+const direct =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (direct) {
+  const root =
+    option(process.argv, 'root') ?? resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const problems = await verifyReceipt(process.argv, root);
+  if (problems.length > 0) {
+    console.error(`Package receipt rejected:\n  ${problems.join('\n  ')}`);
+    process.exit(1);
+  }
+  console.log(
+    `Package receipt accepted: ${option(process.argv, 'platform')} ${option(process.argv, 'arch')}`,
+  );
+}

--- a/scripts/verify-package-receipt.test.mjs
+++ b/scripts/verify-package-receipt.test.mjs
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { receiptProblems, verifyReceipt } from './verify-package-receipt.mjs';
+
+const manifest = {
+  version: '0.7.0',
+  engines: { bun: '1.4.2', node: '22.23.2', npm: '12.0.2' },
+};
+
+/** A receipt that must pass, so every case below differs from it by exactly one field. */
+const good = () => ({
+  status: 'passed',
+  platform: 'linux',
+  arch: 'x64',
+  node: 'v22.23.2',
+  npm: '12.0.2',
+  engineVersion: '0.7.0',
+  tarballSha256: 'unchecked-here',
+  tarball: '/nonexistent.tgz',
+  checks: [
+    'packaged-node-worker',
+    'source-reference-edit-images',
+    'server-restart-persistence',
+    'exact-source-export',
+    'csg-wasm',
+  ],
+});
+
+const target = { platform: 'linux', arch: 'x64', manifest };
+
+describe('package receipt verification', () => {
+  test('a receipt matching the release is accepted', () => {
+    expect(receiptProblems(good(), target)).toEqual([]);
+  });
+
+  // One case per field, because the whole reason this left the workflow as a one-liner
+  // is that a per-platform copy can assert the wrong platform and still pass.
+  test.each([
+    ['status', { status: 'failed' }, 'status'],
+    ['platform', { platform: 'darwin' }, 'platform'],
+    ['arch', { arch: 'arm64' }, 'arch'],
+    ['node', { node: 'v22.22.0' }, 'node'],
+    ['npm', { npm: '11.0.0' }, 'npm'],
+    ['engineVersion', { engineVersion: '0.6.0' }, 'engineVersion'],
+  ])('a receipt disagreeing about %s is rejected', (_label, patch, named) => {
+    const problems = receiptProblems({ ...good(), ...patch }, target);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain(named);
+  });
+
+  test('a dropped check is named individually', () => {
+    const receipt = good();
+    receipt.checks = receipt.checks.filter((c) => c !== 'server-restart-persistence');
+    expect(receiptProblems(receipt, target)).toEqual(['missing check: server-restart-persistence']);
+  });
+
+  test('a receipt with no checks at all reports every one of them', () => {
+    expect(receiptProblems({ ...good(), checks: undefined }, target)).toHaveLength(4);
+  });
+
+  // The end-to-end path, including the hash the release actually depends on.
+  test('the tarball hash is checked against the file, and --tarball overrides the path', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kiln-receipt-'));
+    const tarball = join(dir, 'kiln-engine-0.7.0.tgz');
+    const bytes = Buffer.from('not really a tarball');
+    await writeFile(tarball, bytes);
+
+    const receipt = {
+      ...good(),
+      tarballSha256: createHash('sha256').update(bytes).digest('hex'),
+      // A path belonging to a runner that no longer exists, which is what a downloaded
+      // receipt always carries.
+      tarball: '/runner/work/kiln/candidate/kiln-engine-0.7.0.tgz',
+    };
+    await writeFile(join(dir, 'package-smoke.json'), JSON.stringify(receipt));
+    await writeFile(join(dir, 'package.json'), JSON.stringify(manifest));
+
+    const argv = ['--platform', 'linux', '--arch', 'x64'];
+    // Without the override it reports the unreadable path rather than crashing.
+    const unresolvable = await verifyReceipt(argv, dir);
+    expect(unresolvable).toHaveLength(1);
+    expect(unresolvable[0]).toContain('unreadable');
+
+    expect(await verifyReceipt([...argv, '--tarball', tarball], dir)).toEqual([]);
+
+    // And a tarball that is present but wrong is rejected, not waved through.
+    await writeFile(tarball, Buffer.from('tampered'));
+    const tampered = await verifyReceipt([...argv, '--tarball', tarball], dir);
+    expect(tampered).toHaveLength(1);
+    expect(tampered[0]).toContain('tarballSha256');
+  });
+
+  test('an unknown platform is refused before anything is read', async () => {
+    await expect(verifyReceipt(['--platform', 'solaris', '--arch', 'x64'], '.')).rejects.toThrow(
+      'must be one of',
+    );
+    await expect(verifyReceipt(['--platform', 'linux'], '.')).rejects.toThrow('--arch is required');
+  });
+});


### PR DESCRIPTION
## Two of four platforms had no reproducible source

The 2026-09-05 release attached `linux-package.json` and `windows-package.json`, but
`test:package` ran in the macOS job and **nowhere else** — so half the platforms a release
attests to were made by hand. `linux-package` and `windows-package` jobs close that: CI
now emits the tarball and all four receipts from one run.

Chosen over hand-making them again because it is what makes the *next* release cheap, not
just this one.

## Why that became an extraction, not a copy-paste

The receipt check was a ~400-character `node -e` one-liner inside the macOS job, and it
hard-codes `assert.equal(r.platform,'darwin')` mid-string among six other assertions.
Copied to two more platforms, the natural failure is a Linux job that asserts `darwin`,
passes, and attests nothing.

**A receipt that cannot fail is not evidence**, and four near-copies of one assertion is
four chances to make one. It is now `scripts/verify-package-receipt.mjs` — one line in
each of the four jobs.

Extracting it bought two things beyond deduplication:

- **Expected Node and npm come from `engines`** rather than being written a second time,
  so `check-toolchain.mjs` stays their single source. The one-liner carried `'v22.23.2'`
  and `'12.0.2'` as literals that would have outlived a toolchain bump in silence.
- **The receipt records `engineVersion`**, so it is now checked against `package.json`.
  With #101 that closes the loop: the tarball's name, the committed bundle's `identity`,
  and every platform receipt must agree on one version.

`--tarball` overrides the path the receipt recorded, which is what lets one verifier serve
both uses. In the job the receipt names a tarball sitting right there. At release-assembly
time the receipts are downloaded artifacts whose absolute paths belong to runners that no
longer exist — while their `tarballSha256` is exactly what has to be checked against the
file about to be published. Found by thinking about the last step before writing the
first.

## Verified against a real receipt, not only fixtures

The Linux smoke was run on a Linux host **before** the job was written — `status: passed`,
`platform: linux`, `node v22.23.2`, `npm 12.0.2`, `engineVersion 0.7.0`, 16 checks — so
the job lands with evidence rather than hope.

| Input | Result |
| --- | --- |
| that real receipt | `Package receipt accepted: linux x64` |
| same receipt, asserting `darwin` | `platform: expected darwin, receipt says linux` |
| one byte appended to the tarball | `hashes to 99fdb261…, receipt says b4db03e6…` |

Plus 11 unit tests: one per field, a dropped check named individually, an unknown platform
refused before anything is read, and the `--tarball` override end to end.

## Shape

7 jobs → 8 contexts. `REQUIRED_CHECKS` moves to eight, **and #99's gate is what forced
that edit** — the suite fails on a job whose context nobody decided about. First time a
gate from this phase caught the *next* change rather than a past one, which is the only
real evidence any of them will keep working.

`lint` clean over 483 files · `typecheck` clean · full suite **1872 pass / 2 skip / 0
fail**.

The two new contexts get added to branch protection once they have reported here, per
13.4's precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
