### PR TITLE
fix: --receipt was relative to the wrong directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 Changes to `@kiln/engine`. Source and installable packages are distributed through
 GitHub. The package is not published on the npm registry.
 
+## `--receipt` was relative to the wrong directory — 2026-09-12
+
+- `scripts/verify-package-receipt.mjs` resolved `--receipt` against `--root` rather than the
+  working directory. Those are **the same directory in the CI step**, which is why the
+  original passed its own tests and every CI run — and different everywhere else.
+- Found by using it. Assembling the release from downloaded artifacts puts the receipts in
+  a staging directory while `root` is the repository, so every path silently became
+  `<repo>/linux-package.json` and all four verifications failed with `ENOENT`. The
+  assembly refused to publish, which is what it is for.
+- A path a person types on a command line belongs to where they typed it. `root` now
+  locates `package.json` and nothing else.
+- The test that passed while the bug existed is the finding worth keeping: its fixture had
+  `root` and the receipt in the same temp directory, mirroring the CI step, so it could not
+  tell the two rules apart. It now addresses the receipt explicitly and a second case pins
+  the resolution rule with `root` and the receipt in *different* directories. Both fail if
+  the old behaviour is reintroduced — the doubled path in the error is its signature.
+
 ## webgpu 0.6.1 is held out of 0.7.0 — 2026-09-12
 
 - The bump was slated for this release and then held, because reading what is in it

--- a/docs/plans/repo-size-and-r2-migration-2026-09-10.md
+++ b/docs/plans/repo-size-and-r2-migration-2026-09-10.md
@@ -2089,6 +2089,7 @@ re-measured since the day it was written.
 | 15.4 | `version` has been `0.6.0` for 21 shipped changes, and the tarball is named from it | **Done 2026-09-12.** 0.7.0, gated. See below |
 | 15.5 | Linux and Windows package receipts had no reproducible source | **Done 2026-09-12.** Four receipts from one CI run; the check extracted. See below |
 | 15.6 | `webgpu` 0.6.0 to 0.6.1 in `render-service/` | **Deferred 2026-09-12, and the reason is its publish date.** Gated on the owner's GPU smoke. See below |
+| 15.7 | `--receipt` resolved against `root`, not the working directory | **Done 2026-09-12.** Found by assembling the release. See below |
 
 ### 15.1 -- the tag is the whole rewrite, on the clone side too
 
@@ -2340,3 +2341,35 @@ build execution and is not one. Left in place rather than deleted, because remov
 field that appears to be a security boundary is a decision the owner should make
 knowingly: either wire it to a tool that honours it, or drop it. Noted so the version key
 is not mistaken for something enforcing anything when 15.6 is eventually taken.
+
+
+### 15.7 -- a test that could not tell two rules apart
+
+`verify-package-receipt.mjs` shipped in 15.5 resolving `--receipt` against `--root`. In
+the CI step those are the same directory, so it worked there, passed its own eleven tests,
+and passed on four platforms across three pull requests.
+
+Assembling the release is the first use where they differ: the receipts are downloaded
+artifacts in a staging directory while `root` is the repository, so every path became
+`<repo>/linux-package.json` and all four verifications failed with `ENOENT`. The assembly
+script refused to publish rather than warning, which is the only reason this was found
+before a release carried four unverified receipts.
+
+The fix is one line. The lesson is in the test that did not catch it.
+
+Its fixture wrote `package.json` and `package-smoke.json` into **one** temp directory and
+passed that directory as `root`, which mirrors the CI step exactly -- and that is precisely
+why it was blind. A fixture that reproduces the environment where a bug is invisible
+inherits the blindness. The two rules "relative to root" and "relative to the working
+directory" have identical behaviour whenever those directories coincide, so the assertion
+had no way to distinguish them no matter how many fields it checked.
+
+It now addresses the receipt explicitly, and a second case pins the rule with `root` and
+the receipt in deliberately *different* directories. Both fail if the old behaviour comes
+back, and the error names the defect: a doubled path,
+`/tmp/kiln-receipt-root-BkY0tL/tmp/kiln-receipt-cwd-7OWwVU/package-smoke.json`.
+
+Worth pairing with 15.3, which was the same shape in a different medium: there an
+assertion read the whole file when it needed to read one block, and the prose in the same
+commit kept it green. Here a fixture collapsed two directories that had to stay apart.
+Both times the assertion was true and measured nothing.

--- a/scripts/verify-package-receipt.mjs
+++ b/scripts/verify-package-receipt.mjs
@@ -17,7 +17,7 @@
  */
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /** Checks the smoke run must report, named individually so a silent drop is a failure. */
@@ -63,9 +63,15 @@ export async function verifyReceipt(argv, root) {
   }
   if (!arch) throw new Error('--arch is required');
 
+  // `--receipt` is resolved against the working directory, not `root`. Those are the same
+  // directory in the CI step, which is why the original resolved it against `root` and the
+  // tests still passed -- and different everywhere else. Assembling a release from
+  // downloaded artifacts is the case that found it: the receipts sit in a staging
+  // directory while `root` is the repository, and every path silently became
+  // `<repo>/linux-package.json`. A path a person types on a command line belongs to where
+  // they typed it. `root` locates `package.json` and nothing else.
   const receiptPath = option(argv, 'receipt') ?? 'package-smoke.json';
-  const resolved = isAbsolute(receiptPath) ? receiptPath : join(root, receiptPath);
-  const receipt = JSON.parse(await readFile(resolved, 'utf8'));
+  const receipt = JSON.parse(await readFile(resolve(receiptPath), 'utf8'));
   const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
 
   const problems = receiptProblems(receipt, { platform, arch, manifest });

--- a/scripts/verify-package-receipt.test.mjs
+++ b/scripts/verify-package-receipt.test.mjs
@@ -78,7 +78,19 @@ describe('package receipt verification', () => {
     await writeFile(join(dir, 'package-smoke.json'), JSON.stringify(receipt));
     await writeFile(join(dir, 'package.json'), JSON.stringify(manifest));
 
-    const argv = ['--platform', 'linux', '--arch', 'x64'];
+    // The receipt is addressed explicitly, because `--receipt` is relative to the working
+    // directory and this fixture lives in a temp directory. The original version resolved
+    // it against `root` instead, and this test passed anyway -- `root` and the receipt's
+    // directory were the same here, exactly as they are in the CI step. Keeping them
+    // different is what makes the assertion mean something.
+    const argv = [
+      '--platform',
+      'linux',
+      '--arch',
+      'x64',
+      '--receipt',
+      join(dir, 'package-smoke.json'),
+    ];
     // Without the override it reports the unreadable path rather than crashing.
     const unresolvable = await verifyReceipt(argv, dir);
     expect(unresolvable).toHaveLength(1);
@@ -91,6 +103,23 @@ describe('package receipt verification', () => {
     const tampered = await verifyReceipt([...argv, '--tarball', tarball], dir);
     expect(tampered).toHaveLength(1);
     expect(tampered[0]).toContain('tarballSha256');
+  });
+
+  test('--receipt is relative to the working directory, not to root', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kiln-receipt-cwd-'));
+    await writeFile(join(dir, 'package-smoke.json'), JSON.stringify(good()));
+    // `root` is a DIFFERENT directory that has the manifest but no receipt. If the receipt
+    // were resolved against it, this would throw ENOENT instead of reporting problems.
+    const manifestRoot = await mkdtemp(join(tmpdir(), 'kiln-receipt-root-'));
+    await writeFile(join(manifestRoot, 'package.json'), JSON.stringify(manifest));
+
+    const problems = await verifyReceipt(
+      ['--platform', 'linux', '--arch', 'x64', '--receipt', join(dir, 'package-smoke.json')],
+      manifestRoot,
+    );
+    // Only the tarball is unreadable; every field check found the receipt and passed.
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('unreadable');
   });
 
   test('an unknown platform is refused before anything is read', async () => {


### PR DESCRIPTION
## Found by assembling the release

`scripts/verify-package-receipt.mjs` — shipped two PRs ago — resolved `--receipt` against
`--root` rather than the working directory. **Those are the same directory in the CI step**,
which is why it worked there, passed its own eleven tests, and passed on four platforms
across three pull requests.

Assembling the release is the first use where they differ. The receipts are downloaded
artifacts in a staging directory while `root` is the repository, so every path became
`<repo>/linux-package.json`:

```
Error: ENOENT: no such file or directory, open '/home/matthewk/X/kiln/macos-arm64-package.json'
REFUSING: a receipt does not match the tarball
```

The assembly refused to publish rather than warning. That is the only reason this surfaced
before a release shipped four receipts nothing had checked.

A path a person types on a command line belongs to where they typed it. `root` now locates
`package.json` and nothing else.

## The lesson is in the test that didn't catch it

The fix is one line. The interesting part is why eleven passing tests were blind to it.

The fixture wrote `package.json` **and** `package-smoke.json` into one temp directory and
passed that directory as `root` — mirroring the CI step exactly, which is precisely what
made it useless here. "Relative to `root`" and "relative to the working directory" have
identical behaviour whenever those directories coincide, so no number of field assertions
could distinguish them.

**A fixture that reproduces the environment where a bug is invisible inherits the
blindness.**

It now addresses the receipt explicitly, and a second case pins the rule with `root` and
the receipt in deliberately *different* directories. Both fail if the old behaviour
returns, and the error names the defect — a doubled path:

```
ENOENT: .../kiln-receipt-root-BkY0tL/tmp/kiln-receipt-cwd-7OWwVU/package-smoke.json
```

Same shape as #100 in a different medium: there an assertion read a whole file when it
needed to read one block, and prose added in the same commit kept it green. Both times the
assertion was true and measured nothing.

## Verification

Re-ran the real assembly against the CI run for `59daf01`:

```
Package receipt accepted: linux x64
Package receipt accepted: win32 x64
Package receipt accepted: darwin arm64
Package receipt accepted: darwin x64
```

`lint` clean over 483 files · full suite **1873 pass / 2 skip / 0 fail** (+1, the new case).

Last change before the `v0.7.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
